### PR TITLE
Support for storing logfile aggregates

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -87,6 +87,7 @@ namespace NuGet.Jobs
 
         //Arguments specific to ParseAzureCdnLogs
         public const string AzureCdnCloudStorageTableName = "AzureCdnCloudStorageTableName";
+        public const string AggregatesOnly = "AggregatesOnly";
 
         //Arguments specific to Heartbeat
         public const string HeartbeatConfig = "HeartbeatConfig";

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -28,6 +28,8 @@ namespace NuGet.Jobs
 
         public JobTraceListener JobTraceListener { get; private set; }
 
+        public bool ConsoleLogOnly { get; set; }
+
         public void SetJobTraceListener(JobTraceListener jobTraceListener)
         {
             JobTraceListener = jobTraceListener;

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -52,7 +52,7 @@ namespace NuGet.Jobs
                 int? sleepDuration = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.Sleep); // sleep is in milliseconds
                 if (!sleepDuration.HasValue)
                 {
-                    sleepDuration = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.Interval); 
+                    sleepDuration = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.Interval);
                     if (sleepDuration.HasValue)
                     {
                         sleepDuration = sleepDuration.Value * 1000; // interval is in seconds
@@ -60,7 +60,7 @@ namespace NuGet.Jobs
                 }
 
                 // Setup the job for running
-                JobSetup(job, jobArgsDictionary, ref sleepDuration);
+                JobSetup(job, consoleLogOnly, jobArgsDictionary, ref sleepDuration);
 
                 // Run the job loop
                 await JobLoop(job, runContinuously, sleepDuration.Value, consoleLogOnly);
@@ -110,7 +110,7 @@ namespace NuGet.Jobs
             }
         }
 
-        private static void JobSetup(JobBase job, IDictionary<string, string> jobArgsDictionary, ref int? sleepDuration)
+        private static void JobSetup(JobBase job, bool consoleLogOnly, IDictionary<string, string> jobArgsDictionary, ref int? sleepDuration)
         {
             if (JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, "dbg"))
             {
@@ -127,6 +127,8 @@ namespace NuGet.Jobs
                 Trace.TraceWarning("SleepDuration is not provided or is not a valid integer. Unit is milliSeconds. Assuming default of 5000 ms...");
                 sleepDuration = 5000;
             }
+
+            job.ConsoleLogOnly = consoleLogOnly;
 
             // Initialize the job once with everything needed.
             // JobTraceListener(s) are already initialized

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -100,7 +100,7 @@ namespace Stats.ImportAzureCdnStatistics
 
                     if (_aggregatesOnly)
                     {
-                        _blobLeaseManager.HoldMemLockOnBlob(leasedLogFile.Uri);
+                        _blobLeaseManager.TrackLastProcessedBlobUri(leasedLogFile.Uri);
                     }
 
                     leasedLogFile.Dispose();

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -75,6 +75,7 @@ namespace Stats.ImportAzureCdnStatistics
 
                 // Get the dead-letter table (corrupted or failed blobs will end up there)
                 var deadLetterBlobContainer = cloudBlobClient.GetContainerReference(_cloudStorageContainerName + "-deadletter");
+                await deadLetterBlobContainer.CreateIfNotExistsAsync();
 
                 // Create a parser
                 var logProcessor = new LogFileProcessor(targetBlobContainer, deadLetterBlobContainer, _targetDatabase, _loggerFactory);

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -37,7 +37,8 @@ namespace Stats.ImportAzureCdnStatistics
                 var instrumentationKey = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
-                _loggerFactory = LoggingSetup.CreateLoggerFactory();
+                var loggerConfiguration = LoggingSetup.CreateDefaultLoggerConfiguration(ConsoleLogOnly);
+                _loggerFactory = LoggingSetup.CreateLoggerFactory(loggerConfiguration);
                 _logger = _loggerFactory.CreateLogger<Job>();
 
                 var azureCdnPlatform = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnPlatform);

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -51,7 +51,7 @@ namespace Stats.ImportAzureCdnStatistics
                 _azureCdnPlatform = ValidateAzureCdnPlatform(azureCdnPlatform);
                 _cloudStorageContainerName = ValidateAzureContainerName(JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnCloudStorageContainerName));
 
-                _aggregatesOnly = JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, "AggregatesOnly");
+                _aggregatesOnly = JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, JobArgumentNames.AggregatesOnly);
 
                 // construct a cloud blob client for the configured storage account
                 _cloudBlobClient = _cloudStorageAccount.CreateCloudBlobClient();

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -85,13 +85,22 @@ namespace Stats.ImportAzureCdnStatistics
                 await deadLetterBlobContainer.CreateIfNotExistsAsync();
 
                 // Create a parser
