### PR TITLE
Remove usage of EnvVar for azure logging 

### DIFF
--- a/src/Gallery.CredentialExpiration/Scripts/Gallery.CredentialExpiration.cmd
+++ b/src/Gallery.CredentialExpiration/Scripts/Gallery.CredentialExpiration.cmd
@@ -5,13 +5,11 @@ cd bin
 :Top
 	echo "Starting job - #{Jobs.gallery.credentialexpiration.Title}"
 	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.gallery.credentialexpiration.Storage.Primary}
-
 	title #{Jobs.gallery.credentialexpiration.Title}
 
 	REM SmtpUri is expected to be of the format: smtps://username:password@host:port. Note that if username contains an "@", you need to URI encode it!
 
-	start /w gallery.credentialexpiration.exe -WhatIf #{Jobs.gallery.credentialexpiration.WhatIf} -WarnDaysBeforeExpiration #{Jobs.gallery.credentialexpiration.WarnDaysBeforeExpiration} -MailFrom "#{Jobs.gallery.credentialexpiration.MailFrom}" -GalleryBrand "#{Jobs.gallery.credentialexpiration.GalleryBrand}" -GalleryAccountUrl "#{Jobs.gallery.credentialexpiration.GalleryAccountUrl}"	-SmtpUri "#{Jobs.gallery.credentialexpiration.SmtpUri}"	-GalleryDatabase "#{Jobs.gallery.credentialexpiration.GalleryDatabase}"	-InstrumentationKey "#{Jobs.gallery.credentialexpiration.InstrumentationKey}" -verbose true -interval #{Jobs.gallery.credentialexpiration.Interval}
+	start /w gallery.credentialexpiration.exe -LogsAzureStorageConnectionString #{Jobs.gallery.credentialexpiration.Storage.Primary} -WhatIf #{Jobs.gallery.credentialexpiration.WhatIf} -WarnDaysBeforeExpiration #{Jobs.gallery.credentialexpiration.WarnDaysBeforeExpiration} -MailFrom "#{Jobs.gallery.credentialexpiration.MailFrom}" -GalleryBrand "#{Jobs.gallery.credentialexpiration.GalleryBrand}" -GalleryAccountUrl "#{Jobs.gallery.credentialexpiration.GalleryAccountUrl}"	-SmtpUri "#{Jobs.gallery.credentialexpiration.SmtpUri}"	-GalleryDatabase "#{Jobs.gallery.credentialexpiration.GalleryDatabase}"	-InstrumentationKey "#{Jobs.gallery.credentialexpiration.InstrumentationKey}" -verbose true -interval #{Jobs.gallery.credentialexpiration.Interval}
 
 	echo "Finished #{Jobs.gallery.credentialexpiration.Title}"
 

--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -121,5 +121,8 @@ namespace NuGet.Jobs
         // Arguments specific to e-mail
         public const string MailFrom = "MailFrom";
         public const string SmtpUri = "SmtpUri";
+
+        // Arguments for Azure logs
+        public const string LogsAzureStorageConnectionString = "LogsAzureStorageConnectionString";
     }
 }

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -48,6 +48,10 @@ namespace NuGet.Jobs
                 consoleLogOnly = true;
             }
 
+            // Set the default trace listener, so if we get args parsing issues they will be printed. This will be overriden by the configured trace listener
+            // after config is parsed.
+            job.SetJobTraceListener(new JobTraceListener());
+
             try
             {
                 Trace.TraceInformation("Started...");

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -48,14 +48,15 @@ namespace NuGet.Jobs
                 consoleLogOnly = true;
             }
 
-            // Set JobTraceListener. This will be done on every job run as well
-            SetJobTraceListener(job, consoleLogOnly);
             try
             {
                 Trace.TraceInformation("Started...");
 
                 // Get the args passed in or provided as an env variable based on jobName as a dictionary of <string argName, string argValue>
                 var jobArgsDictionary = JobConfigurationManager.GetJobArgsDictionary(commandLineArgs, job.JobName, (ISecretReaderFactory)ServiceContainer.GetService(typeof(ISecretReaderFactory)));
+
+                // Set JobTraceListener. This will be done on every job run as well
+                SetJobTraceListener(job, consoleLogOnly, jobArgsDictionary);
 
                 bool runContinuously = !JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, JobArgumentNames.Once);
                 int? sleepDuration = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.Sleep); // sleep is in milliseconds
