### PR TITLE
TempLocalLogFlushing

### DIFF
--- a/src/Tests.Logger/Tests.Logger.Job.cs
+++ b/src/Tests.Logger/Tests.Logger.Job.cs
@@ -9,9 +9,12 @@ namespace Tests.Logger
     internal class Job : JobBase
     {
         private const string ScenarioArgumentName = "scenario";
+        private const string LogCountArgumentName = "logcount";
         private const string HelpMessage = "Please provide 1 for successful job, 2 for failed job, 3 for crashed job and 4 for successful job with heavy logging";
 
         private int? JobScenario { get; set; }
+
+        private int? LogCount { get; set; }
         public override bool Init(IDictionary<string, string> jobArgsDictionary)
         {
             JobScenario = JobConfigManager.TryGetIntArgument(jobArgsDictionary, ScenarioArgumentName);
@@ -20,11 +23,14 @@ namespace Tests.Logger
                 throw new ArgumentException("Argument '"+ ScenarioArgumentName +"' is mandatory." + HelpMessage);
             }
 
+            LogCount = JobConfigManager.TryGetIntArgument(jobArgsDictionary, LogCountArgumentName);
+
             return true;
         }
 
         public async override Task<bool> Run()
         {
+            LogCount = LogCount ?? AzureBlobJobTraceLogger.MaxLogBatchSize * 2;
             switch(JobScenario)
             {
                 case 1:
@@ -37,9 +43,9 @@ namespace Tests.Logger
                     throw new Exception("Job crashed test");
 
                 case 4:
-                    for(int i = 0; i < 200; i++)
+                    for(int i = 0; i < LogCount; i++)
                     {
-                        Trace.WriteLine("Messge number : " + i);
+                        Trace.WriteLine("Message number : " + i);
                     }
                     return true;
 


### PR DESCRIPTION
In addition to queueing the log messages in memory, also writing it to a local log file. In the unlikely event of the process crashing in a manner that the log messages in memory are not uploaded to blob storage, say, due to critical exceptions such as OOM; log messages can still be found in the local log file created temporarily

The log messages are always written to the local log file synchronously in addition to writing it in memory. After every 100 or so log messages, the messages in memory are uploaded to Azure. Once the upload is successful, the local log file is deleted. Similar to the azure log files which are sequenced, the local log files are also sequenced. Only difference is once the ith batch log file is uploaded to azure, ith batch local log file is
deleted from the local filesystem

The local log files are always generated in LocalAppData\ng-jobs-logs(or nugetjobscontainername)