-                var logProcessor = new LogFileProcessor(targetBlobContainer, deadLetterBlobContainer, _targetDatabase, _loggerFactory);
+                var warehouse = new Warehouse(_loggerFactory, _targetDatabase);
+                var logProcessor = new LogFileProcessor(targetBlobContainer, deadLetterBlobContainer, _loggerFactory, warehouse);
 
                 // Get the next to-be-processed raw log file using the cdn raw log file name prefix
                 var prefix = string.Format(CultureInfo.InvariantCulture, "{0}_{1}_", _azureCdnPlatform.GetRawLogFilePrefix(), _azureCdnAccountNumber);
 
                 // Get next raw log file to be processed
-                var leasedLogFiles = await _blobLeaseManager.LeaseNextLogFilesToBeProcessedAsync(prefix);
+                IReadOnlyCollection<string> alreadyAggregatedLogFiles = null;
+                if (_aggregatesOnly)
+                {
+                    // We only want to process aggregates for the log files.
+                    // Get the list of files we already processed so we can skip them.
+                    alreadyAggregatedLogFiles = await warehouse.GetAlreadyAggregatedLogFilesAsync();
+                }
+
+                var leasedLogFiles = await _blobLeaseManager.LeaseNextLogFilesToBeProcessedAsync(prefix, alreadyAggregatedLogFiles);
                 foreach (var leasedLogFile in leasedLogFiles)
                 {
                     var packageTranslator = new PackageTranslator("packagetranslations.json");

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using NuGet.Jobs;
 using NuGet.Services.Logging;
@@ -18,13 +19,16 @@ namespace Stats.ImportAzureCdnStatistics
     public class Job
         : JobBase
     {
+        private bool _aggregatesOnly;
         private string _azureCdnAccountNumber;
         private string _cloudStorageContainerName;
         private AzureCdnPlatform _azureCdnPlatform;
         private SqlConnectionStringBuilder _targetDatabase;
         private CloudStorageAccount _cloudStorageAccount;
+        private CloudBlobClient _cloudBlobClient;
         private ILoggerFactory _loggerFactory;
         private ILogger _logger;
+        private LogFileProvider _blobLeaseManager;
 
         public override bool Init(IDictionary<string, string> jobArgsDictionary)
         {
@@ -45,6 +49,17 @@ namespace Stats.ImportAzureCdnStatistics
                 _azureCdnAccountNumber = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnAccountNumber);
                 _azureCdnPlatform = ValidateAzureCdnPlatform(azureCdnPlatform);
                 _cloudStorageContainerName = ValidateAzureContainerName(JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnCloudStorageContainerName));
+
+                _aggregatesOnly = JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, "AggregatesOnly");
+
+                // construct a cloud blob client for the configured storage account
+                _cloudBlobClient = _cloudStorageAccount.CreateCloudBlobClient();
+                _cloudBlobClient.DefaultRequestOptions.RetryPolicy = new ExponentialRetry(TimeSpan.FromSeconds(10), 5);
+
+                // Get the source blob container (containing compressed log files)
+                // and construct a log source (fetching raw logs from the source blob container)
+                var sourceBlobContainer = _cloudBlobClient.GetContainerReference(_cloudStorageContainerName);
+                _blobLeaseManager = new LogFileProvider(sourceBlobContainer, _loggerFactory);
             }
             catch (Exception exception)
             {
@@ -60,21 +75,12 @@ namespace Stats.ImportAzureCdnStatistics
         {
             try
             {
-                // construct a cloud blob client for the configured storage account
-                var cloudBlobClient = _cloudStorageAccount.CreateCloudBlobClient();
-                cloudBlobClient.DefaultRequestOptions.RetryPolicy = new ExponentialRetry(TimeSpan.FromSeconds(10), 5);
-
-                // Get the source blob container (containing compressed log files)
-                // and construct a log source (fetching raw logs from the source blob container)
-                var sourceBlobContainer = cloudBlobClient.GetContainerReference(_cloudStorageContainerName);
-                var blobLeaseManager = new LogFileProvider(sourceBlobContainer, _loggerFactory);
-
                 // Get the target blob container (for archiving decompressed log files)
-                var targetBlobContainer = cloudBlobClient.GetContainerReference(_cloudStorageContainerName + "-archive");
+                var targetBlobContainer = _cloudBlobClient.GetContainerReference(_cloudStorageContainerName + "-archive");
                 await targetBlobContainer.CreateIfNotExistsAsync();
 
                 // Get the dead-letter table (corrupted or failed blobs will end up there)
-                var deadLetterBlobContainer = cloudBlobClient.GetContainerReference(_cloudStorageContainerName + "-deadletter");
+                var deadLetterBlobContainer = _cloudBlobClient.GetContainerReference(_cloudStorageContainerName + "-deadletter");
                 await deadLetterBlobContainer.CreateIfNotExistsAsync();
 
                 // Create a parser
@@ -84,12 +90,18 @@ namespace Stats.ImportAzureCdnStatistics
                 var prefix = string.Format(CultureInfo.InvariantCulture, "{0}_{1}_", _azureCdnPlatform.GetRawLogFilePrefix(), _azureCdnAccountNumber);
 
                 // Get next raw log file to be processed
-                var leasedLogFiles = await blobLeaseManager.LeaseNextLogFilesToBeProcessedAsync(prefix);
+                var leasedLogFiles = await _blobLeaseManager.LeaseNextLogFilesToBeProcessedAsync(prefix);
                 foreach (var leasedLogFile in leasedLogFiles)
                 {
                     var packageTranslator = new PackageTranslator("packagetranslations.json");
                     var packageStatisticsParser = new PackageStatisticsParser(packageTranslator);
-                    await logProcessor.ProcessLogFileAsync(leasedLogFile, packageStatisticsParser);
+                    await logProcessor.ProcessLogFileAsync(leasedLogFile, packageStatisticsParser, _aggregatesOnly);
+
+                    if (_aggregatesOnly)
+                    {
+                        _blobLeaseManager.HoldMemLockOnBlob(leasedLogFile.Uri);
+                    }
+
                     leasedLogFile.Dispose();
                 }
             }

--- a/src/Stats.ImportAzureCdnStatistics/LogFileAggregates.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileAggregates.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Stats.ImportAzureCdnStatistics
+{
+    internal class LogFileAggregates
+    {
+        public LogFileAggregates(string logFileName)
+        {
+            LogFileName = logFileName;
+            PackageDownloadsByDate = new Dictionary<int, int>();
+        }
+
+        public string LogFileName { get; private set; }
+
+        public IDictionary<int, int> PackageDownloadsByDate { get; private set; }
+    }
+}

--- a/src/Stats.ImportAzureCdnStatistics/LogFileAggregates.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileAggregates.cs
@@ -10,11 +10,14 @@ namespace Stats.ImportAzureCdnStatistics
         public LogFileAggregates(string logFileName)
         {
             LogFileName = logFileName;
-            PackageDownloadsByDate = new Dictionary<int, int>();
+            PackageDownloadsByDateDimensionId = new Dictionary<int, int>();
         }
 
         public string LogFileName { get; private set; }
 
-        public IDictionary<int, int> PackageDownloadsByDate { get; private set; }
+        /// <summary>
+        /// Contains date dimension id's linked to total package download counts for a given log file.
+        /// </summary>
+        public IDictionary<int, int> PackageDownloadsByDateDimensionId { get; private set; }
     }
 }

