### PR TITLE
Made a minor change to always create an 'ended.txt' for each job run at its end

### DIFF
--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.21322.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Catalog.Updater", "src\Catalog.Updater\Catalog.Updater.csproj", "{5825F5A5-6584-473B-BB64-1409FAF3C814}"
 EndProject
@@ -21,6 +21,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatalogCollector.PackageRegistrationBlobs", "src\CatalogCollector.PackageRegistrationBlobs\CatalogCollector.PackageRegistrationBlobs.csproj", "{6091F819-830A-4B3D-88BC-3289C17DE127}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stats.AggregateInGallery", "src\Stats.AggregateInGallery\Stats.AggregateInGallery.csproj", "{7E66CECA-2CA7-4435-AF78-8207AB6AD0AD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6A776396-02B1-475D-A104-26940ADB04AB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.Logger", "src\Tests.Logger\Tests.Logger.csproj", "{7EBE57A8-D3B1-44FE-A467-AEC5636CA82B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,6 +52,10 @@ Global
 		{7E66CECA-2CA7-4435-AF78-8207AB6AD0AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E66CECA-2CA7-4435-AF78-8207AB6AD0AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E66CECA-2CA7-4435-AF78-8207AB6AD0AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EBE57A8-D3B1-44FE-A467-AEC5636CA82B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EBE57A8-D3B1-44FE-A467-AEC5636CA82B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EBE57A8-D3B1-44FE-A467-AEC5636CA82B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EBE57A8-D3B1-44FE-A467-AEC5636CA82B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,5 +65,6 @@ Global
 		{6091F819-830A-4B3D-88BC-3289C17DE127} = {A33AB7AB-EFC8-4B3F-9D54-01692EAF981F}
 		{2EB38FC7-C2EA-4BB3-93FE-059856AD40A4} = {3B227DEE-B610-440F-866E-6F79D413B21F}
 		{7E66CECA-2CA7-4435-AF78-8207AB6AD0AD} = {3B227DEE-B610-440F-866E-6F79D413B21F}
+		{7EBE57A8-D3B1-44FE-A467-AEC5636CA82B} = {6A776396-02B1-475D-A104-26940ADB04AB}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Jobs.Common/Loggers.cs
+++ b/src/NuGet.Jobs.Common/Loggers.cs
@@ -122,7 +122,7 @@ namespace NuGet.Jobs.Common
         /// FlushAll should NEVER get called until after all the logging is done
         /// </summary>
         [Conditional("TRACE")]
-        public virtual void FlushAll()
+        public virtual void FlushAllAndEnd(string jobEndMessage)
         {
             // Check AzureBlobJobTraceLogger
             Trace.Listeners.Clear();

--- a/src/Tests.Logger/App.config
+++ b/src/Tests.Logger/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/src/Tests.Logger/Properties/AssemblyInfo.cs
+++ b/src/Tests.Logger/Properties/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Tests.Logger")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyProduct("Tests.Logger")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("025942ee-4905-46f0-bf5a-0726ead02f87")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Tests.Logger/Tests.Logger.Job.cs
+++ b/src/Tests.Logger/Tests.Logger.Job.cs
@@ -1,0 +1,51 @@
+﻿using NuGet.Jobs.Common;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Tests.Logger
+{
+    internal class Job : JobBase
+    {
+        private const string ScenarioArgumentName = "scenario";
+        private const string HelpMessage = "Please provide 1 for successful job, 2 for failed job, 3 for crashed job and 4 for successful job with heavy logging";
+
+        private int? JobScenario { get; set; }
+        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        {
+            JobScenario = JobConfigManager.TryGetIntArgument(jobArgsDictionary, ScenarioArgumentName);
+            if(JobScenario == null)
+            {
+                throw new ArgumentException("Argument '"+ ScenarioArgumentName +"' is mandatory." + HelpMessage);
+            }
+
+            return true;
+        }
+
+        public async override Task<bool> Run()
+        {
+            switch(JobScenario)
+            {
+                case 1:
+                    return true;
+                    
+                case 2:
+                    return false;
+
+                case 3:
+                    throw new Exception("Job crashed test");
+
+                case 4:
+                    for(int i = 0; i < 200; i++)
+                    {
+                        Trace.WriteLine("Messge number : " + i);
+                    }
+                    return true;
+
+                default:
+                    throw new ArgumentException("Unknown scenario. " + HelpMessage);
+            }
+        }
+    }
+}

--- a/src/Tests.Logger/Tests.Logger.Program.cs
+++ b/src/Tests.Logger/Tests.Logger.Program.cs
@@ -1,0 +1,18 @@
+﻿using NuGet.Jobs.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.Logger
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var job = new Job();
+            JobRunner.Run(job, args).Wait();
+        }
+    }
+}

--- a/src/Tests.Logger/Tests.Logger.csproj
+++ b/src/Tests.Logger/Tests.Logger.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7EBE57A8-D3B1-44FE-A467-AEC5636CA82B}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tests.Logger</RootNamespace>
+    <AssemblyName>Tests.Logger</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Tests.Logger.Job.cs" />
+    <Compile Include="Tests.Logger.Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
+      <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
+      <Name>NuGet.Jobs.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
This file indicates that the job has completed running.
Text contains one of the following
1) Job succeeded
2) Job failed
3) Job crashed
