### PR TITLE
FixedSizeAggregateInGallery

### DIFF
--- a/src/Stats.AggregateInGallery/Stats.AggregateInGallery.Job.cs
+++ b/src/Stats.AggregateInGallery/Stats.AggregateInGallery.Job.cs
@@ -73,25 +73,16 @@ DECLARE @UpdatedGallerySettings TABLE
     ,   LastAggregatedStatisticsId int
 )
 
-DECLARE     @MostRecentDownloadStatisticsId INT
 DECLARE     @LatestGallerySettingPlusOffset INT
 DECLARE     @Offset INT = 1000
 
 BEGIN TRANSACTION
 
-    SET    @MostRecentDownloadStatisticsId = (SELECT MAX([Key]) FROM PackageStatistics)
-
-    IF (@MostRecentDownloadStatisticsId IS NULL)
-        RETURN
-
     SET    @LatestGallerySettingPlusOffset = ISNULL(@Offset + (SELECT [DownloadStatsLastAggregatedId] FROM GallerySettings), @Offset)
 
     -- Claim the latest PackageStatistics rows
     UPDATE  GallerySettings
-    SET     DownloadStatsLastAggregatedId = (SELECT (CASE WHEN @MostRecentDownloadStatisticsId < @LatestGallerySettingPlusOffset
-				                                          THEN @MostRecentDownloadStatisticsId
-				                                          ELSE @LatestGallerySettingPlusOffset
-                                                     END))
+    SET     DownloadStatsLastAggregatedId = (SELECT MAX([Key]) FROM PackageStatistics WHERE [Key] <= @LatestGallerySettingPlusOffset)
     OUTPUT  inserted.DownloadStatsLastAggregatedId AS MostRecentStatisticsId
         ,   deleted.DownloadStatsLastAggregatedId AS LastAggregatedStatisticsId
     INTO    @UpdatedGallerySettings


### PR DESCRIPTION
Changed AggregateInGallery to never process more than 1000 records at a time. Currently, 1000 is hard-coded

NOTE: On average, 1000 records take 5 seconds to execute. 10000 could not be completed in the default 30 seconds timeout, so, sticking with 1000

TODO: Make offset a parameter of the job instead of hard-coding it