@@ -72,7 +73,7 @@ namespace NuGet.Jobs
                 JobSetup(job, consoleLogOnly, jobArgsDictionary, ref sleepDuration);
 
                 // Run the job loop
-                await JobLoop(job, runContinuously, sleepDuration.Value, consoleLogOnly);
+                await JobLoop(job, runContinuously, sleepDuration.Value, j => SetJobTraceListener(j, consoleLogOnly, jobArgsDictionary));
             }
             catch (AggregateException ex)
             {
@@ -106,7 +107,7 @@ namespace NuGet.Jobs
                 (milliSeconds / 60000.0).ToString(precisionSpecifier));  // Time in minutes
         }
 
-        private static void SetJobTraceListener(JobBase job, bool consoleLogOnly)
+        private static void SetJobTraceListener(JobBase job, bool consoleLogOnly, IDictionary<string, string> argsDictionary)
         {
             if(consoleLogOnly)
             {
@@ -115,7 +116,8 @@ namespace NuGet.Jobs
             }
             else
             {
-                job.SetJobTraceListener(new AzureBlobJobTraceListener(job.JobName));
+                var connectionString = JobConfigurationManager.GetArgument(argsDictionary, JobArgumentNames.LogsAzureStorageConnectionString);
+                job.SetJobTraceListener(new AzureBlobJobTraceListener(job.JobName, connectionString));
             }
         }
 
@@ -148,7 +150,7 @@ namespace NuGet.Jobs
             }
         }
 
-        private static async Task<string> JobLoop(JobBase job, bool runContinuously, int sleepDuration, bool consoleLogOnly)
+        private static async Task<string> JobLoop(JobBase job, bool runContinuously, int sleepDuration, Action<JobBase> setTraceListener)
         {
             // Run the job now
             var stopWatch = new Stopwatch();
@@ -195,7 +197,7 @@ namespace NuGet.Jobs
                 Console.WriteLine("Sleeping for {0} before the next job run", PrettyPrintTime(sleepDuration));
                 Thread.Sleep(sleepDuration);
 
-                SetJobTraceListener(job, consoleLogOnly);
+                setTraceListener(job);
             }
 
             return success ? _jobSucceeded : _jobFailed;

--- a/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
@@ -20,7 +20,7 @@ namespace NuGet.Jobs
                     JobConfigurationManager.GetArgument(settings, JobArgumentNames.VaultName),
                     JobConfigurationManager.GetArgument(settings, JobArgumentNames.ClientId),
                     JobConfigurationManager.GetArgument(settings, JobArgumentNames.CertificateThumbprint),
-                    JobConfigurationManager.TryGetBoolArgument(settings, JobArgumentNames.ValidateCertificate, fallbackEnvVariable: null, defaultValue: true));
+                    JobConfigurationManager.TryGetBoolArgument(settings, JobArgumentNames.ValidateCertificate, defaultValue: true));
 
             return new KeyVaultReader(keyVaultConfiguration);
         }

--- a/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
+++ b/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
@@ -7,7 +7,7 @@ cd bin
 
 	title #{Jobs.search.generateauxiliarydata.Title}
 
-    start /w search.generateauxiliarydata.exe -VaultName "#{Deployment.Azure.KeyVault.VaultName}" -ClientId "#{Deployment.Azure.KeyVault.ClientId}" -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" -LogsAzureStorageConnectionString #{Jobs.search.generateauxiliarydata.Storage.Primary} -PrimaryDestination #{Jobs.search.generateauxiliarydata.Storage.Primary} -PackageDatabase #{Jobs.search.generateauxiliarydata.PackageDatabase}" -verbose true -sleep #{Jobs.search.generateauxiliarydata.Sleep}
+    start /w search.generateauxiliarydata.exe -VaultName "#{Deployment.Azure.KeyVault.VaultName}" -ClientId "#{Deployment.Azure.KeyVault.ClientId}" -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" -LogsAzureStorageConnectionString #{Jobs.search.generateauxiliarydata.Storage.Primary} -PrimaryDestination #{Jobs.search.generateauxiliarydata.Storage.Primary} -PackageDatabase "#{Jobs.search.generateauxiliarydata.PackageDatabase}" -verbose true -sleep #{Jobs.search.generateauxiliarydata.Sleep}
 
 	echo "Finished #{Jobs.search.generateauxiliarydata.Title}"
 

