### PR TITLE
Recognize 'NuGet xplat' in the NuGet client category

### DIFF
--- a/src/Stats.ImportAzureCdnStatistics/knownclients.yaml
+++ b/src/Stats.ImportAzureCdnStatistics/knownclients.yaml
@@ -35,6 +35,10 @@
   - regex: '(NuGet Command Line)/(\d+)\.(\d+)\.?(\d+)?'
     family_replacement: 'NuGet Command Line'
 
+  # NuGet xplat CLI
+  - regex: '(NuGet xplat)/(\d+)\.(\d+)\.?(\d+)?'
+    family_replacement: 'NuGet Cross-Platform Command Line'
+
   # NuGet Core
   - regex: '(NuGet Core)/?(\d+)\.(\d+)\.?(\d+)?'
     family_replacement: 'NuGet'

--- a/src/Stats.Warehouse/Programmability/Functions/dbo.IsNuGetClient.sql
+++ b/src/Stats.Warehouse/Programmability/Functions/dbo.IsNuGetClient.sql
@@ -16,6 +16,7 @@ BEGIN
 		OR	CHARINDEX('NuGet VS Packages Dialog', @ClientName) > 0
 		OR	CHARINDEX('NuGet Client V3', @ClientName) > 0
 		OR	CHARINDEX('NuGet Shim', @ClientName) > 0
+		OR	CHARINDEX('NuGet xplat', @ClientName) > 0
 
 			-- VS NuGet (pre-2.8)
 		OR	CHARINDEX('NuGet Add Package Dialog', @ClientName) > 0

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/UserAgentParserFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/UserAgentParserFacts.cs
@@ -22,6 +22,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
 
             [Theory]
             [InlineData("NuGet Command Line/1.2.3 (Microsoft Windows NT 6.2.9200.0)", "NuGet Command Line", "1", "2", "3")]
+            [InlineData("NuGet xplat/3.4.0 (Microsoft Windows NT 6.2.9200.0)", "NuGet Cross-Platform Command Line", "3", "4", "0")]
             [InlineData("NuGet VS PowerShell Console/1.2.3 (Microsoft Windows NT 6.2.9200.0)", "NuGet VS PowerShell Console", "1", "2", "3")]
             [InlineData("NuGet VS Packages Dialog/1.2.3 (Microsoft Windows NT 6.2.9200.0)", "NuGet VS Packages Dialog - Solution", "1", "2", "3")]
             [InlineData("NuGet Add Package Dialog/1.2.3 (Microsoft Windows NT 6.2.9200.0)", "NuGet Add Package Dialog", "1", "2", "3")]


### PR DESCRIPTION
cc @emgarten 

This will ensure the 'NuGet xplat' user agent string gets properly parsed and recognized in the NuGet client category. Display name of the client in the gallery would be: *NuGet Cross-Platform Command Line*.