--- a/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
@@ -77,6 +77,7 @@ namespace Stats.ImportAzureCdnStatistics
                         var downloadFacts = await warehouse.CreateAsync(cdnStatistics.PackageStatistics, logFile.Blob.Name);
                         await warehouse.InsertDownloadFactsAsync(downloadFacts, logFile.Blob.Name);
                     }
+
                     if (hasToolStatistics)
                     {
                         var downloadFacts = await warehouse.CreateAsync(cdnStatistics.ToolStatistics, logFile.Blob.Name);
@@ -85,20 +86,15 @@ namespace Stats.ImportAzureCdnStatistics
                 }
 
                 await ArchiveBlobAsync(logFile);
-
-                // delete the blob from the 'to-be-processed' container
-                await DeleteSourceBlobAsync(logFile);
             }
             catch (Exception e)
             {
-                await _deadLetterContainer.CreateIfNotExistsAsync();
-
                 // copy the blob to a dead-letter container
                 await EnsureCopiedToContainerAsync(logFile, _deadLetterContainer, e);
-
-                // delete the blob from the 'to-be-processed' container
-                await DeleteSourceBlobAsync(logFile);
             }
+
+            // delete the blob from the 'to-be-processed' container
+            await DeleteSourceBlobAsync(logFile);
         }
 
         private static async Task EnsureCopiedToContainerAsync(ILeasedLogFile logFile, CloudBlobContainer targetContainer, Exception e = null)

