### PR TITLE
HandlePackageEdits - Update NugetGallery.Core dependency

### DIFF
--- a/src/HandlePackageEdits/HandlePackageEdits.csproj
+++ b/src/HandlePackageEdits/HandlePackageEdits.csproj
@@ -124,8 +124,8 @@
       <HintPath>..\..\packages\NuGet.Versioning.3.5.0-beta-final\lib\net45\NuGet.Versioning.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGetGallery.Core, Version=3.0.2108.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGetGallery.Core.3.0.2108-r-master\lib\net452\NuGetGallery.Core.dll</HintPath>
+    <Reference Include="NuGetGallery.Core, Version=3.0.2118.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGetGallery.Core.3.0.2118-r-master\lib\net452\NuGetGallery.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/src/HandlePackageEdits/PackageEdit.cs
+++ b/src/HandlePackageEdits/PackageEdit.cs
@@ -48,17 +48,17 @@ namespace HandlePackageEdits
         {
             return new List<Action<ManifestEdit>>
             {
-                (m) => { m.Authors = string.IsNullOrEmpty(Authors) ? m.Authors : Authors; },
-                (m) => { m.Copyright = string.IsNullOrEmpty(Copyright) ? m.Copyright : Copyright; },
-                (m) => { m.Description = string.IsNullOrEmpty(Description) ? m.Description: Description; },
-                (m) => { m.IconUrl = string.IsNullOrEmpty(IconUrl) ? m.IconUrl : IconUrl; },
-                (m) => { m.LicenseUrl = string.IsNullOrEmpty(LicenseUrl) ? m.LicenseUrl : LicenseUrl; },
-                (m) => { m.ProjectUrl = string.IsNullOrEmpty(ProjectUrl) ? m.ProjectUrl : ProjectUrl; },
-                (m) => { m.ReleaseNotes = string.IsNullOrEmpty(ReleaseNotes) ? m.ReleaseNotes : ReleaseNotes; },
+                (m) => { m.Authors = Authors; },
+                (m) => { m.Copyright = Copyright; },
+                (m) => { m.Description = Description; },
+                (m) => { m.IconUrl = IconUrl; },
+                (m) => { m.LicenseUrl = LicenseUrl; },
+                (m) => { m.ProjectUrl = ProjectUrl; },
+                (m) => { m.ReleaseNotes = ReleaseNotes; },
                 (m) => { m.RequireLicenseAcceptance = RequiresLicenseAcceptance ?? m.RequireLicenseAcceptance; },
-                (m) => { m.Summary = string.IsNullOrEmpty(Summary) ? m.Summary : Summary; },
-                (m) => { m.Title = string.IsNullOrEmpty(Title) ? m.Title : Title; },
-                (m) => { m.Tags = string.IsNullOrEmpty(Tags) ? m.Tags : Tags; },
+                (m) => { m.Summary = Summary; },
+                (m) => { m.Title = Title; },
+                (m) => { m.Tags = Tags; },
             };
         }
     }

--- a/src/HandlePackageEdits/packages.config
+++ b/src/HandlePackageEdits/packages.config
@@ -20,7 +20,7 @@
   <package id="NuGet.Packaging.Core" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGet.Packaging.Core.Types" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.5.0-beta-final" targetFramework="net452" />
-  <package id="NuGetGallery.Core" version="3.0.2108-r-master" targetFramework="net452" />
+  <package id="NuGetGallery.Core" version="3.0.2118-r-master" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="2.0.0-rc2-1" targetFramework="net451" />
   <package id="Serilog" version="2.0.0-rc-563" targetFramework="net451" />
   <package id="Serilog.Enrichers.Environment" version="2.0.0-rc-708" targetFramework="net451" />


### PR DESCRIPTION
Job now uses the latest changes for NugetGallery.Core. I verified making edits to the package and it works like a charm. I can open the nupkg in Nuget Package Explorer and it shows just the relevant metadata tags in there. Also verified changes from VS 2015 Nuget Package management extension and the changes show up just fine.

/cc @skofman1 @ryuyu @maartenba @scottbommarito 