### PR TITLE
Add rankings.v1.json report to the CreateAzureCdnWarehouseReports job

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
@@ -48,7 +48,7 @@ namespace NuGet.Jobs
                 {
                     if (!allArgsList[i].StartsWith("-"))
                     {
-                        throw new ArgumentException("Argument Name does not start with a hyphen ('-')");
+                        throw new ArgumentException($"Argument Name '{allArgsList[i]}' does not start with a hyphen ('-')");
                     }
 
                     var argName = allArgsList[i].Substring(1);

--- a/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
@@ -141,6 +141,15 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 ApplicationInsightsHelper.TrackReportProcessed(DownloadCountReport.ReportName);
                 stopwatch.Restart();
 
+                // build rankings.v1.json
+                var rankingsReport = new RankingsReport(_cloudStorageAccount, _statisticsContainerName, _statisticsDatabase, _galleryDatabase);
+                await rankingsReport.Run();
+
+                stopwatch.Stop();
+                ApplicationInsightsHelper.TrackMetric(RankingsReport.ReportName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
+                ApplicationInsightsHelper.TrackReportProcessed(RankingsReport.ReportName);
+                stopwatch.Restart();
+
                 // build stats-totals.json
                 var galleryTotalsReport = new GalleryTotalsReport(_cloudStorageAccount, _statisticsContainerName, _statisticsDatabase, _galleryDatabase);
                 await galleryTotalsReport.Run();
@@ -148,7 +157,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 stopwatch.Stop();
                 ApplicationInsightsHelper.TrackMetric(GalleryTotalsReport.ReportName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
                 ApplicationInsightsHelper.TrackReportProcessed(GalleryTotalsReport.ReportName);
-
+                //stopwatch.Restart();
 
                 // build tools.v1.json
                 var toolsReport = new DownloadsPerToolVersionReport(_cloudStorageAccount, _statisticsContainerName, _statisticsDatabase, _galleryDatabase);

--- a/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
@@ -157,7 +157,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 stopwatch.Stop();
                 ApplicationInsightsHelper.TrackMetric(GalleryTotalsReport.ReportName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
                 ApplicationInsightsHelper.TrackReportProcessed(GalleryTotalsReport.ReportName);
-                //stopwatch.Restart();
+                stopwatch.Restart();
 
                 // build tools.v1.json
                 var toolsReport = new DownloadsPerToolVersionReport(_cloudStorageAccount, _statisticsContainerName, _statisticsDatabase, _galleryDatabase);

--- a/src/Stats.CreateAzureCdnWarehouseReports/RankingsData.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/RankingsData.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Stats.CreateAzureCdnWarehouseReports
+{
+    public class RankingsData
+    {
+        [JsonProperty("PackageId")]
+        public string PackageId { get; set; }
+
+        [JsonProperty("Downloads")]
+        public long Downloads { get; set; }
+    }
+}

--- a/src/Stats.CreateAzureCdnWarehouseReports/RankingsReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/RankingsReport.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json;
+
+namespace Stats.CreateAzureCdnWarehouseReports
+{
+    public class RankingsReport
+        : ReportBase
+    {
+        private const int RankingCount = 250;
+        private const string RankingsQuery =
+                  @"SELECT  TOP(250)
+                            [Dimension_Package].[PackageId],
+                            SUM
+                            (
+                                CASE
+                                    WHEN LOWER([Dimension_Operation].[Operation]) = 'install'
+                                    THEN [Fact_Download].[DownloadCount]
+                                    ELSE (0.5 * [Fact_Download].[DownloadCount])
+                                END
+                            ) 'Downloads'
+                    FROM    [Fact_Download]
+
+                    INNER JOIN  [Dimension_Package]
+                    ON          [Dimension_Package].[Id] = [Fact_Download].[Dimension_Package_Id]
+
+                    INNER JOIN  [Dimension_Date]
+                    ON          [Dimension_Date].[Id] = [Fact_Download].[Dimension_Date_Id]
+
+                    INNER JOIN  [Dimension_Operation]
+                    ON          [Dimension_Operation].[Id] = [Fact_Download].[Dimension_Operation_Id]
+
+                    WHERE   [Dimension_Date].[Date] >= CONVERT(DATE, DATEADD(day, -42, GETUTCDATE()))
+                        AND [Dimension_Date].[Date] < CONVERT(DATE, GETUTCDATE())
+                        AND (
+                                LOWER([Dimension_Operation].[Operation]) = 'install'
+                                OR
+                                LOWER([Dimension_Operation].[Operation]) = 'update'
+                            )
+
+                    GROUP BY    [Dimension_Package].[PackageId]
+                    ORDER BY    Downloads DESC";
+        internal const string ReportName = "rankings.v1.json";
+
+        public RankingsReport(CloudStorageAccount cloudStorageAccount, string statisticsContainerName, SqlConnectionStringBuilder statisticsDatabase, SqlConnectionStringBuilder galleryDatabase)
+            : base(new [] { new StorageContainerTarget(cloudStorageAccount, statisticsContainerName) }, statisticsDatabase, galleryDatabase)
+        {
+        }
+
+        public async Task Run()
+        {
+            // gather download count data from statistics warehouse
+            IReadOnlyCollection<RankingsData> rankingsData;
+            Trace.TraceInformation("Gathering Rankings from {0}/{1}...", StatisticsDatabase.DataSource, StatisticsDatabase.InitialCatalog);
+            using (var connection = await StatisticsDatabase.ConnectTo())
+            using (var transaction = connection.BeginTransaction(IsolationLevel.Snapshot))
+            {
+                rankingsData = (await connection.QueryWithRetryAsync<RankingsData>(
+                    RankingsQuery, commandType: CommandType.Text, transaction: transaction)).ToList();
+            }
+            Trace.TraceInformation("Finished gathering Rankings from {0}/{1}.", StatisticsDatabase.DataSource, StatisticsDatabase.InitialCatalog);
+
+            // write to blob
+            var reportText = JsonConvert.SerializeObject(rankingsData);
+
+            Trace.TraceInformation(reportText);
+
+            foreach (var storageContainerTarget in Targets)
+            {
+                try
+                {
+                    var targetBlobContainer = await GetBlobContainer(storageContainerTarget);
+                    var blob = targetBlobContainer.GetBlockBlobReference(ReportName);
+                    Trace.TraceInformation("Writing report to {0}", blob.Uri.AbsoluteUri);
+                    blob.Properties.ContentType = "application/json";
+                    await blob.UploadTextAsync(reportText);
+                    Trace.TraceInformation("Wrote report to {0}", blob.Uri.AbsoluteUri);
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError("Error writing report to storage account {0}, container {1}. {2} {3}",
+                        storageContainerTarget.StorageAccount.Credentials.AccountName,
+                        storageContainerTarget.ContainerName, ex.Message, ex.StackTrace);
+                }
+            }
+        }
+    }
+}

--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
@@ -163,7 +163,9 @@
     <Compile Include="DownloadsPerToolVersionReport.cs" />
     <Compile Include="Formatting\JsonFormat.cs" />
     <Compile Include="Formatting\NuGetContractResolver.cs" />
+    <Compile Include="RankingsData.cs" />
     <Compile Include="GalleryTotalsData.cs" />
+    <Compile Include="RankingsReport.cs" />
     <Compile Include="GalleryTotalsReport.cs" />
     <Compile Include="Job.cs" />
     <Compile Include="Program.cs" />


### PR DESCRIPTION
Added a rankings.v1.json report to the CreateAzureCdnWarehouseReports job.

We may want to put the query in a stored procedure on the database so we can remove that long script from the file.

(Fixes https://github.com/NuGet/NuGetGallery/issues/3134)