### PR TITLE
Validation job - System.ArgumentException: Messages cannot be larger than 65536 bytes

### DIFF
--- a/src/Validation.Common/NuGetPackageQueueExtensions.cs
+++ b/src/Validation.Common/NuGetPackageQueueExtensions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace NuGet.Jobs.Validation.Common
+{
+    public static class NuGetPackageQueueExtensions
+    {
+        /// <summary>
+        /// Azure Queues have a max message length of 65536 bytes.
+        /// This method truncates potentially long fields so that a serialized representation
+        /// of the package falls within that boundary.
+        /// </summary>
+        /// <param name="package">The package to truncate</param>
+        /// <returns>Truncated package</returns>
+        public static NuGetPackage TruncateForAzureQueue(this NuGetPackage package)
+        {
+            // Clone the package
+            var clone = JsonConvert.DeserializeObject<NuGetPackage>(
+                JsonConvert.SerializeObject(package));
+
+            // Truncate long properties
+            clone.Description = Truncate(clone.Description, 4000);
+            clone.ReleaseNotes = Truncate(clone.ReleaseNotes, 4000);
+            clone.Summary = Truncate(clone.Summary, 4000);
+            clone.Tags = Truncate(clone.Tags, 4000);
+
+            return clone;
+        }
+
+        private static string Truncate(string value, int maxLength)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                return value.Substring(0, maxLength - 1);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Validation.Common/NuGetPackageQueueExtensions.cs
+++ b/src/Validation.Common/NuGetPackageQueueExtensions.cs
@@ -7,6 +7,8 @@ namespace NuGet.Jobs.Validation.Common
 {
     public static class NuGetPackageQueueExtensions
     {
+        private const int TruncatedPropertyMaxLength = 4000;
+
         /// <summary>
         /// Azure Queues have a max message length of 65536 bytes.
         /// This method truncates potentially long fields so that a serialized representation
@@ -21,10 +23,10 @@ namespace NuGet.Jobs.Validation.Common
                 JsonConvert.SerializeObject(package));
 
             // Truncate long properties
-            clone.Description = Truncate(clone.Description, 4000);
-            clone.ReleaseNotes = Truncate(clone.ReleaseNotes, 4000);
-            clone.Summary = Truncate(clone.Summary, 4000);
-            clone.Tags = Truncate(clone.Tags, 4000);
+            clone.Description = Truncate(clone.Description, TruncatedPropertyMaxLength);
+            clone.ReleaseNotes = Truncate(clone.ReleaseNotes, TruncatedPropertyMaxLength);
+            clone.Summary = Truncate(clone.Summary, TruncatedPropertyMaxLength);
+            clone.Tags = Truncate(clone.Tags, TruncatedPropertyMaxLength);
 
             return clone;
         }

--- a/src/Validation.Common/NuGetPackageQueueExtensions.cs
+++ b/src/Validation.Common/NuGetPackageQueueExtensions.cs
@@ -7,7 +7,7 @@ namespace NuGet.Jobs.Validation.Common
 {
     public static class NuGetPackageQueueExtensions
     {
-        private const int TruncatedPropertyMaxLength = 4000;
+        private const string Truncated = "(truncated)";
 
         /// <summary>
         /// Azure Queues have a max message length of 65536 bytes.
@@ -22,23 +22,13 @@ namespace NuGet.Jobs.Validation.Common
             var clone = JsonConvert.DeserializeObject<NuGetPackage>(
                 JsonConvert.SerializeObject(package));
 
-            // Truncate long properties
-            clone.Description = Truncate(clone.Description, TruncatedPropertyMaxLength);
-            clone.ReleaseNotes = Truncate(clone.ReleaseNotes, TruncatedPropertyMaxLength);
-            clone.Summary = Truncate(clone.Summary, TruncatedPropertyMaxLength);
-            clone.Tags = Truncate(clone.Tags, TruncatedPropertyMaxLength);
+            // Truncate long properties (https://github.com/NuGet/NuGet.Jobs/pull/54/files/228105a40129c076afc9b9e21551ffadef315f92#r70679869)
+            clone.Description = Truncated;
+            clone.ReleaseNotes = Truncated;
+            clone.Summary = Truncated;
+            clone.Tags = Truncated;
 
             return clone;
-        }
-
-        private static string Truncate(string value, int maxLength)
-        {
-            if (!string.IsNullOrEmpty(value))
-            {
-                return value.Substring(0, maxLength - 1);
-            }
-
-            return value;
         }
     }
 }

--- a/src/Validation.Common/PackageValidationQueue.cs
+++ b/src/Validation.Common/PackageValidationQueue.cs
@@ -40,6 +40,8 @@ namespace NuGet.Jobs.Validation.Common
 
         public async Task EnqueueAsync(string validatorName, PackageValidationMessage message)
         {
+            message.Package = message.Package.TruncateForAzureQueue();
+
             Trace.TraceInformation("Start enqueue validation {0} {1} - package {2} {3}...", validatorName, message.ValidationId, message.PackageId, message.PackageVersion);
 
             var queue = await GetQueueAsync(validatorName);

--- a/src/Validation.Common/Validation.Common.csproj
+++ b/src/Validation.Common/Validation.Common.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Extensions\CloudBlobExtensions.cs" />
     <Compile Include="INotificationService.cs" />
     <Compile Include="NotificationService.cs" />
+    <Compile Include="NuGetPackageQueueExtensions.cs" />
     <Compile Include="OData\NuGetV2Feed.cs" />
     <Compile Include="NuGetPackage.cs" />
     <Compile Include="OData\NuGetV2PackageComparer.cs" />


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGetGallery/issues/3120

* Decided to keep the data in our audits, but truncate it for processing
in the queue.
* Truncating nvarchar(max) columns

@skofman1 @xavierdecoster @scottbommarito 