### PR TITLE
Limit the number of retries on failing package edits

### DIFF
--- a/src/HandlePackageEdits/HandlePackageEdits.Job.cs
+++ b/src/HandlePackageEdits/HandlePackageEdits.Job.cs
@@ -31,6 +31,7 @@ namespace HandlePackageEdits
 
         public const string DefaultSourceContainerName = "packages";
         public const string DefaultBackupContainerName = "package-backups";
+        public const int DefaultMaxRetryCount = 10;
 
         /// <summary>
         /// Gets or sets an Azure Storage Uri referring to a container to use as the source for package blobs
@@ -89,6 +90,8 @@ namespace HandlePackageEdits
 
             SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(SourceContainerName);
             BackupsContainer = Backups.CreateCloudBlobClient().GetContainerReference(BackupsContainerName);
+
+            MaxTryCount = DefaultMaxRetryCount;
             return true;
 
         }


### PR DESCRIPTION
Enable a feature that limits the number of retires on package edits.
@yishaigalatzer @maartenba @xavierdecoster 