--- a/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
+++ b/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
@@ -4,12 +4,10 @@ cd bin
 
 :Top
 	echo "Starting job - #{Jobs.search.generateauxiliarydata.Title}"
-	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.search.generateauxiliarydata.Storage.Primary}
 
 	title #{Jobs.search.generateauxiliarydata.Title}
 
-    start /w search.generateauxiliarydata.exe -VaultName "#{KeyVaultName}" -ClientId "#{KeyVaultClientId}" -CertificateThumbprint "#{KeyVaultCertificateThumbprint}" -PackageDatabase #{Jobs.search.generateauxiliarydata.PackageDatabase}" -verbose true -sleep #{Jobs.search.generateauxiliarydata.Sleep}
+    start /w search.generateauxiliarydata.exe -VaultName "#{KeyVaultName}" -ClientId "#{KeyVaultClientId}" -CertificateThumbprint "#{KeyVaultCertificateThumbprint}" -LogsAzureStorageConnectionString #{Jobs.search.generateauxiliarydata.Storage.Primary} -PrimaryDestination #{Jobs.search.generateauxiliarydata.Storage.Primary} -PackageDatabase #{Jobs.search.generateauxiliarydata.PackageDatabase}" -verbose true -sleep #{Jobs.search.generateauxiliarydata.Sleep}
 
 	echo "Finished #{Jobs.search.generateauxiliarydata.Title}"
 

--- a/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
+++ b/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
@@ -7,7 +7,7 @@ cd bin
 
 	title #{Jobs.search.generateauxiliarydata.Title}
 
-    start /w search.generateauxiliarydata.exe -VaultName "#{KeyVaultName}" -ClientId "#{KeyVaultClientId}" -CertificateThumbprint "#{KeyVaultCertificateThumbprint}" -LogsAzureStorageConnectionString #{Jobs.search.generateauxiliarydata.Storage.Primary} -PrimaryDestination #{Jobs.search.generateauxiliarydata.Storage.Primary} -PackageDatabase #{Jobs.search.generateauxiliarydata.PackageDatabase}" -verbose true -sleep #{Jobs.search.generateauxiliarydata.Sleep}
+    start /w search.generateauxiliarydata.exe -VaultName "#{Deployment.Azure.KeyVault.VaultName}" -ClientId "#{Deployment.Azure.KeyVault.ClientId}" -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" -LogsAzureStorageConnectionString #{Jobs.search.generateauxiliarydata.Storage.Primary} -PrimaryDestination #{Jobs.search.generateauxiliarydata.Storage.Primary} -PackageDatabase #{Jobs.search.generateauxiliarydata.PackageDatabase}" -verbose true -sleep #{Jobs.search.generateauxiliarydata.Sleep}
 
 	echo "Finished #{Jobs.search.generateauxiliarydata.Title}"
 

--- a/src/Search.GenerateAuxiliaryData/SqlExportArguments.cs
+++ b/src/Search.GenerateAuxiliaryData/SqlExportArguments.cs
@@ -11,21 +11,21 @@ namespace Search.GenerateAuxiliaryData
 {
     internal class SqlExportArguments
     {
-        public string ConnectionString { get; private set; }
-        public CloudStorageAccount Destination { get; private set; }
-        public CloudBlobContainer DestinationContainer { get; private set; }
-        public string DestinationContainerName { get; private set; }
-        public string Name { get; private set; }
+        public string ConnectionString { get; }
+        public CloudStorageAccount Destination { get; }
+        public CloudBlobContainer DestinationContainer { get; }
+        public string DestinationContainerName { get; }
+        public string Name { get; }
 
         public SqlExportArguments(IDictionary<string, string> jobArgsDictionary, string defaultContainerName, string defaultName)
         {
             var connStrBldr = new SqlConnectionStringBuilder(
-                JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase, EnvironmentVariableKeys.SqlGallery));
+                JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase));
 
             ConnectionString = connStrBldr.ToString();
 
             Destination = CloudStorageAccount.Parse(
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PrimaryDestination, EnvironmentVariableKeys.StoragePrimary));
+                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PrimaryDestination));
 
             DestinationContainerName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.DestinationContainerName) ?? defaultContainerName;
             DestinationContainer = Destination.CreateCloudBlobClient().GetContainerReference(DestinationContainerName);