--- a/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
@@ -109,7 +109,7 @@ namespace Stats.ImportAzureCdnStatistics
 
                                 foreach (var keyValuePair in downloadsByDate)
                                 {
-                                    logFileAggregates.PackageDownloadsByDate.Add(keyValuePair.Key, keyValuePair.Value);
+                                    logFileAggregates.PackageDownloadsByDateDimensionId.Add(keyValuePair.Key, keyValuePair.Value);
 
 #if DEBUG
                                     _logger.LogInformation(

--- a/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
@@ -235,7 +235,7 @@ namespace Stats.ImportAzureCdnStatistics
 
                 stopwatch.Stop();
 
-                _logger.LogDebug("Finished parsing blob {FtpBlobUri} ({RecordCount} records.", blobUri, packageStatistics.Count);
+                _logger.LogDebug("Finished parsing blob {FtpBlobUri} ({RecordCount} records).", blobUri, packageStatistics.Count);
                 ApplicationInsightsHelper.TrackMetric("Blob parsing duration (ms)", stopwatch.ElapsedMilliseconds, blobName);
             }
             catch (Exception exception)

--- a/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
@@ -111,11 +111,9 @@ namespace Stats.ImportAzureCdnStatistics
                                 {
                                     logFileAggregates.PackageDownloadsByDateDimensionId.Add(keyValuePair.Key, keyValuePair.Value);
 
-#if DEBUG
                                     _logger.LogInformation(
                                         "{LogFile} contains {PackageDownloadCount} package downloads for date id {DimensionDateId}",
                                         logFileName, keyValuePair.Value, keyValuePair.Key);
-#endif
                                 }
                             }
                         }
