### PR TITLE
Made the AggregateInGallery job an adaptive batch job

### DIFF
--- a/src/Stats.AggregateInGallery/Stats.AggregateInGallery.Job.cs
+++ b/src/Stats.AggregateInGallery/Stats.AggregateInGallery.Job.cs
@@ -91,6 +91,8 @@ namespace Stats.AggregateInGallery
                     aggregated = await AggregateBatch(batchSize);
                     batchWatch.Stop();
 
+                    totalAggregated += aggregated;
+
                     // If we had fewer records to aggregate than our batch size,
                     // then we've caught up and we can exit and let some more
                     // records accumulate.
@@ -101,7 +103,6 @@ namespace Stats.AggregateInGallery
                     else
                     {
                         RecordSuccessfulBatchTime(batchSize, batchWatch.Elapsed);
-                        totalAggregated += aggregated;
                     }
 
                     CurrentFailures = 0;


### PR DESCRIPTION
Tested pretty thoroughly against a backup.  Rewound the GallerySettings cursor and had it replay the aggregation.  Tested that the aggregated stats increases (Packages and PackageRegistrations) matches the number of records that were rolled back.

Its adaptive batching will scale from 1000 to 100000 and in the sweet spot against a P1 database, it's processing 2000 stats per second.