--- a/src/Stats.AggregateCdnDownloadsInGallery/Scripts/Stats.AggregateCdnDownloadsInGallery.cmd
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Scripts/Stats.AggregateCdnDownloadsInGallery.cmd
@@ -5,11 +5,9 @@ cd bin
 :Top
 	echo "Starting job - #{Jobs.stats.aggregatecdndownloadsingallery.Title}"
 	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.stats.aggregatecdndownloadsingallery.Storage.Primary}
-
 	title #{Jobs.stats.aggregatecdndownloadsingallery.Title}
 
-	start /w stats.aggregatecdndownloadsingallery.exe -StatisticsDatabase "#{Jobs.stats.aggregatecdndownloadsingallery.StatisticsDatabase}" -DestinationDatabase "#{Jobs.stats.aggregatecdndownloadsingallery.DestinationDatabase}" -InstrumentationKey "#{Jobs.stats.aggregatecdndownloadsingallery.InstrumentationKey}" -verbose true -interval #{Jobs.stats.aggregatecdndownloadsingallery.Interval}
+	start /w stats.aggregatecdndownloadsingallery.exe -LogsAzureStorageConnectionString #{Jobs.stats.aggregatecdndownloadsingallery.Storage.Primary} -StatisticsDatabase "#{Jobs.stats.aggregatecdndownloadsingallery.StatisticsDatabase}" -DestinationDatabase "#{Jobs.stats.aggregatecdndownloadsingallery.DestinationDatabase}" -InstrumentationKey "#{Jobs.stats.aggregatecdndownloadsingallery.InstrumentationKey}" -verbose true -interval #{Jobs.stats.aggregatecdndownloadsingallery.Interval}
 
 	echo "Finished #{Jobs.stats.aggregatecdndownloadsingallery.Title}"
 

--- a/src/Stats.CollectAzureCdnLogs/Scripts/Stats.CollectAzureCdnLogs.cmd
+++ b/src/Stats.CollectAzureCdnLogs/Scripts/Stats.CollectAzureCdnLogs.cmd
@@ -5,11 +5,9 @@ cd bin
 :Top
 	echo "Starting job - #{Jobs.stats.collectazurecdnlogs.Title}"
 	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.stats.collectazurecdnlogs.Storage.Primary}
-
 	title #{Jobs.stats.collectazurecdnlogs.Title}
 