@@ -132,6 +130,8 @@ namespace Stats.ImportAzureCdnStatistics
             }
             catch (Exception e)
             {
+                _logger.LogError(new FormattedLogValues("Unable to process {LogFile}", logFile.Uri), e);
+
                 if (!aggregatesOnly)
                 {
                     // copy the blob to a dead-letter container

--- a/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -29,8 +28,8 @@ namespace Stats.ImportAzureCdnStatistics
 
         public LogFileProcessor(CloudBlobContainer targetContainer,
             CloudBlobContainer deadLetterContainer,
-            SqlConnectionStringBuilder targetDatabase,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory,
+            Warehouse warehouse)
         {
             if (targetContainer == null)
             {
@@ -42,9 +41,9 @@ namespace Stats.ImportAzureCdnStatistics
                 throw new ArgumentNullException(nameof(deadLetterContainer));
             }
 
-            if (targetDatabase == null)
+            if (warehouse == null)
             {
-                throw new ArgumentNullException(nameof(targetDatabase));
+                throw new ArgumentNullException(nameof(warehouse));
             }
 
             if (loggerFactory == null)
@@ -56,7 +55,7 @@ namespace Stats.ImportAzureCdnStatistics
             _deadLetterContainer = deadLetterContainer;
             _logger = loggerFactory.CreateLogger<Job>();
 
-            _warehouse = new Warehouse(loggerFactory, targetDatabase);
+            _warehouse = warehouse;
         }
 
         public async Task ProcessLogFileAsync(ILeasedLogFile logFile, PackageStatisticsParser packageStatisticsParser, bool aggregatesOnly = false)

--- a/src/Stats.ImportAzureCdnStatistics/LogFileProvider.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileProvider.cs
@@ -23,6 +23,7 @@ namespace Stats.ImportAzureCdnStatistics
         private readonly CloudBlobContainer _container;
         private readonly ILogger _logger;
         private string _lastProcessedBlobUri;
+        private List<IListBlobItem> _allBlobs;
 
         public LogFileProvider(CloudBlobContainer container, ILoggerFactory loggerFactory)
         {
@@ -39,19 +40,36 @@ namespace Stats.ImportAzureCdnStatistics
             _logger = loggerFactory.CreateLogger<LogFileProvider>();
         }
 
-        public async Task<IReadOnlyCollection<ILeasedLogFile>> LeaseNextLogFilesToBeProcessedAsync(string prefix)
+        public async Task<IReadOnlyCollection<ILeasedLogFile>> LeaseNextLogFilesToBeProcessedAsync(string prefix, IReadOnlyCollection<string> alreadyAggregatedLogFiles)
         {
             try
             {
                 _logger.LogDebug("Beginning blob listing using prefix {BlobPrefix}.", prefix);
 
-                var blobResultSegments = await _container.ListBlobsSegmentedAsync(prefix, true, BlobListingDetails.None, _maxListBlobResultSegments, null, null, null);
+                var aggregatesOnly = alreadyAggregatedLogFiles != null;
+
+                var leasedFiles = new List<ILeasedLogFile>();
+                IEnumerable<IListBlobItem> blobs;
+
+                if (!aggregatesOnly)
+                {
+                    var blobResultSegments = await _container.ListBlobsSegmentedAsync(prefix, true, BlobListingDetails.None, _maxListBlobResultSegments, null, null, null);
+                    blobs = blobResultSegments.Results;
+                }
+                else
+                {
+                    if (_allBlobs == null)
+                    {
+                        _allBlobs = _container.ListBlobs(prefix, true).ToList();
+                    }
+
+                    blobs = _allBlobs.Where(b => !alreadyAggregatedLogFiles.Contains(b.Uri.Segments.Last(), StringComparer.InvariantCultureIgnoreCase));
+                }
 
                 _logger.LogInformation("Finishing blob listing using prefix {BlobPrefix}.", prefix);
 
-                var leasedFiles = new List<ILeasedLogFile>();
-
-                foreach (var logFile in blobResultSegments.Results)
+                var alreadyProcessedBlobs = new List<IListBlobItem>();
+                foreach (var logFile in blobs)
                 {
                     if (leasedFiles.Count == _maxLeasesPerJobRun)
                     {
@@ -65,6 +83,8 @@ namespace Stats.ImportAzureCdnStatistics
                     if (_lastProcessedBlobUri != null && string.CompareOrdinal(_lastProcessedBlobUri, logFileBlob.Uri.ToString()) >= 0)
                     {
                         // skip blobs we already processed (when generating aggregate logfile info only)
+                        alreadyProcessedBlobs.Add(logFile);
+
                         continue;
                     }
 
@@ -77,6 +97,11 @@ namespace Stats.ImportAzureCdnStatistics
                     }
 
                     leasedFiles.Add(new LeasedLogFile(logFileBlob, leaseId));
+                }
+
+                foreach (var logFile in alreadyProcessedBlobs)
+                {
+                    _allBlobs.Remove(logFile);
                 }
 
                 return leasedFiles;

--- a/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
+++ b/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
@@ -137,6 +137,7 @@
   <ItemGroup>
     <Compile Include="ApplicationInsightsHelper.cs" />
     <Compile Include="Dimensions\IpAddressFact.cs" />
+    <Compile Include="LogFileAggregates.cs" />
     <Compile Include="PackageTranslator.cs" />
     <Compile Include="UserAgentFactTableType.cs" />
     <Compile Include="ClientDimensionTableType.cs" />

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -1257,7 +1257,7 @@ namespace Stats.ImportAzureCdnStatistics
             table.Columns.Add("Date_Dimension_Id", typeof(int));
             table.Columns.Add("PackageDownloads", typeof(int));
 
-            foreach (var kvp in logFileAggregates.PackageDownloadsByDate)
+            foreach (var kvp in logFileAggregates.PackageDownloadsByDateDimensionId)
             {
                 var row = table.NewRow();
                 row["LogFileName"] = logFileAggregates.LogFileName;

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -21,15 +21,15 @@ namespace Stats.ImportAzureCdnStatistics
         private readonly TimeSpan _retryDelay = TimeSpan.FromSeconds(5);
         private readonly ILogger _logger;
         private readonly SqlConnectionStringBuilder _targetDatabase;
-        private static IReadOnlyCollection<TimeDimension> _times;
-        private static readonly IList<PackageDimension> _cachedPackageDimensions = new List<PackageDimension>();
-        private static readonly IList<ToolDimension> _cachedToolDimensions = new List<ToolDimension>();
-        private static readonly IDictionary<string, int> _cachedClientDimensions = new Dictionary<string, int>();
-        private static readonly IDictionary<string, int> _cachedPlatformDimensions = new Dictionary<string, int>();
-        private static readonly IDictionary<string, int> _cachedOperationDimensions = new Dictionary<string, int>();
-        private static readonly IDictionary<string, int> _cachedProjectTypeDimensions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        private static readonly IDictionary<string, int> _cachedUserAgentFacts = new Dictionary<string, int>();
-        private static readonly IDictionary<string, int> _cachedIpAddressFacts = new Dictionary<string, int>();
+        private readonly IList<PackageDimension> _cachedPackageDimensions = new List<PackageDimension>();
+        private readonly IList<ToolDimension> _cachedToolDimensions = new List<ToolDimension>();
+        private readonly IDictionary<string, int> _cachedClientDimensions = new Dictionary<string, int>();
+        private readonly IDictionary<string, int> _cachedPlatformDimensions = new Dictionary<string, int>();
+        private readonly IDictionary<string, int> _cachedOperationDimensions = new Dictionary<string, int>();
+        private readonly IDictionary<string, int> _cachedProjectTypeDimensions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        private readonly IDictionary<string, int> _cachedUserAgentFacts = new Dictionary<string, int>();
+        private readonly IDictionary<string, int> _cachedIpAddressFacts = new Dictionary<string, int>();
+        private IReadOnlyCollection<TimeDimension> _times;
 
         public Warehouse(ILoggerFactory loggerFactory, SqlConnectionStringBuilder targetDatabase)
         {
@@ -37,6 +37,7 @@ namespace Stats.ImportAzureCdnStatistics
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
+
             if (targetDatabase == null)
             {
                 throw new ArgumentNullException(nameof(targetDatabase));
@@ -537,7 +538,7 @@ namespace Stats.ImportAzureCdnStatistics
             return id;
         }
 
-        private static async Task<IReadOnlyCollection<ToolDimension>> RetrieveToolDimensions(IReadOnlyCollection<ToolStatistics> sourceData, SqlConnection connection)
+        private async Task<IReadOnlyCollection<ToolDimension>> RetrieveToolDimensions(IReadOnlyCollection<ToolStatistics> sourceData, SqlConnection connection)
         {
             var tools = sourceData
                    .Select(e => new ToolDimension(e.ToolId, e.ToolVersion, e.FileName))
@@ -596,7 +597,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IReadOnlyCollection<PackageDimension>> RetrievePackageDimensions(IReadOnlyCollection<PackageStatistics> sourceData, SqlConnection connection)
+        private async Task<IReadOnlyCollection<PackageDimension>> RetrievePackageDimensions(IReadOnlyCollection<PackageStatistics> sourceData, SqlConnection connection)
         {
             var packages = sourceData
                 .Select(e => new PackageDimension(e.PackageId, e.PackageVersion))
@@ -702,7 +703,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IDictionary<string, int>> RetrieveOperationDimensions(IReadOnlyCollection<PackageStatistics> sourceData, SqlConnection connection)
+        private async Task<IDictionary<string, int>> RetrieveOperationDimensions(IReadOnlyCollection<PackageStatistics> sourceData, SqlConnection connection)
         {
             var operations = sourceData
                 .Where(e => !string.IsNullOrEmpty(e.Operation))
@@ -760,7 +761,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IDictionary<string, int>> RetrieveProjectTypeDimensions(IReadOnlyCollection<PackageStatistics> sourceData, SqlConnection connection)
+        private async Task<IDictionary<string, int>> RetrieveProjectTypeDimensions(IReadOnlyCollection<PackageStatistics> sourceData, SqlConnection connection)
         {
             var projectTypes = sourceData
                 .Where(e => !string.IsNullOrEmpty(e.ProjectGuids))
@@ -816,7 +817,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IDictionary<string, int>> RetrieveClientDimensions(IReadOnlyCollection<ITrackUserAgent> sourceData, SqlConnection connection)
+        private async Task<IDictionary<string, int>> RetrieveClientDimensions(IReadOnlyCollection<ITrackUserAgent> sourceData, SqlConnection connection)
         {
             var clientDimensions = sourceData
                 .Where(e => !string.IsNullOrEmpty(e.UserAgent))
@@ -877,7 +878,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IDictionary<string, int>> RetrievePlatformDimensions(IReadOnlyCollection<ITrackUserAgent> sourceData, SqlConnection connection)
+        private async Task<IDictionary<string, int>> RetrievePlatformDimensions(IReadOnlyCollection<ITrackUserAgent> sourceData, SqlConnection connection)
         {
             var platformDimensions = sourceData
                 .Where(e => !string.IsNullOrEmpty(e.UserAgent))
@@ -938,7 +939,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IDictionary<string, int>> RetrieveUserAgentFacts(IReadOnlyCollection<ITrackUserAgent> sourceData, SqlConnection connection)
+        private async Task<IDictionary<string, int>> RetrieveUserAgentFacts(IReadOnlyCollection<ITrackUserAgent> sourceData, SqlConnection connection)
         {
             var userAgents = sourceData
                 .Where(e => !string.IsNullOrEmpty(e.UserAgent))
@@ -1000,7 +1001,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IDictionary<string, int>> RetrieveLogFileNameFacts(string logFileName, SqlConnection connection)
+        private async Task<IDictionary<string, int>> RetrieveLogFileNameFacts(string logFileName, SqlConnection connection)
         {
             var results = new Dictionary<string, int>();
 
@@ -1026,7 +1027,7 @@ namespace Stats.ImportAzureCdnStatistics
             return results;
         }
 
-        private static async Task<IDictionary<string, int>> RetrieveIpAddressesFacts(IReadOnlyCollection<ITrackEdgeServerIpAddress> sourceData, SqlConnection connection)
+        private async Task<IDictionary<string, int>> RetrieveIpAddressesFacts(IReadOnlyCollection<ITrackEdgeServerIpAddress> sourceData, SqlConnection connection)
         {
             var ipAddressFacts = sourceData
                 .Where(e => !string.IsNullOrEmpty(e.EdgeServerIpAddress))

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.SelectAlreadyAggregatedLogFiles.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.SelectAlreadyAggregatedLogFiles.sql
@@ -1,0 +1,10 @@
+﻿CREATE PROCEDURE [dbo].[SelectAlreadyAggregatedLogFiles]
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	SELECT	DISTINCT [LogFileName]
+	FROM	[dbo].[Agg_PackageDownloads_LogFile] (NOLOCK)
+	ORDER BY [LogFileName] ASC
+
+END

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.StoreLogFileAggregates.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.StoreLogFileAggregates.sql
@@ -1,0 +1,65 @@
+﻿CREATE PROCEDURE [dbo].[StoreLogFileAggregates]
+	@packageDownloadsByDate [dbo].[LogFileAggregatesPackageDownloadsByDateTableType] READONLY
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	BEGIN TRY
+		DECLARE @LogFileName NVARCHAR(255)
+		DECLARE @Dimension_Date_Id INT
+		DECLARE @PackageDownloads INT
+
+		-- Open Cursor
+		DECLARE aggregates_Cursor CURSOR FOR
+			SELECT	[LogFileName], [Dimension_Date_Id], [PackageDownloads]
+			FROM	@packageDownloadsByDate
+
+		OPEN	aggregates_Cursor FETCH NEXT
+		FROM	aggregates_Cursor
+		INTO	@LogFileName, @Dimension_Date_Id, @PackageDownloads
+
+		WHILE @@FETCH_STATUS = 0
+		BEGIN
+			SET TRANSACTION ISOLATION LEVEL READ COMMITTED
+			BEGIN TRANSACTION
+
+			IF NOT EXISTS (SELECT [Id] FROM [dbo].[Agg_PackageDownloads_LogFile] (NOLOCK) WHERE [LogFileName] = @LogFileName AND [Dimension_Date_Id] = @Dimension_Date_Id)
+					INSERT INTO [dbo].[Agg_PackageDownloads_LogFile] ([LogFileName], [Dimension_Date_Id], [PackageDownloads])
+					VALUES (@LogFileName, @Dimension_Date_Id, @PackageDownloads);
+			ELSE
+			BEGIN
+				DECLARE @tmp INT
+				SELECT	@tmp = [PackageDownloads]
+				FROM	[dbo].[Agg_PackageDownloads_LogFile] (NOLOCK)
+				WHERE	[LogFileName] = @LogFileName
+						AND [Dimension_Date_Id] = @Dimension_Date_Id
+
+				UPDATE	[dbo].[Agg_PackageDownloads_LogFile]
+				SET		[PackageDownloads] = @tmp + @PackageDownloads
+				WHERE	[LogFileName] = @LogFileName
+						AND [Dimension_Date_Id] = @Dimension_Date_Id
+			END
+
+			COMMIT
+
+			-- Advance cursor
+			FETCH NEXT FROM aggregates_Cursor
+			INTO @LogFileName, @Dimension_Date_Id, @PackageDownloads
+
+		END
+
+		-- Close cursor
+		CLOSE aggregates_Cursor
+		DEALLOCATE aggregates_Cursor
+
+	END TRY
+	BEGIN CATCH
+
+		IF @@TRANCOUNT > 0
+			ROLLBACK;
+
+		THROW
+
+	END CATCH
+
+END

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.StoreLogFileAggregates.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.StoreLogFileAggregates.sql
@@ -28,14 +28,8 @@ BEGIN
 					VALUES (@LogFileName, @Dimension_Date_Id, @PackageDownloads);
 			ELSE
 			BEGIN
-				DECLARE @tmp INT
-				SELECT	@tmp = [PackageDownloads]
-				FROM	[dbo].[Agg_PackageDownloads_LogFile] (NOLOCK)
-				WHERE	[LogFileName] = @LogFileName
-						AND [Dimension_Date_Id] = @Dimension_Date_Id
-
 				UPDATE	[dbo].[Agg_PackageDownloads_LogFile]
-				SET		[PackageDownloads] = @tmp + @PackageDownloads
+				SET		[PackageDownloads] = @PackageDownloads
 				WHERE	[LogFileName] = @LogFileName
 						AND [Dimension_Date_Id] = @Dimension_Date_Id
 			END

--- a/src/Stats.Warehouse/Programmability/Types/dbo.LogFileAggregatesPackageDownloadsByDateTableType.sql
+++ b/src/Stats.Warehouse/Programmability/Types/dbo.LogFileAggregatesPackageDownloadsByDateTableType.sql
@@ -1,0 +1,6 @@
+﻿CREATE TYPE [dbo].[LogFileAggregatesPackageDownloadsByDateTableType] AS TABLE
+(
+	LogFileName NVARCHAR(255) NOT NULL,
+	Dimension_Date_Id INT NOT NULL,
+	PackageDownloads INT NOT NULL
+)

--- a/src/Stats.Warehouse/Stats.Warehouse.refactorlog
+++ b/src/Stats.Warehouse/Stats.Warehouse.refactorlog
@@ -21,4 +21,25 @@
     <Property Name="ParentElementType" Value="SqlTable" />
     <Property Name="NewName" Value="IsIp4" />
   </Operation>
+  <Operation Name="Rename Refactor" Key="b088e036-f628-4300-9e24-786e849eac38" ChangeDateTime="05/10/2016 17:35:24">
+    <Property Name="ElementName" Value="[dbo].[Agg_PackageDownloads_LogFile].[LogFileName]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Agg_PackageDownloads_LogFile]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="Fact_LogFileName_Id" />
+  </Operation>
+  <Operation Name="Rename Refactor" Key="0bc57375-b645-4067-bf0c-b07dc1d9cb2f" ChangeDateTime="05/10/2016 17:36:03">
+    <Property Name="ElementName" Value="[dbo].[Agg_PackageDownloads_LogFile].[Fact_LogFileName_Id]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Agg_PackageDownloads_LogFile]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="LogFileName" />
+  </Operation>
+  <Operation Name="Rename Refactor" Key="2fec8a80-98de-4ff6-a066-bfc08d2ce20d" ChangeDateTime="05/10/2016 17:42:02">
+    <Property Name="ElementName" Value="[dbo].[Agg_PackageDownloads_LogFile].[Date_Dimension_Id]" />
+    <Property Name="ElementType" Value="SqlSimpleColumn" />
+    <Property Name="ParentElementName" Value="[dbo].[Agg_PackageDownloads_LogFile]" />
+    <Property Name="ParentElementType" Value="SqlTable" />
+    <Property Name="NewName" Value="Dimension_Date_Id" />
+  </Operation>
 </Operations>

--- a/src/Stats.Warehouse/Stats.Warehouse.sqlproj
+++ b/src/Stats.Warehouse/Stats.Warehouse.sqlproj
@@ -131,8 +131,14 @@
     <Build Include="Programmability\Stored Procedures\dbo.CleanupPlatformDimension.sql" />
     <Build Include="Programmability\Stored Procedures\dbo.CleanupFactIpAddress.sql" />
     <Build Include="Programmability\Stored Procedures\dbo.CleanupFactUserAgent.sql" />
+    <Build Include="Programmability\Stored Procedures\dbo.StoreLogFileAggregates.sql" />
+    <Build Include="Programmability\Types\dbo.LogFileAggregatesPackageDownloadsByDateTableType.sql" />
+    <Build Include="Tables\dbo.Agg_PackageDownloads_LogFile.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="StaticCodeAnalysis.SuppressMessages.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <RefactorLog Include="Stats.Warehouse.refactorlog" />
   </ItemGroup>
 </Project>

--- a/src/Stats.Warehouse/Stats.Warehouse.sqlproj
+++ b/src/Stats.Warehouse/Stats.Warehouse.sqlproj
@@ -134,6 +134,7 @@
     <Build Include="Programmability\Stored Procedures\dbo.StoreLogFileAggregates.sql" />
     <Build Include="Programmability\Types\dbo.LogFileAggregatesPackageDownloadsByDateTableType.sql" />
     <Build Include="Tables\dbo.Agg_PackageDownloads_LogFile.sql" />
+    <Build Include="Programmability\Stored Procedures\dbo.SelectAlreadyAggregatedLogFiles.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="StaticCodeAnalysis.SuppressMessages.xml" />

--- a/src/Stats.Warehouse/Tables/dbo.Agg_PackageDownloads_LogFile.sql
+++ b/src/Stats.Warehouse/Tables/dbo.Agg_PackageDownloads_LogFile.sql
@@ -1,0 +1,8 @@
+﻿CREATE TABLE [dbo].[Agg_PackageDownloads_LogFile]
+(
+	[Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY DEFAULT NEWID(),
+    [LogFileName] NVARCHAR(255) NOT NULL,
+    [Dimension_Date_Id] INT NOT NULL,
+    [PackageDownloads] INT NOT NULL,
+    CONSTRAINT [FK_Agg_PackageDownloads_LogFile_Dimension_Date] FOREIGN KEY ([Dimension_Date_Id]) REFERENCES [dbo].[Dimension_Date]([Id])
+)


### PR DESCRIPTION
This PR:
* Adds support for a new -AggregatesOnly job execution mode, which enables ad-hoc retroactive parsing of log files and storing aggregates only (needed to patch the db for already imported blobs)
* Enables the stats importer (in regular execution mode) to also store total package download counts per log file to the stats db, linked to the date dimension id.

This combined will provide a means to easily query total package downloads by date.

cc @maartenba @skofman1 