-    start /w stats.collectazurecdnlogs.exe -FtpSourceUri "#{Jobs.stats.collectazurecdnlogs.FtpSource.Uri}" -FtpSourceUsername "#{Jobs.stats.collectazurecdnlogs.FtpSource.Username}" -FtpSourcePassword "#{Jobs.stats.collectazurecdnlogs.FtpSource.Password}" -AzureCdnAccountNumber "#{Jobs.stats.collectazurecdnlogs.AzureCdn.AccountNumber}" -AzureCdnPlatform "#{Jobs.stats.collectazurecdnlogs.AzureCdn.Platform}" -AzureCdnCloudStorageAccount "#{Jobs.stats.collectazurecdnlogs.AzureCdn.CloudStorageAccount}" -AzureCdnCloudStorageContainerName "#{Jobs.stats.collectazurecdnlogs.AzureCdn.CloudStorageContainerName}" -InstrumentationKey "#{Jobs.stats.collectazurecdnlogs.InstrumentationKey}" -verbose true -interval #{Jobs.stats.collectazurecdnlogs.Interval}
+    start /w stats.collectazurecdnlogs.exe -LogsAzureStorageConnectionString #{Jobs.stats.collectazurecdnlogs.Storage.Primary} -FtpSourceUri "#{Jobs.stats.collectazurecdnlogs.FtpSource.Uri}" -FtpSourceUsername "#{Jobs.stats.collectazurecdnlogs.FtpSource.Username}" -FtpSourcePassword "#{Jobs.stats.collectazurecdnlogs.FtpSource.Password}" -AzureCdnAccountNumber "#{Jobs.stats.collectazurecdnlogs.AzureCdn.AccountNumber}" -AzureCdnPlatform "#{Jobs.stats.collectazurecdnlogs.AzureCdn.Platform}" -AzureCdnCloudStorageAccount "#{Jobs.stats.collectazurecdnlogs.AzureCdn.CloudStorageAccount}" -AzureCdnCloudStorageContainerName "#{Jobs.stats.collectazurecdnlogs.AzureCdn.CloudStorageContainerName}" -InstrumentationKey "#{Jobs.stats.collectazurecdnlogs.InstrumentationKey}" -verbose true -interval #{Jobs.stats.collectazurecdnlogs.Interval}
 
 	echo "Finished #{Jobs.stats.collectazurecdnlogs.Title}"
 

--- a/src/Stats.CreateAzureCdnWarehouseReports/Scripts/Stats.CreateAzureCdnWarehouseReports.cmd
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Scripts/Stats.CreateAzureCdnWarehouseReports.cmd
@@ -4,12 +4,10 @@ cd bin
 
 :Top
 	echo "Starting job - #{Jobs.stats.createazurecdnwarehousereports.Title}"
-	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.stats.createazurecdnwarehousereports.Storage.Primary}
 
 	title #{Jobs.stats.createazurecdnwarehousereports.Title}
 
-	start /w stats.createazurecdnwarehousereports.exe -AzureCdnCloudStorageAccount "#{Jobs.stats.createazurecdnwarehousereports.AzureCdn.CloudStorageAccount}" -AzureCdnCloudStorageContainerName "#{Jobs.stats.createazurecdnwarehousereports.AzureCdn.CloudStorageContainerName}" -StatisticsDatabase "#{Jobs.stats.createazurecdnwarehousereports.StatisticsDatabase}" -SourceDatabase "#{Jobs.stats.createazurecdnwarehousereports.SourceDatabase}" -DataStorageAccount "#{Jobs.stats.createazurecdnwarehousereports.DataStorageAccount}" -InstrumentationKey "#{Jobs.stats.createazurecdnwarehousereports.InstrumentationKey}" -DataContainerName "#{Jobs.stats.createazurecdnwarehousereports.DataContainerName}" -verbose true -interval #{Jobs.stats.createazurecdnwarehousereports.Interval}
+	start /w stats.createazurecdnwarehousereports.exe -LogsAzureStorageConnectionString #{Jobs.stats.createazurecdnwarehousereports.Storage.Primary} -AzureCdnCloudStorageAccount "#{Jobs.stats.createazurecdnwarehousereports.AzureCdn.CloudStorageAccount}" -AzureCdnCloudStorageContainerName "#{Jobs.stats.createazurecdnwarehousereports.AzureCdn.CloudStorageContainerName}" -StatisticsDatabase "#{Jobs.stats.createazurecdnwarehousereports.StatisticsDatabase}" -SourceDatabase "#{Jobs.stats.createazurecdnwarehousereports.SourceDatabase}" -DataStorageAccount "#{Jobs.stats.createazurecdnwarehousereports.DataStorageAccount}" -InstrumentationKey "#{Jobs.stats.createazurecdnwarehousereports.InstrumentationKey}" -DataContainerName "#{Jobs.stats.createazurecdnwarehousereports.DataContainerName}" -verbose true -interval #{Jobs.stats.createazurecdnwarehousereports.Interval}
 
 	echo "Finished #{Jobs.stats.createazurecdnwarehousereports.Title}"
 

--- a/src/Stats.ImportAzureCdnStatistics/Scripts/Stats.ImportAzureCdnStatistics.cmd
+++ b/src/Stats.ImportAzureCdnStatistics/Scripts/Stats.ImportAzureCdnStatistics.cmd
@@ -5,11 +5,9 @@ cd bin
 :Top
 	echo "Starting job - #{Jobs.stats.importazurecdnstatistics.Title}"
 	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.stats.importazurecdnstatistics.Storage.Primary}
-
 	title #{Jobs.stats.importazurecdnstatistics.Title}
 
-	start /w stats.importazurecdnstatistics.exe -AzureCdnCloudStorageAccount "#{Jobs.stats.importazurecdnstatistics.AzureCdn.CloudStorageAccount}" -AzureCdnCloudStorageContainerName "#{Jobs.stats.importazurecdnstatistics.AzureCdn.CloudStorageContainerName}" -AzureCdnPlatform "#{Jobs.stats.importazurecdnstatistics.AzureCdn.Platform}" -AzureCdnAccountNumber "#{Jobs.stats.importazurecdnstatistics.AzureCdn.AccountNumber}" -StatisticsDatabase "#{Jobs.stats.importazurecdnstatistics.StatisticsDatabase}" -InstrumentationKey "#{Jobs.stats.importazurecdnstatistics.InstrumentationKey}" -verbose true -interval #{Jobs.stats.importazurecdnstatistics.Interval}
+	start /w stats.importazurecdnstatistics.exe -LogsAzureStorageConnectionString #{Jobs.stats.importazurecdnstatistics.Storage.Primary} -AzureCdnCloudStorageAccount "#{Jobs.stats.importazurecdnstatistics.AzureCdn.CloudStorageAccount}" -AzureCdnCloudStorageContainerName "#{Jobs.stats.importazurecdnstatistics.AzureCdn.CloudStorageContainerName}" -AzureCdnPlatform "#{Jobs.stats.importazurecdnstatistics.AzureCdn.Platform}" -AzureCdnAccountNumber "#{Jobs.stats.importazurecdnstatistics.AzureCdn.AccountNumber}" -StatisticsDatabase "#{Jobs.stats.importazurecdnstatistics.StatisticsDatabase}" -InstrumentationKey "#{Jobs.stats.importazurecdnstatistics.InstrumentationKey}" -verbose true -interval #{Jobs.stats.importazurecdnstatistics.Interval}
 
 	echo "Finished #{Jobs.stats.importazurecdnstatistics.Title}"
 

--- a/src/Stats.RollUpDownloadFacts/Scripts/Stats.RollUpDownloadFacts.cmd
+++ b/src/Stats.RollUpDownloadFacts/Scripts/Stats.RollUpDownloadFacts.cmd
@@ -5,11 +5,9 @@ cd bin
 :Top
 	echo "Starting job - #{Jobs.stats.rollupdownloadfacts.Title}"
 	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.stats.rollupdownloadfacts.Storage.Primary}
-
 	title #{Jobs.stats.rollupdownloadfacts.Title}
 
-    start /w stats.rollupdownloadfacts.exe -MinAgeInDays "#{Jobs.stats.rollupdownloadfacts.MinAgeInDays}" -StatisticsDatabase "#{Jobs.stats.rollupdownloadfacts.StatisticsDatabase}" -InstrumentationKey "#{Jobs.stats.rollupdownloadfacts.InstrumentationKey}" -verbose true -interval #{Jobs.stats.rollupdownloadfacts.Interval}
+    start /w stats.rollupdownloadfacts.exe -LogsAzureStorageConnectionString #{Jobs.stats.rollupdownloadfacts.Storage.Primary} -MinAgeInDays "#{Jobs.stats.rollupdownloadfacts.MinAgeInDays}" -StatisticsDatabase "#{Jobs.stats.rollupdownloadfacts.StatisticsDatabase}" -InstrumentationKey "#{Jobs.stats.rollupdownloadfacts.InstrumentationKey}" -verbose true -interval #{Jobs.stats.rollupdownloadfacts.Interval}
 
 	echo "Finished #{Jobs.stats.rollupdownloadfacts.Title}"
 

--- a/src/UpdateLicenseReports/Scripts/UpdateLicenseReports.cmd
+++ b/src/UpdateLicenseReports/Scripts/UpdateLicenseReports.cmd
@@ -5,11 +5,9 @@ cd bin
 :Top
 	echo "Starting job - #{Jobs.updatelicensereports.Title}"
 	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.updatelicensereports.Storage.Primary}
-
 	title #{Jobs.updatelicensereports.Title}
 
-    	start /w updatelicensereports.exe -LicenseReportService "#{Jobs.updatelicensereports.LicenseReportServiceUri}" -LicenseReportUser "#{Jobs.updatelicensereports.LicenseReportUser}" -LicenseReportPassword "#{Jobs.updatelicensereports.LicenseReportPassword}" -PackageDatabase "#{Jobs.updatelicensereports.PackageDatabase}" -verbose true -sleep #{Jobs.updatelicensereports.Sleep}
+    start /w updatelicensereports.exe -LogsAzureStorageConnectionString #{Jobs.updatelicensereports.Storage.Primary} -LicenseReportService "#{Jobs.updatelicensereports.LicenseReportServiceUri}" -LicenseReportUser "#{Jobs.updatelicensereports.LicenseReportUser}" -LicenseReportPassword "#{Jobs.updatelicensereports.LicenseReportPassword}" -PackageDatabase "#{Jobs.updatelicensereports.PackageDatabase}" -verbose true -sleep #{Jobs.updatelicensereports.Sleep}
 
 	echo "Finished #{Jobs.updatelicensereports.Title}"
 

--- a/src/Validation.Runner/Scripts/Validation.Runner.cmd
+++ b/src/Validation.Runner/Scripts/Validation.Runner.cmd
@@ -5,11 +5,9 @@ cd bin
 :Top
 	echo "Starting job - #{Jobs.validation.Title}"
 	
-	set NUGETJOBS_STORAGE_PRIMARY=#{Jobs.validation.DataStorageAccount}
-
 	title #{Jobs.validation.Title}
 
-	start /w Validation.Runner.exe -RunValidationTasks "#{Jobs.validation.RunValidationTasks}" -RequestValidationTasks "#{Jobs.validation.RequestValidationTasks}" -GalleryBaseAddress "#{Jobs.validation.GalleryBaseAddress}" -DataStorageAccount "#{Jobs.validation.DataStorageAccount}" -ContainerName "#{Jobs.validation.ContainerName}" -VcsValidatorServiceUrl "#{Jobs.validation.VcsValidatorServiceUrl}" -VcsValidatorCallbackUrl "#{Jobs.validation.VcsValidatorCallbackUrl}" -VcsValidatorAlias "#{Jobs.validation.VcsValidatorAlias}" -VcsPackageUrlTemplate "#{Jobs.validation.VcsPackageUrlTemplate}" -verbose true -interval #{Jobs.validation.Interval}
+	start /w Validation.Runner.exe -LogsAzureStorageConnectionString #{Jobs.validation.DataStorageAccount} -RunValidationTasks "#{Jobs.validation.RunValidationTasks}" -RequestValidationTasks "#{Jobs.validation.RequestValidationTasks}" -GalleryBaseAddress "#{Jobs.validation.GalleryBaseAddress}" -DataStorageAccount "#{Jobs.validation.DataStorageAccount}" -ContainerName "#{Jobs.validation.ContainerName}" -VcsValidatorServiceUrl "#{Jobs.validation.VcsValidatorServiceUrl}" -VcsValidatorCallbackUrl "#{Jobs.validation.VcsValidatorCallbackUrl}" -VcsValidatorAlias "#{Jobs.validation.VcsValidatorAlias}" -VcsPackageUrlTemplate "#{Jobs.validation.VcsPackageUrlTemplate}" -verbose true -interval #{Jobs.validation.Interval}
 
 	echo "Finished #{Jobs.validation.Title}"
 


### PR DESCRIPTION
1. Removed usage of EnvVar from NuGet.Jobs.Common - azure logging feature
2. Removed usage of EnvVar from Search.GenerateAuxiliaryData job

Next steps: remove usage of EnvVar  from other jobs and move them to use KeyVault