### PR TITLE
Key rotation logic for jobs in NuGet.Jobs

### DIFF
--- a/src/ArchivePackages/ArchivePackages.Job.cs
+++ b/src/ArchivePackages/ArchivePackages.Job.cs
@@ -68,11 +68,11 @@ namespace ArchivePackages
         {
             try
             {
-                PackageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
+                PackageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
-                Source = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.Source));
+                Source = CloudStorageAccount.Parse(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.Source));
 
-                PrimaryDestination = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.PrimaryDestination));
+                PrimaryDestination = CloudStorageAccount.Parse(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PrimaryDestination));
 
                 var secondaryDestinationCstr = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.SecondaryDestination);
                 SecondaryDestination = string.IsNullOrEmpty(secondaryDestinationCstr) ? null : CloudStorageAccount.Parse(secondaryDestinationCstr);

--- a/src/ArchivePackages/ArchivePackages.Job.cs
+++ b/src/ArchivePackages/ArchivePackages.Job.cs
@@ -13,6 +13,7 @@ using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Jobs;
+using NuGet.Services.KeyVault;
 
 namespace ArchivePackages
 {
@@ -63,32 +64,29 @@ namespace ArchivePackages
 
         public Job() : base(JobEventSource.Log) { }
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             try
             {
-                PackageDatabase = new SqlConnectionStringBuilder(
-                            JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase));
+                PackageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
 
-                Source = CloudStorageAccount.Parse(
-                            JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.Source));
+                Source = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.Source));
 
-                PrimaryDestination = CloudStorageAccount.Parse(
-                                        JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PrimaryDestination));
+                PrimaryDestination = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.PrimaryDestination));
 
-                var secondaryDestinationCstr = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.SecondaryDestination);
+                var secondaryDestinationCstr = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.SecondaryDestination);
                 SecondaryDestination = string.IsNullOrEmpty(secondaryDestinationCstr) ? null : CloudStorageAccount.Parse(secondaryDestinationCstr);
 
-                SourceContainerName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.SourceContainerName) ?? DefaultPackagesContainerName;
+                SourceContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.SourceContainerName) ?? DefaultPackagesContainerName;
 
-                DestinationContainerName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.DestinationContainerName) ?? DefaultPackagesArchiveContainerName;
+                DestinationContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DestinationContainerName) ?? DefaultPackagesArchiveContainerName;
 
                 SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(SourceContainerName);
                 PrimaryDestinationContainer = PrimaryDestination.CreateCloudBlobClient().GetContainerReference(DestinationContainerName);
                 SecondaryDestinationContainer = SecondaryDestination == null ? null :
                     SecondaryDestination.CreateCloudBlobClient().GetContainerReference(DestinationContainerName);
 
-                CursorBlobName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.CursorBlob) ?? DefaultCursorBlobName;
+                CursorBlobName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.CursorBlob) ?? DefaultCursorBlobName;
 
                 // Initialized successfully
                 return true;

--- a/src/ArchivePackages/ArchivePackages.csproj
+++ b/src/ArchivePackages/ArchivePackages.csproj
@@ -92,6 +92,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -118,6 +118,10 @@
       <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Scripts\nssm.exe" />

--- a/src/Gallery.CredentialExpiration/Job.cs
+++ b/src/Gallery.CredentialExpiration/Job.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using NuGet.Jobs;
 using NuGet.Services.Logging;
+using NuGet.Services.KeyVault;
 
 namespace Gallery.CredentialExpiration
 {
@@ -39,40 +40,40 @@ namespace Gallery.CredentialExpiration
         
         private ILogger _logger;
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             try
             {
-                var instrumentationKey = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 var loggerConfiguration = LoggingSetup.CreateDefaultLoggerConfiguration(ConsoleLogOnly);
                 var loggerFactory = LoggingSetup.CreateLoggerFactory(loggerConfiguration);
                 _logger = loggerFactory.CreateLogger<Job>();
 
-                _whatIf = JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, JobArgumentNames.WhatIf);
+                _whatIf = await jobArgsDictionary.GetOrDefault<bool>(JobArgumentNames.WhatIf);
 
-                var databaseConnectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.GalleryDatabase);
+                var databaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.GalleryDatabase);
                 _galleryDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
 
-                _galleryBrand = JobConfigurationManager.GetArgument(jobArgsDictionary, MyJobArgumentNames.GalleryBrand);
-                _galleryAccountUrl = JobConfigurationManager.GetArgument(jobArgsDictionary, MyJobArgumentNames.GalleryAccountUrl);
+                _galleryBrand = await jobArgsDictionary.Get<string>(MyJobArgumentNames.GalleryBrand);
+                _galleryAccountUrl = await jobArgsDictionary.Get<string>(MyJobArgumentNames.GalleryAccountUrl);
 
-                _mailFrom = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.MailFrom);
+                _mailFrom = await jobArgsDictionary.Get<string>(JobArgumentNames.MailFrom);
 
-                var smtpConnectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.SmtpUri);
+                var smtpConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.SmtpUri);
                 var smtpUri = new SmtpUri(new Uri(smtpConnectionString));
                 _smtpClient = CreateSmtpClient(smtpUri);
 
-                var temp = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, MyJobArgumentNames.WarnDaysBeforeExpiration);
-                if (temp.HasValue)
+                var temp = await jobArgsDictionary.GetOrDefault<int>(MyJobArgumentNames.WarnDaysBeforeExpiration);
+                if (temp != default(int))
                 {
-                    _warnDaysBeforeExpiration = temp.Value;
+                    _warnDaysBeforeExpiration = temp;
                 }
             }
             catch (Exception exception)
             {
-                _logger.LogCritical("Failed to initialize job! {Exception}", exception);
+                _logger?.LogCritical("Failed to initialize job! {Exception}", exception);
 
                 return false;
             }

--- a/src/Gallery.CredentialExpiration/Job.cs
+++ b/src/Gallery.CredentialExpiration/Job.cs
@@ -53,15 +53,15 @@ namespace Gallery.CredentialExpiration
 
                 _whatIf = await jobArgsDictionary.GetOrDefault<bool>(JobArgumentNames.WhatIf);
 
-                var databaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.GalleryDatabase);
+                var databaseConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.GalleryDatabase);
                 _galleryDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
 
-                _galleryBrand = await jobArgsDictionary.Get<string>(MyJobArgumentNames.GalleryBrand);
-                _galleryAccountUrl = await jobArgsDictionary.Get<string>(MyJobArgumentNames.GalleryAccountUrl);
+                _galleryBrand = await jobArgsDictionary.GetOrThrow<string>(MyJobArgumentNames.GalleryBrand);
+                _galleryAccountUrl = await jobArgsDictionary.GetOrThrow<string>(MyJobArgumentNames.GalleryAccountUrl);
 
-                _mailFrom = await jobArgsDictionary.Get<string>(JobArgumentNames.MailFrom);
+                _mailFrom = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.MailFrom);
 
-                var smtpConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.SmtpUri);
+                var smtpConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.SmtpUri);
                 var smtpUri = new SmtpUri(new Uri(smtpConnectionString));
                 _smtpClient = CreateSmtpClient(smtpUri);
 

--- a/src/HandlePackageEdits/HandlePackageEdits.Job.cs
+++ b/src/HandlePackageEdits/HandlePackageEdits.Job.cs
@@ -17,6 +17,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using NuGet.Jobs;
 using NuGet.Services.Logging;
 using NuGetGallery.Packaging;
+using NuGet.Services.KeyVault;
 
 namespace HandlePackageEdits
 {
@@ -63,31 +64,28 @@ namespace HandlePackageEdits
         protected long MaxManifestSize { get; set; }
         private ILogger _logger;
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             try
             {
-                var instrumentationKey = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 var loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = loggerFactory.CreateLogger<Job>();
 
-                var retrievedMaxManifestSize = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.MaxManifestSize);
-                MaxManifestSize = retrievedMaxManifestSize == null
+                var retrievedMaxManifestSize = await jobArgsDictionary.GetOrDefault<int>(JobArgumentNames.MaxManifestSize);
+                MaxManifestSize = retrievedMaxManifestSize == default(int)
                     ? DefaultMaxAllowedManifestBytes
                     : Convert.ToInt64(retrievedMaxManifestSize);
 
-                PackageDatabase = new SqlConnectionStringBuilder(
-                            JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase));
+                PackageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
 
-                Source = CloudStorageAccount.Parse(
-                                           JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.SourceStorage));
-                Backups = CloudStorageAccount.Parse(
-                                           JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.BackupStorage));
+                Source = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.SourceStorage));
+                Backups = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.BackupStorage));
 
-                SourceContainerName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.SourceContainerName) ?? DefaultSourceContainerName;
-                BackupsContainerName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.BackupContainerName) ?? DefaultBackupContainerName;
+                SourceContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.SourceContainerName) ?? DefaultSourceContainerName;
+                BackupsContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.BackupContainerName) ?? DefaultBackupContainerName;
 
                 SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(SourceContainerName);
                 BackupsContainer = Backups.CreateCloudBlobClient().GetContainerReference(BackupsContainerName);

--- a/src/HandlePackageEdits/HandlePackageEdits.Job.cs
+++ b/src/HandlePackageEdits/HandlePackageEdits.Job.cs
@@ -79,10 +79,10 @@ namespace HandlePackageEdits
                     ? DefaultMaxAllowedManifestBytes
                     : Convert.ToInt64(retrievedMaxManifestSize);
 
-                PackageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
+                PackageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
-                Source = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.SourceStorage));
-                Backups = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.BackupStorage));
+                Source = CloudStorageAccount.Parse(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.SourceStorage));
+                Backups = CloudStorageAccount.Parse(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.BackupStorage));
 
                 SourceContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.SourceContainerName) ?? DefaultSourceContainerName;
                 BackupsContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.BackupContainerName) ?? DefaultBackupContainerName;

--- a/src/HandlePackageEdits/HandlePackageEdits.csproj
+++ b/src/HandlePackageEdits/HandlePackageEdits.csproj
@@ -191,6 +191,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Services.KeyVault;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
@@ -47,7 +48,7 @@ namespace NuGet.Jobs
             }
         }
 
-        public abstract bool Init(IDictionary<string, string> jobArgsDictionary);
+        public abstract Task<bool> Init(IArgumentsDictionary jobArgsDictionary);
 
         public abstract Task<bool> Run();
     }

--- a/src/NuGet.Services.KeyVault/IArgumentsDictionary.cs
+++ b/src/NuGet.Services.KeyVault/IArgumentsDictionary.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.KeyVault
+{
+    public interface IArgumentsDictionary
+    {
+        Task<T> Get<T>(string key);
+
+        Task<T> GetOrDefault<T>(string key);
+
+        void Set(string key, string value);
+
+        bool ContainsKey(string key);
+
+        bool Contains(KeyValuePair<string, string> item);
+
+        void Add(KeyValuePair<string, string> item);
+
+        void Add(string key, string value);
+
+        bool Remove(KeyValuePair<string, string> item);
+
+        bool Remove(string key);
+
+        void ClearCache();
+    }
+}

--- a/src/NuGet.Services.KeyVault/IArgumentsDictionary.cs
+++ b/src/NuGet.Services.KeyVault/IArgumentsDictionary.cs
@@ -6,11 +6,30 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.KeyVault
 {
+    /// <summary>
+    /// A dictionary of configuration or command line arguments.
+    /// </summary>
     public interface IArgumentsDictionary
     {
-        Task<T> Get<T>(string key);
+        /// <summary>
+        /// Gets an argument from the dictionary.
+        /// </summary>
+        /// <typeparam name="T">Converts the argument from a string into this type.</typeparam>
+        /// <param name="key">The key mapping to the desired argument.</param>
+        /// <returns>The argument mapped to by the key converted to type T.</returns>
+        /// <exception cref="KeyNotFoundException">Thrown when the key is not mapped to an argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the argument mapped to by the key is null or empty.</exception>
+        /// <exception cref="NotSupportedException">Thrown when the argument mapped to by the key cannot be converted into an object of type T.</exception>
+        Task<T> GetOrThrow<T>(string key);
 
-        Task<T> GetOrDefault<T>(string key);
+        /// <summary>
+        /// Gets an argument from the dictionary.
+        /// </summary>
+        /// <typeparam name="T">Converts the argument from a string into this type.</typeparam>
+        /// <param name="key">The key mapping to the desired argument.</param>
+        /// <param name="defaultValue">The value returned if there is an issue getting the argument from the cache.</param>
+        /// <returns>The argument mapped to by the key converted to type T or defaultValue if the argument could not be acquired and converted.</returns>
+        Task<T> GetOrDefault<T>(string key, T defaultValue = default(T));
 
         void Set(string key, string value);
 
@@ -27,7 +46,5 @@ namespace NuGet.Services.KeyVault
         bool Remove(string key);
 
         void Clear();
-
-        void ClearCache();
     }
 }

--- a/src/NuGet.Services.KeyVault/IArgumentsDictionary.cs
+++ b/src/NuGet.Services.KeyVault/IArgumentsDictionary.cs
@@ -26,6 +26,8 @@ namespace NuGet.Services.KeyVault
 
         bool Remove(string key);
 
+        void Clear();
+
         void ClearCache();
     }
 }

--- a/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
+++ b/src/NuGet.Services.KeyVault/NuGet.Services.KeyVault.csproj
@@ -92,10 +92,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EmptySecretReader.cs" />
+    <Compile Include="IArgumentsDictionary.cs" />
     <Compile Include="ISecretInjector.cs" />
     <Compile Include="ISecretReader.cs" />
     <Compile Include="KeyVaultConfiguration.cs" />
     <Compile Include="KeyVaultReader.cs" />
+    <Compile Include="RefreshingArgumentsDictionary.cs" />
     <Compile Include="SecretInjector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/NuGet.Services.KeyVault/RefreshingArgumentsDictionary.cs
+++ b/src/NuGet.Services.KeyVault/RefreshingArgumentsDictionary.cs
@@ -1,0 +1,136 @@
+﻿using NuGet.Services.KeyVault;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs
+{
+    public class RefreshingArgumentsDictionary : IArgumentsDictionary
+    {
+        public const string RefreshArgsIntervalSec = "RefreshArgsIntervalSec";
+        private const int DefaultRefreshIntervalSec = 86400; // 1 day (24 hrs)
+
+        private int _refreshArgsIntervalSec;
+        private ISecretInjector _secretInjector;
+
+        private Dictionary<string, string> _unprocessedArguments;
+        private Dictionary<string, Tuple<string, DateTime>> _injectedArguments;
+
+        public RefreshingArgumentsDictionary(ISecretInjector secretInjector, Dictionary<string, string> unprocessedArguments)
+        {
+            _secretInjector = secretInjector;
+            _unprocessedArguments = unprocessedArguments;
+            _injectedArguments = new Dictionary<string, Tuple<string, DateTime>>();
+
+            var refreshArgsIntervalSec = DefaultRefreshIntervalSec;
+            if (_unprocessedArguments.ContainsKey(RefreshArgsIntervalSec))
+            {
+                int parsedRefreshInterval;
+                if (int.TryParse(_unprocessedArguments[RefreshArgsIntervalSec], out parsedRefreshInterval)) refreshArgsIntervalSec = parsedRefreshInterval;
+            }
+            _refreshArgsIntervalSec = refreshArgsIntervalSec;
+        }
+
+        private async Task<string> Get(string key)
+        {
+            if (!_unprocessedArguments.ContainsKey(key)) throw new KeyNotFoundException();
+
+            if (!_injectedArguments.ContainsKey(key) || DateTime.UtcNow.Subtract(_injectedArguments[key].Item2).TotalSeconds >= _refreshArgsIntervalSec)
+            {
+                await processArgument(key);
+            }
+
+            var argumentValue = _injectedArguments[key].Item1;
+            if (string.IsNullOrEmpty(argumentValue)) throw new ArgumentNullException();
+
+            return argumentValue;
+        }
+
+        public async Task<T> Get<T>(string key)
+        {
+            string argumentString = await Get(key);
+            var converter = TypeDescriptor.GetConverter(typeof(T));
+
+            if (converter != null && !string.IsNullOrEmpty(argumentString)) return (T)converter.ConvertFromString(argumentString);
+            return default(T);
+        }
+
+        public async Task<T> GetOrDefault<T>(string key)
+        {
+            try
+            {
+                return await Get<T>(key);
+            }
+            catch (ArgumentNullException)
+            {
+                // in arguments but null
+            }
+            catch (KeyNotFoundException)
+            {
+                // not in arguments
+            }
+            catch (NotSupportedException)
+            {
+                // could not convert
+            }
+            return default(T);
+        }
+
+        public void Set(string key, string value)
+        {
+            _injectedArguments[key] = new Tuple<string, DateTime>(value, DateTime.UtcNow);
+        }
+
+        private async Task<string> processArgument(string key)
+        {
+            var processedArgument = await _secretInjector.InjectAsync(_unprocessedArguments[key]);
+            Set(key, processedArgument);
+            return processedArgument;
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _unprocessedArguments.ContainsKey(key);
+        }
+
+        public bool Contains(KeyValuePair<string, string> item)
+        {
+            return ContainsKey(item.Key) && Get(item.Key).Equals(item.Value);
+        }
+
+        public void Add(KeyValuePair<string, string> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        public void Add(string key, string value)
+        {
+            _unprocessedArguments.Add(key, value);
+        }
+
+        public bool Remove(KeyValuePair<string, string> item)
+        {
+            return Contains(item) && Remove(item.Key);
+        }
+
+        public bool Remove(string key)
+        {
+            return _unprocessedArguments.Remove(key) && _injectedArguments.Remove(key);
+        }
+
+        public void Clear()
+        {
+            _unprocessedArguments.Clear();
+            _injectedArguments.Clear();
+        }
+
+        public void ClearCache()
+        {
+            _injectedArguments.Clear();
+        }
+    }
+}

--- a/src/NuGet.Services.KeyVault/SecretInjector.cs
+++ b/src/NuGet.Services.KeyVault/SecretInjector.cs
@@ -36,6 +36,8 @@ namespace NuGet.Services.KeyVault
 
         public async Task<string> InjectAsync(string input)
         {
+            if (input == null) return input;
+
             var output = new StringBuilder(input);
             var secretNames = GetSecretNames(input);
 

--- a/src/Search.GenerateAuxiliaryData/Job.cs
+++ b/src/Search.GenerateAuxiliaryData/Job.cs
@@ -38,11 +38,11 @@ namespace Search.GenerateAuxiliaryData
 
         public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
-            var packageDatabaseConnString = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase)).ToString();
+            var packageDatabaseConnString = new SqlConnectionStringBuilder(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase)).ToString();
 
-            var statisticsDatabaseConnString = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase)).ToString();
+            var statisticsDatabaseConnString = new SqlConnectionStringBuilder(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase)).ToString();
 
-            var destination = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.PrimaryDestination));
+            var destination = CloudStorageAccount.Parse(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PrimaryDestination));
 
             var destinationContainerName =
                             await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DestinationContainerName)

--- a/src/Search.GenerateAuxiliaryData/Job.cs
+++ b/src/Search.GenerateAuxiliaryData/Job.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using NuGet.Jobs;
+using NuGet.Services.KeyVault;
 
 namespace Search.GenerateAuxiliaryData
 {
@@ -35,19 +36,16 @@ namespace Search.GenerateAuxiliaryData
         private List<SqlExporter> _sqlExportScriptsToRun;
         private CloudBlobContainer _destContainer;
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
-            var packageDatabaseConnString = new SqlConnectionStringBuilder(
-                JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase)).ToString();
+            var packageDatabaseConnString = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase)).ToString();
 
-            var statisticsDatabaseConnString = new SqlConnectionStringBuilder(
-                JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.StatisticsDatabase)).ToString();
+            var statisticsDatabaseConnString = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase)).ToString();
 
-            var destination = CloudStorageAccount.Parse(
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PrimaryDestination));
+            var destination = CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.PrimaryDestination));
 
             var destinationContainerName =
-                            JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.DestinationContainerName)
+                            await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DestinationContainerName)
                             ?? _defaultContainerName;
 
             _destContainer = destination.CreateCloudBlobClient().GetContainerReference(destinationContainerName);

--- a/src/Search.GenerateAuxiliaryData/Search.GenerateAuxiliaryData.csproj
+++ b/src/Search.GenerateAuxiliaryData/Search.GenerateAuxiliaryData.csproj
@@ -86,6 +86,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="SqlScripts\Owners.sql" />

--- a/src/Search.RebuildIndex/Search.RebuildIndex.Job.cs
+++ b/src/Search.RebuildIndex/Search.RebuildIndex.Job.cs
@@ -9,6 +9,7 @@ using NuGet.Indexing;
 using Lucene.Net.Store;
 using System.IO;
 using NuGet.Jobs;
+using NuGet.Services.KeyVault;
 
 namespace Search.RebuildIndex
 {
@@ -36,26 +37,22 @@ namespace Search.RebuildIndex
         private string DataContainerName { get; set; }
         private string LocalIndexFolder { get; set; }
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             PackageDatabase =
-            new SqlConnectionStringBuilder(
-                JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase));
+            new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
 
             DataStorageAccount =
-                CloudStorageAccount.Parse(
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.DataStorageAccount));
+                CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.DataStorageAccount));
 
-            DataContainerName =
-                JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.DataContainerName);
+            DataContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DataContainerName);
 
             if (string.IsNullOrEmpty(DataContainerName))
             {
                 DataContainerName = DefaultDataContainerName;
             }
 
-            LocalIndexFolder =
-                JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.LocalIndexFolder);
+            LocalIndexFolder = await jobArgsDictionary.Get<string>(JobArgumentNames.LocalIndexFolder);
 
             // Initialized successfully, return true
             return true;

--- a/src/Search.RebuildIndex/Search.RebuildIndex.Job.cs
+++ b/src/Search.RebuildIndex/Search.RebuildIndex.Job.cs
@@ -40,10 +40,10 @@ namespace Search.RebuildIndex
         public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             PackageDatabase =
-            new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
+            new SqlConnectionStringBuilder(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
             DataStorageAccount =
-                CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.DataStorageAccount));
+                CloudStorageAccount.Parse(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount));
 
             DataContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DataContainerName);
 
@@ -52,7 +52,7 @@ namespace Search.RebuildIndex
                 DataContainerName = DefaultDataContainerName;
             }
 
-            LocalIndexFolder = await jobArgsDictionary.Get<string>(JobArgumentNames.LocalIndexFolder);
+            LocalIndexFolder = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.LocalIndexFolder);
 
             // Initialized successfully, return true
             return true;

--- a/src/Search.RebuildIndex/Search.RebuildIndex.csproj
+++ b/src/Search.RebuildIndex/Search.RebuildIndex.csproj
@@ -162,6 +162,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Eula.htm" />

--- a/src/Search.UpdateIndex/Search.UpdateIndex.Job.cs
+++ b/src/Search.UpdateIndex/Search.UpdateIndex.Job.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage;
 using NuGet.Indexing;
 using NuGet.Jobs;
+using NuGet.Services.KeyVault;
 
 namespace Search.UpdateIndex
 {
@@ -34,26 +35,22 @@ namespace Search.UpdateIndex
         /// </summary>
         private string ContainerName { get; set; }
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             PackageDatabase =
-            new SqlConnectionStringBuilder(
-                JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase));
+            new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
 
             DataStorageAccount =
-                CloudStorageAccount.Parse(
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.DataStorageAccount));
+                CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.DataStorageAccount));
 
-            DataContainerName =
-                JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.DataContainerName);
+            DataContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DataContainerName);
 
             if (string.IsNullOrEmpty(DataContainerName))
             {
                 DataContainerName = DefaultDataContainerName;
             }
 
-            ContainerName =
-               JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.ContainerName);
+            ContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.ContainerName);
 
             // Initialized successfully, return true
             return true;

--- a/src/Search.UpdateIndex/Search.UpdateIndex.Job.cs
+++ b/src/Search.UpdateIndex/Search.UpdateIndex.Job.cs
@@ -38,10 +38,10 @@ namespace Search.UpdateIndex
         public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             PackageDatabase =
-            new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
+            new SqlConnectionStringBuilder(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
             DataStorageAccount =
-                CloudStorageAccount.Parse(await jobArgsDictionary.Get<string>(JobArgumentNames.DataStorageAccount));
+                CloudStorageAccount.Parse(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount));
 
             DataContainerName = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DataContainerName);
 

--- a/src/Search.UpdateIndex/Search.UpdateIndex.csproj
+++ b/src/Search.UpdateIndex/Search.UpdateIndex.csproj
@@ -179,6 +179,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
@@ -65,10 +65,10 @@ namespace Stats.AggregateCdnDownloadsInGallery
                 _loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var statisticsDatabaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase);
+                var statisticsDatabaseConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
                 _statisticsDatabase = new SqlConnectionStringBuilder(statisticsDatabaseConnectionString);
 
-                var destinationDatabaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.DestinationDatabase);
+                var destinationDatabaseConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DestinationDatabase);
                 _destinationDatabase = new SqlConnectionStringBuilder(destinationDatabaseConnectionString);
             }
             catch (Exception exception)

--- a/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
@@ -153,6 +153,10 @@
       <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -45,13 +45,13 @@ namespace Stats.CollectAzureCdnLogs
                 _loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var ftpLogFolder = await jobArgsDictionary.Get<string>(JobArgumentNames.FtpSourceUri);
-                var azureCdnPlatform = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnPlatform);
-                var cloudStorageAccount = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
-                _cloudStorageContainerName = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageContainerName);
-                _azureCdnAccountNumber = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnAccountNumber);
-                _ftpUsername = await jobArgsDictionary.Get<string>(JobArgumentNames.FtpSourceUsername);
-                _ftpPassword = await jobArgsDictionary.Get<string>(JobArgumentNames.FtpSourcePassword);
+                var ftpLogFolder = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.FtpSourceUri);
+                var azureCdnPlatform = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnPlatform);
+                var cloudStorageAccount = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
+                _cloudStorageContainerName = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageContainerName);
+                _azureCdnAccountNumber = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnAccountNumber);
+                _ftpUsername = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.FtpSourceUsername);
+                _ftpPassword = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.FtpSourcePassword);
 
                 _ftpServerUri = ValidateFtpUri(ftpLogFolder);
                 _azureCdnPlatform = ValidateAzureCdnPlatform(azureCdnPlatform);

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -17,6 +17,7 @@ using NuGet.Services.Logging;
 using Stats.AzureCdnLogs.Common;
 using Stats.CollectAzureCdnLogs.Blob;
 using Stats.CollectAzureCdnLogs.Ftp;
+using NuGet.Services.KeyVault;
 
 namespace Stats.CollectAzureCdnLogs
 {
@@ -34,23 +35,23 @@ namespace Stats.CollectAzureCdnLogs
         private ILoggerFactory _loggerFactory;
         private ILogger _logger;
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             try
             {
-                var instrumentationKey = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 _loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var ftpLogFolder = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.FtpSourceUri);
-                var azureCdnPlatform = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnPlatform);
-                var cloudStorageAccount = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnCloudStorageAccount);
-                _cloudStorageContainerName = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnCloudStorageContainerName);
-                _azureCdnAccountNumber = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.AzureCdnAccountNumber);
-                _ftpUsername = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.FtpSourceUsername);
-                _ftpPassword = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.FtpSourcePassword);
+                var ftpLogFolder = await jobArgsDictionary.Get<string>(JobArgumentNames.FtpSourceUri);
+                var azureCdnPlatform = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnPlatform);
+                var cloudStorageAccount = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
+                _cloudStorageContainerName = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageContainerName);
+                _azureCdnAccountNumber = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnAccountNumber);
+                _ftpUsername = await jobArgsDictionary.Get<string>(JobArgumentNames.FtpSourceUsername);
+                _ftpPassword = await jobArgsDictionary.Get<string>(JobArgumentNames.FtpSourcePassword);
 
                 _ftpServerUri = ValidateFtpUri(ftpLogFolder);
                 _azureCdnPlatform = ValidateAzureCdnPlatform(azureCdnPlatform);
@@ -58,7 +59,7 @@ namespace Stats.CollectAzureCdnLogs
             }
             catch (Exception ex)
             {
-                _logger.LogCritical("Job failed to initialize! {Exception}", ex);
+                _logger?.LogCritical("Job failed to initialize! {Exception}", ex);
 
                 return false;
             }

--- a/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj
+++ b/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj
@@ -150,6 +150,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Stats.AzureCdnLogs.Common\Stats.AzureCdnLogs.Common.csproj">
       <Project>{f72c31a7-424d-48c6-924c-ebfd4be0918b}</Project>
       <Name>Stats.AzureCdnLogs.Common</Name>

--- a/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
@@ -53,19 +53,19 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 var loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = loggerFactory.CreateLogger<Job>();
 
-                var cloudStorageAccountConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
-                var statisticsDatabaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase);
-                var galleryDatabaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.SourceDatabase);
-                var dataStorageAccountConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.DataStorageAccount);
+                var cloudStorageAccountConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
+                var statisticsDatabaseConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
+                var galleryDatabaseConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.SourceDatabase);
+                var dataStorageAccountConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount);
 
                 _cloudStorageAccount = ValidateAzureCloudStorageAccount(cloudStorageAccountConnectionString, JobArgumentNames.AzureCdnCloudStorageAccount);
-                _statisticsContainerName = ValidateAzureContainerName(await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageContainerName), JobArgumentNames.AzureCdnCloudStorageContainerName);
+                _statisticsContainerName = ValidateAzureContainerName(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageContainerName), JobArgumentNames.AzureCdnCloudStorageContainerName);
                 _dataStorageAccount = ValidateAzureCloudStorageAccount(dataStorageAccountConnectionString, JobArgumentNames.DataStorageAccount);
                 _reportName = ValidateReportName(await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.WarehouseReportName));
                 _statisticsDatabase = new SqlConnectionStringBuilder(statisticsDatabaseConnectionString);
                 _galleryDatabase = new SqlConnectionStringBuilder(galleryDatabaseConnectionString);
 
-                var containerNames = (await jobArgsDictionary.Get<string>(JobArgumentNames.DataContainerName))
+                var containerNames = (await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataContainerName))
                         .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var containerName in containerNames)
                 {

--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
@@ -185,6 +185,10 @@
       <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Stats.AzureCdnLogs.Common\Stats.AzureCdnLogs.Common.csproj">
       <Project>{F72C31A7-424D-48C6-924C-EBFD4BE0918B}</Project>
       <Name>Stats.AzureCdnLogs.Common</Name>

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -42,15 +42,15 @@ namespace Stats.ImportAzureCdnStatistics
                 _loggerFactory = LoggingSetup.CreateLoggerFactory(loggerConfiguration);
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var azureCdnPlatform = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnPlatform);
-                var cloudStorageAccountConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
-                var databaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase);
+                var azureCdnPlatform = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnPlatform);
+                var cloudStorageAccountConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
+                var databaseConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
                 _cloudStorageAccount = ValidateAzureCloudStorageAccount(cloudStorageAccountConnectionString);
 
                 _targetDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
-                _azureCdnAccountNumber = await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnAccountNumber);
+                _azureCdnAccountNumber = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnAccountNumber);
                 _azureCdnPlatform = ValidateAzureCdnPlatform(azureCdnPlatform);
-                _cloudStorageContainerName = ValidateAzureContainerName(await jobArgsDictionary.Get<string>(JobArgumentNames.AzureCdnCloudStorageContainerName));
+                _cloudStorageContainerName = ValidateAzureContainerName(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageContainerName));
 
                 _aggregatesOnly = await jobArgsDictionary.GetOrDefault<bool>(JobArgumentNames.AggregatesOnly);
 

--- a/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
+++ b/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
@@ -181,6 +181,10 @@
       <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Stats.AzureCdnLogs.Common\Stats.AzureCdnLogs.Common.csproj">
       <Project>{F72C31A7-424D-48C6-924C-EBFD4BE0918B}</Project>
       <Name>Stats.AzureCdnLogs.Common</Name>

--- a/src/Stats.RefreshClientDimension/Program.cs
+++ b/src/Stats.RefreshClientDimension/Program.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Jobs;
 using Stats.ImportAzureCdnStatistics;
+using NuGet.Services.KeyVault;
 
 namespace Stats.RefreshClientDimension
 {
@@ -20,9 +21,14 @@ namespace Stats.RefreshClientDimension
 
         public static void Main(string[] args)
         {
+            MainAsync(args).Wait();
+        }
+
+        public static async Task MainAsync(string[] args)
+        {
             Trace.TraceInformation("Started...");
             var argsDictionary = ParseArgsDictionary(args);
-            if (Init(argsDictionary))
+            if (await Init(argsDictionary))
             {
                 Run().Wait();
             }
@@ -138,15 +144,15 @@ namespace Stats.RefreshClientDimension
             return results;
         }
 
-        private static bool Init(IDictionary<string, string> argsDictionary)
+        private static async Task<bool> Init(IArgumentsDictionary argsDictionary)
         {
             try
             {
-                var databaseConnectionString = JobConfigurationManager.GetArgument(argsDictionary, JobArgumentNames.StatisticsDatabase);
+                var databaseConnectionString = await argsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase);
                 _targetDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
 
-                _targetClientName = JobConfigurationManager.TryGetArgument(argsDictionary, "TargetClientName");
-                _userAgentFilter = JobConfigurationManager.TryGetArgument(argsDictionary, "UserAgentFilter");
+                _targetClientName = await argsDictionary.GetOrDefault<string>("TargetClientName");
+                _userAgentFilter = await argsDictionary.GetOrDefault<string>("UserAgentFilter");
 
                 return true;
             }
@@ -157,7 +163,7 @@ namespace Stats.RefreshClientDimension
             return false;
         }
 
-        private static IDictionary<string, string> ParseArgsDictionary(string[] commandLineArgs)
+        private static IArgumentsDictionary ParseArgsDictionary(string[] commandLineArgs)
         {
             if (commandLineArgs.Length > 0 && string.Equals(commandLineArgs[0], "-dbg", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Stats.RefreshClientDimension/Program.cs
+++ b/src/Stats.RefreshClientDimension/Program.cs
@@ -148,7 +148,7 @@ namespace Stats.RefreshClientDimension
         {
             try
             {
-                var databaseConnectionString = await argsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase);
+                var databaseConnectionString = await argsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
                 _targetDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
 
                 _targetClientName = await argsDictionary.GetOrDefault<string>("TargetClientName");

--- a/src/Stats.RefreshClientDimension/Stats.RefreshClientDimension.csproj
+++ b/src/Stats.RefreshClientDimension/Stats.RefreshClientDimension.csproj
@@ -83,6 +83,10 @@
       <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/Stats.RollUpDownloadFacts/Job.cs
+++ b/src/Stats.RollUpDownloadFacts/Job.cs
@@ -37,7 +37,7 @@ namespace Stats.RollUpDownloadFacts
                 _loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var databaseConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.StatisticsDatabase);
+                var databaseConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
                 _targetDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
 
                 var minAgeInDays = await jobArgsDictionary.GetOrDefault<int>("MinAgeInDays");

--- a/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
+++ b/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
@@ -101,6 +101,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Stats.AzureCdnLogs.Common\Stats.AzureCdnLogs.Common.csproj">
       <Project>{f72c31a7-424d-48c6-924c-ebfd4be0918b}</Project>
       <Name>Stats.AzureCdnLogs.Common</Name>

--- a/src/Tests.Logger/Tests.AzureJobTraceListener.csproj
+++ b/src/Tests.Logger/Tests.AzureJobTraceListener.csproj
@@ -53,6 +53,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Tests.Logger/Tests.Logger.Job.cs
+++ b/src/Tests.Logger/Tests.Logger.Job.cs
@@ -32,13 +32,13 @@ namespace Tests.AzureJobTraceListener
 
         public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
-            JobScenario = await jobArgsDictionary.Get<int>(ScenarioArgumentName);
+            JobScenario = await jobArgsDictionary.GetOrDefault<int>(ScenarioArgumentName);
             if (JobScenario == default(int))
             {
                 throw new ArgumentException("Argument '"+ ScenarioArgumentName +"' is mandatory." + HelpMessage);
             }
 
-            LogCount = await jobArgsDictionary.Get<int>(LogCountArgumentName);
+            LogCount = await jobArgsDictionary.GetOrDefault<int>(LogCountArgumentName);
 
             return await Task.FromResult(true);
         }

--- a/src/Tests.Logger/Tests.Logger.Job.cs
+++ b/src/Tests.Logger/Tests.Logger.Job.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Jobs;
+using NuGet.Services.KeyVault;
 
 namespace Tests.AzureJobTraceListener
 {
@@ -25,20 +26,21 @@ namespace Tests.AzureJobTraceListener
                         6 for job that calls Trace.Close from multiple threads,
                         7 for job that calls Job.JobTraceListener.Close from multiple threads";
 
-        private int? JobScenario { get; set; }
+        private int JobScenario { get; set; }
 
         private int? LogCount { get; set; }
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
-            JobScenario = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, ScenarioArgumentName);
-            if(JobScenario == null)
+            JobScenario = await jobArgsDictionary.Get<int>(ScenarioArgumentName);
+            if (JobScenario == default(int))
             {
                 throw new ArgumentException("Argument '"+ ScenarioArgumentName +"' is mandatory." + HelpMessage);
             }
 
-            LogCount = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, LogCountArgumentName);
+            LogCount = await jobArgsDictionary.Get<int>(LogCountArgumentName);
 
-            return true;
+            return await Task.FromResult(true);
         }
 
         public async override Task<bool> Run()

--- a/src/UpdateLicenseReports/UpdateLicenseReports.Job.cs
+++ b/src/UpdateLicenseReports/UpdateLicenseReports.Job.cs
@@ -11,6 +11,7 @@ using Dapper;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
 using NuGet.Jobs;
+using NuGet.Services.KeyVault;
 
 namespace UpdateLicenseReports
 {
@@ -54,12 +55,11 @@ namespace UpdateLicenseReports
             return report;
         }
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
-            _packageDatabase = new SqlConnectionStringBuilder(
-                        JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase));
+            _packageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
 
-            var retryCountString = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.RetryCount);
+            var retryCountString = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.RetryCount);
             if (string.IsNullOrEmpty(retryCountString))
             {
                 _retryCount = _defaultRetryCount;
@@ -69,9 +69,9 @@ namespace UpdateLicenseReports
                 _retryCount = Convert.ToInt32(retryCountString);
             }
 
-            _licenseReportService = new Uri(JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.LicenseReportService));
-            _licenseReportUser = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.LicenseReportUser);
-            _licenseReportPassword = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.LicenseReportPassword);
+            _licenseReportService = new Uri(await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.LicenseReportService));
+            _licenseReportUser = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.LicenseReportUser);
+            _licenseReportPassword = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.LicenseReportPassword);
 
             // Build credentials
             if (!string.IsNullOrEmpty(_licenseReportUser))

--- a/src/UpdateLicenseReports/UpdateLicenseReports.Job.cs
+++ b/src/UpdateLicenseReports/UpdateLicenseReports.Job.cs
@@ -57,7 +57,7 @@ namespace UpdateLicenseReports
 
         public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
-            _packageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.Get<string>(JobArgumentNames.PackageDatabase));
+            _packageDatabase = new SqlConnectionStringBuilder(await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
             var retryCountString = await jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.RetryCount);
             if (string.IsNullOrEmpty(retryCountString))

--- a/src/UpdateLicenseReports/UpdateLicenseReports.csproj
+++ b/src/UpdateLicenseReports/UpdateLicenseReports.csproj
@@ -91,6 +91,10 @@
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -33,15 +33,15 @@ namespace NuGet.Jobs.Validation.Runner
             try
             {
                 // Configure job
-                _galleryBaseAddress = await jobArgsDictionary.Get<string>(JobArgumentNames.GalleryBaseAddress);
+                _galleryBaseAddress = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.GalleryBaseAddress);
 
-                var storageConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.DataStorageAccount);
+                var storageConnectionString = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount);
                 _cloudStorageAccount = CreateCloudStorageAccount(JobArgumentNames.DataStorageAccount, storageConnectionString);
 
-                _containerName = await jobArgsDictionary.Get<string>(JobArgumentNames.ContainerName);
+                _containerName = await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.ContainerName);
 
-                _runValidationTasks = (await jobArgsDictionary.Get<string>(JobArgumentNames.RunValidationTasks)).Split(';');
-                _requestValidationTasks = (await jobArgsDictionary.Get<string>(JobArgumentNames.RequestValidationTasks)).Split(';');
+                _runValidationTasks = (await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.RunValidationTasks)).Split(';');
+                _requestValidationTasks = (await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.RequestValidationTasks)).Split(';');
 
                 // Add validators
                 if (_runValidationTasks.Contains(UnzipValidator.ValidatorName))
@@ -51,10 +51,10 @@ namespace NuGet.Jobs.Validation.Runner
                 if (_runValidationTasks.Contains(VcsValidator.ValidatorName))
                 {
                     _validators.Add(new VcsValidator(
-                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsValidatorServiceUrl),
-                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsValidatorCallbackUrl),
-                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsValidatorAlias),
-                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsPackageUrlTemplate)));
+                        await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsValidatorServiceUrl),
+                        await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsValidatorCallbackUrl),
+                        await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsValidatorAlias),
+                        await jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsPackageUrlTemplate)));
                 }
 
                 return true;

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -13,6 +13,7 @@ using NuGet.Jobs.Validation.Common.OData;
 using NuGet.Jobs.Validation.Common.Validators;
 using NuGet.Jobs.Validation.Common.Validators.Unzip;
 using NuGet.Jobs.Validation.Common.Validators.Vcs;
+using NuGet.Services.KeyVault;
 
 namespace NuGet.Jobs.Validation.Runner
 {
@@ -27,20 +28,20 @@ namespace NuGet.Jobs.Validation.Runner
         private string[] _runValidationTasks;
         private string[] _requestValidationTasks;
 
-        public override bool Init(IDictionary<string, string> jobArgsDictionary)
+        public override async Task<bool> Init(IArgumentsDictionary jobArgsDictionary)
         {
             try
             {
                 // Configure job
-                _galleryBaseAddress = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.GalleryBaseAddress);
+                _galleryBaseAddress = await jobArgsDictionary.Get<string>(JobArgumentNames.GalleryBaseAddress);
 
-                var storageConnectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.DataStorageAccount);
+                var storageConnectionString = await jobArgsDictionary.Get<string>(JobArgumentNames.DataStorageAccount);
                 _cloudStorageAccount = CreateCloudStorageAccount(JobArgumentNames.DataStorageAccount, storageConnectionString);
 
-                _containerName = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.ContainerName);
+                _containerName = await jobArgsDictionary.Get<string>(JobArgumentNames.ContainerName);
 
-                _runValidationTasks = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.RunValidationTasks).Split(';');
-                _requestValidationTasks = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.RequestValidationTasks).Split(';');
+                _runValidationTasks = (await jobArgsDictionary.Get<string>(JobArgumentNames.RunValidationTasks)).Split(';');
+                _requestValidationTasks = (await jobArgsDictionary.Get<string>(JobArgumentNames.RequestValidationTasks)).Split(';');
 
                 // Add validators
                 if (_runValidationTasks.Contains(UnzipValidator.ValidatorName))
@@ -50,10 +51,10 @@ namespace NuGet.Jobs.Validation.Runner
                 if (_runValidationTasks.Contains(VcsValidator.ValidatorName))
                 {
                     _validators.Add(new VcsValidator(
-                        JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorServiceUrl),
-                        JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorCallbackUrl),
-                        JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorAlias),
-                        JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsPackageUrlTemplate)));
+                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsValidatorServiceUrl),
+                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsValidatorCallbackUrl),
+                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsValidatorAlias),
+                        await jobArgsDictionary.Get<string>(JobArgumentNames.VcsPackageUrlTemplate)));
                 }
 
                 return true;

--- a/src/Validation.Runner/Validation.Runner.csproj
+++ b/src/Validation.Runner/Validation.Runner.csproj
@@ -89,6 +89,10 @@
     <None Include="Validation.Runner.nuspec" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Validation.Common\Validation.Common.csproj">
       <Project>{2539DDF3-0CC5-4A03-B5F9-39B47744A7BD}</Project>
       <Name>Validation.Common</Name>

--- a/tests/NuGet.Services.KeyVaultUnitTests/NuGet.Services.KeyVaultUnitTests.csproj
+++ b/tests/NuGet.Services.KeyVaultUnitTests/NuGet.Services.KeyVaultUnitTests.csproj
@@ -77,12 +77,17 @@
   <ItemGroup>
     <Compile Include="KeyVaultReaderFormatterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RefreshingArgumentsDictionaryTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
+      <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
+      <Name>NuGet.Jobs.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
       <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
       <Name>NuGet.Services.KeyVault</Name>

--- a/tests/NuGet.Services.KeyVaultUnitTests/RefreshingArgumentsDictionaryTests.cs
+++ b/tests/NuGet.Services.KeyVaultUnitTests/RefreshingArgumentsDictionaryTests.cs
@@ -7,6 +7,7 @@ using NuGet.Services.KeyVault;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,8 +39,8 @@ namespace NuGet.Services.KeyVaultUnitTests
             var refreshingArgumentsDictionary = new RefreshingArgumentsDictionary(mockSecretInjector.Object, unprocessedDictionary);
 
             // Act
-            string value1 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
-            value1 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
+            string value1 = await refreshingArgumentsDictionary.GetOrThrow<string>(nameOfSecret);
+            value1 = await refreshingArgumentsDictionary.GetOrThrow<string>(nameOfSecret);
 
             // Assert
             mockSecretInjector.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Once);
@@ -50,8 +51,8 @@ namespace NuGet.Services.KeyVaultUnitTests
             mockSecretInjector.Setup(x => x.InjectAsync(It.IsAny<string>())).Returns(Task.FromResult(secondSecret));
 
             // Act 2
-            string value2 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
-            value2 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
+            string value2 = await refreshingArgumentsDictionary.GetOrThrow<string>(nameOfSecret);
+            value2 = await refreshingArgumentsDictionary.GetOrThrow<string>(nameOfSecret);
 
             // Assert 2
             mockSecretInjector.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Exactly(2));
@@ -64,10 +65,10 @@ namespace NuGet.Services.KeyVaultUnitTests
             var fakeKey = "not a real key";
             IArgumentsDictionary dummy = CreateDummyArgumentsDictionary();
 
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<string>(fakeKey));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<int>(fakeKey));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<bool>(fakeKey));
-            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<DateTime>(fakeKey));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.GetOrThrow<string>(fakeKey));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.GetOrThrow<int>(fakeKey));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.GetOrThrow<bool>(fakeKey));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.GetOrThrow<DateTime>(fakeKey));
 
             Assert.Equal(default(string), await dummy.GetOrDefault<string>(fakeKey));
             Assert.Equal(default(int), await dummy.GetOrDefault<int>(fakeKey));
@@ -75,36 +76,51 @@ namespace NuGet.Services.KeyVaultUnitTests
             Assert.Equal(default(DateTime), await dummy.GetOrDefault<DateTime>(fakeKey));
         }
 
-        [Fact]
-        public async void HandlesNullOrEmptyArgument()
+        [Theory]
+        [InlineData(typeof(string))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(bool))]
+        [InlineData(typeof(DateTime))]
+        public async void HandlesNullOrEmptyArgument(Type type)
         {
+            // Arrange
             IArgumentsDictionary dummy = CreateDummyArgumentsDictionary();
+
+            var getOrThrowMI = typeof(IArgumentsDictionary).GetMethod("GetOrThrow").MakeGenericMethod(type);
+            var getOrDefaultMI = typeof(IArgumentsDictionary).GetMethod("GetOrDefault").MakeGenericMethod(type);
+
+            Type[] taskTypeArgs = { type };
+            var taskType = typeof(Task<>).MakeGenericType(taskTypeArgs);
+
+            var defaultOfType = GetDefault(type);
 
             var nullKey = "this key has a null value";
             dummy.Add(nullKey, null);
-
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<string>(nullKey));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<int>(nullKey));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<bool>(nullKey));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<DateTime>(nullKey));
-
-            Assert.Equal(default(string), await dummy.GetOrDefault<string>(nullKey));
-            Assert.Equal(default(int), await dummy.GetOrDefault<int>(nullKey));
-            Assert.Equal(default(bool), await dummy.GetOrDefault<bool>(nullKey));
-            Assert.Equal(default(DateTime), await dummy.GetOrDefault<DateTime>(nullKey));
+            object[] nullKeyThrowArgs = { nullKey };
+            object[] nullKeyDefaultArgs = { nullKey, defaultOfType };
 
             var emptyKey = "this key has an empty value";
             dummy.Add(emptyKey, "");
+            object[] emptyKeyThrowArgs = { emptyKey };
+            object[] emptyKeyDefaultArgs = { emptyKey, defaultOfType };
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<string>(emptyKey));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<int>(emptyKey));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<bool>(emptyKey));
-            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<DateTime>(emptyKey));
+            // Act and Assert
 
-            Assert.Equal(default(string), await dummy.GetOrDefault<string>(emptyKey));
-            Assert.Equal(default(int), await dummy.GetOrDefault<int>(emptyKey));
-            Assert.Equal(default(bool), await dummy.GetOrDefault<bool>(emptyKey));
-            Assert.Equal(default(DateTime), await dummy.GetOrDefault<DateTime>(emptyKey));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => (Task)getOrThrowMI.Invoke(dummy, nullKeyThrowArgs));
+            Assert.Equal(defaultOfType, await (dynamic)getOrDefaultMI.Invoke(dummy, nullKeyDefaultArgs));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => (Task)getOrThrowMI.Invoke(dummy, emptyKeyThrowArgs));
+            Assert.Equal(defaultOfType, await (dynamic)getOrDefaultMI.Invoke(dummy, emptyKeyDefaultArgs));
+        }
+
+        public dynamic GetDefault(Type t)
+        {
+            return this.GetType().GetMethod("GetDefaultGeneric").MakeGenericMethod(t).Invoke(this, null);
+        }
+
+        public T GetDefaultGeneric<T>()
+        {
+            return default(T);
         }
 
         private IArgumentsDictionary CreateDummyArgumentsDictionary()

--- a/tests/NuGet.Services.KeyVaultUnitTests/RefreshingArgumentsDictionaryTests.cs
+++ b/tests/NuGet.Services.KeyVaultUnitTests/RefreshingArgumentsDictionaryTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Jobs;
+using NuGet.Services.KeyVault;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Services.KeyVaultUnitTests
+{
+    public class RefreshingArgumentsDictionaryTests
+    {
+        [Fact]
+        public async void RefreshesArgumentsAfterIntervalPasses()
+        {
+            // Arrange
+            const string nameOfSecret = "hello i'm a secret";
+            const string firstSecret = "secret1";
+            const string secondSecret = "secret2";
+            const int refreshIntervalSec = 1;
+            const int delayBeforeRefreshingMs = (refreshIntervalSec + 1) * 1000;
+
+            var mockSecretInjector = new Mock<ISecretInjector>();
+            mockSecretInjector.Setup(x => x.InjectAsync(It.IsAny<string>())).Returns(Task.FromResult(firstSecret));
+
+            var unprocessedDictionary = new Dictionary<string, string>()
+            {
+                {RefreshingArgumentsDictionary.RefreshArgsIntervalSec, refreshIntervalSec.ToString()},
+                {nameOfSecret, "fetch me from KeyVault pls"}
+            };
+
+            var refreshingArgumentsDictionary = new RefreshingArgumentsDictionary(mockSecretInjector.Object, unprocessedDictionary);
+
+            // Act
+            string value1 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
+            value1 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
+
+            // Assert
+            mockSecretInjector.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Once);
+            Assert.Equal(firstSecret, value1);
+
+            // Arrange 2
+            Thread.Sleep(delayBeforeRefreshingMs);
+            mockSecretInjector.Setup(x => x.InjectAsync(It.IsAny<string>())).Returns(Task.FromResult(secondSecret));
+
+            // Act 2
+            string value2 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
+            value2 = await refreshingArgumentsDictionary.Get<string>(nameOfSecret);
+
+            // Assert 2
+            mockSecretInjector.Verify(x => x.InjectAsync(It.IsAny<string>()), Times.Exactly(2));
+            Assert.Equal(secondSecret, value2);
+        }
+
+        [Fact]
+        public async void HandlesKeyNotFound()
+        {
+            var fakeKey = "not a real key";
+            IArgumentsDictionary dummy = CreateDummyArgumentsDictionary();
+
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<string>(fakeKey));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<int>(fakeKey));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<bool>(fakeKey));
+            await Assert.ThrowsAsync<KeyNotFoundException>(() => dummy.Get<DateTime>(fakeKey));
+
+            Assert.Equal(default(string), await dummy.GetOrDefault<string>(fakeKey));
+            Assert.Equal(default(int), await dummy.GetOrDefault<int>(fakeKey));
+            Assert.Equal(default(bool), await dummy.GetOrDefault<bool>(fakeKey));
+            Assert.Equal(default(DateTime), await dummy.GetOrDefault<DateTime>(fakeKey));
+        }
+
+        [Fact]
+        public async void HandlesNullOrEmptyArgument()
+        {
+            IArgumentsDictionary dummy = CreateDummyArgumentsDictionary();
+
+            var nullKey = "this key has a null value";
+            dummy.Add(nullKey, null);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<string>(nullKey));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<int>(nullKey));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<bool>(nullKey));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<DateTime>(nullKey));
+
+            Assert.Equal(default(string), await dummy.GetOrDefault<string>(nullKey));
+            Assert.Equal(default(int), await dummy.GetOrDefault<int>(nullKey));
+            Assert.Equal(default(bool), await dummy.GetOrDefault<bool>(nullKey));
+            Assert.Equal(default(DateTime), await dummy.GetOrDefault<DateTime>(nullKey));
+
+            var emptyKey = "this key has an empty value";
+            dummy.Add(emptyKey, "");
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<string>(emptyKey));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<int>(emptyKey));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<bool>(emptyKey));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => dummy.Get<DateTime>(emptyKey));
+
+            Assert.Equal(default(string), await dummy.GetOrDefault<string>(emptyKey));
+            Assert.Equal(default(int), await dummy.GetOrDefault<int>(emptyKey));
+            Assert.Equal(default(bool), await dummy.GetOrDefault<bool>(emptyKey));
+            Assert.Equal(default(DateTime), await dummy.GetOrDefault<DateTime>(emptyKey));
+        }
+
+        private IArgumentsDictionary CreateDummyArgumentsDictionary()
+        {
+            return new RefreshingArgumentsDictionary(new SecretReaderFactory().CreateSecretInjector(new EmptySecretReader()), new Dictionary<string, string>());
+        }
+    }
+}

--- a/tests/Tests.Stats.CollectAzureCdnLogs/JobTests.cs
+++ b/tests/Tests.Stats.CollectAzureCdnLogs/JobTests.cs
@@ -4,38 +4,40 @@
 using System.Collections.Generic;
 using Stats.CollectAzureCdnLogs;
 using Xunit;
+using NuGet.Jobs;
+using NuGet.Services.KeyVault;
 
 namespace Tests.Stats.CollectAzureCdnLogs
 {
     public class JobTests
     {
         [Fact]
-        public void InitFailsWhenNoArguments()
+        public async void InitFailsWhenNoArguments()
         {
             var job = new Job();
-            var initResult = job.Init(null);
+            var initResult = await job.Init(null);
 
             Assert.False(initResult);
         }
 
         [Fact]
-        public void InitFailsWhenEmptyArguments()
+        public async void InitFailsWhenEmptyArguments()
         {
-            var jobArgsDictionary = new Dictionary<string, string>();
+            var jobArgsDictionary = CreateEmptyJobArgsDictionary();
 
             var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
+            var initResult = await job.Init(jobArgsDictionary);
 
             Assert.False(initResult);
         }
 
         [Fact]
-        public void InitSucceedsWhenValidArguments()
+        public async void InitSucceedsWhenValidArguments()
         {
             var jobArgsDictionary = CreateValidJobArgsDictionary();
 
             var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
+            var initResult = await job.Init(jobArgsDictionary);
 
             Assert.True(initResult);
         }
@@ -46,13 +48,13 @@ namespace Tests.Stats.CollectAzureCdnLogs
         [InlineData("http://localhost")]
         [InlineData("ftps://someserver/folder")]
         [InlineData("ftp://")]
-        public void InitFailsForInvalidFtpServerUri(string serverUri)
+        public async void InitFailsForInvalidFtpServerUri(string serverUri)
         {
             var jobArgsDictionary = CreateValidJobArgsDictionary();
-            jobArgsDictionary["FtpSourceUri"] = serverUri;
+            jobArgsDictionary.Set("FtpSourceUri", serverUri);
 
             var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
+            var initResult = await job.Init(jobArgsDictionary);
 
             Assert.False(initResult);
         }
@@ -60,13 +62,13 @@ namespace Tests.Stats.CollectAzureCdnLogs
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void InitFailsForMissingFtpUsername(string username)
+        public async void InitFailsForMissingFtpUsername(string username)
         {
             var jobArgsDictionary = CreateValidJobArgsDictionary();
-            jobArgsDictionary["FtpSourceUsername"] = username;
+            jobArgsDictionary.Set("FtpSourceUsername", username);
 
             var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
+            var initResult = await job.Init(jobArgsDictionary);
 
             Assert.False(initResult);
         }
@@ -74,42 +76,13 @@ namespace Tests.Stats.CollectAzureCdnLogs
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void InitFailsForMissingFtpPassword(string password)
+        public async void InitFailsForMissingFtpPassword(string password)
         {
             var jobArgsDictionary = CreateValidJobArgsDictionary();
-            jobArgsDictionary["FtpSourcePassword"] = password;
+            jobArgsDictionary.Set("FtpSourcePassword", password);
 
             var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
-
-            Assert.False(initResult);
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        [InlineData("bla")]
-        public void InitFailsForMissingOrInvalidAzureCdnPlatform(string platform)
-        {
-            var jobArgsDictionary = CreateValidJobArgsDictionary();
-            jobArgsDictionary["AzureCdnPlatform"] = platform;
-
-            var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
-
-            Assert.False(initResult);
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        public void InitFailsForMissingAzureCdnAccountNumber(string accountNumber)
-        {
-            var jobArgsDictionary = CreateValidJobArgsDictionary();
-            jobArgsDictionary["AzureCdnAccountNumber"] = accountNumber;
-
-            var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
+            var initResult = await job.Init(jobArgsDictionary);
 
             Assert.False(initResult);
         }
@@ -118,13 +91,13 @@ namespace Tests.Stats.CollectAzureCdnLogs
         [InlineData("")]
         [InlineData(null)]
         [InlineData("bla")]
-        public void InitFailsForMissingOrInvalidAzureCdnCloudStorageAccount(string cloudStorageAccount)
+        public async void InitFailsForMissingOrInvalidAzureCdnPlatform(string platform)
         {
             var jobArgsDictionary = CreateValidJobArgsDictionary();
-            jobArgsDictionary["AzureCdnCloudStorageAccount"] = cloudStorageAccount;
+            jobArgsDictionary.Set("AzureCdnPlatform", platform);
 
             var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
+            var initResult = await job.Init(jobArgsDictionary);
 
             Assert.False(initResult);
         }
@@ -132,18 +105,52 @@ namespace Tests.Stats.CollectAzureCdnLogs
         [Theory]
         [InlineData("")]
         [InlineData(null)]
-        public void InitFailsForMissingAzureCdnCloudStorageContainerName(string containerName)
+        public async void InitFailsForMissingAzureCdnAccountNumber(string accountNumber)
         {
             var jobArgsDictionary = CreateValidJobArgsDictionary();
-            jobArgsDictionary["AzureCdnCloudStorageContainerName"] = containerName;
+            jobArgsDictionary.Set("AzureCdnAccountNumber", accountNumber);
 
             var job = new Job();
-            var initResult = job.Init(jobArgsDictionary);
+            var initResult = await job.Init(jobArgsDictionary);
 
             Assert.False(initResult);
         }
 
-        private static Dictionary<string, string> CreateValidJobArgsDictionary()
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("bla")]
+        public async void InitFailsForMissingOrInvalidAzureCdnCloudStorageAccount(string cloudStorageAccount)
+        {
+            var jobArgsDictionary = CreateValidJobArgsDictionary();
+            jobArgsDictionary.Set("AzureCdnCloudStorageAccount", cloudStorageAccount);
+
+            var job = new Job();
+            var initResult = await job.Init(jobArgsDictionary);
+
+            Assert.False(initResult);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public async void InitFailsForMissingAzureCdnCloudStorageContainerName(string containerName)
+        {
+            var jobArgsDictionary = CreateValidJobArgsDictionary();
+            jobArgsDictionary.Set("AzureCdnCloudStorageContainerName", containerName);
+
+            var job = new Job();
+            var initResult = await job.Init(jobArgsDictionary);
+
+            Assert.False(initResult);
+        }
+
+        private static IArgumentsDictionary CreateEmptyJobArgsDictionary()
+        {
+            return CreateArgsDictionaryFromDictionary(new Dictionary<string, string>());
+        }
+
+        private static IArgumentsDictionary CreateValidJobArgsDictionary()
         {
             var jobArgsDictionary = new Dictionary<string, string>();
             jobArgsDictionary.Add("FtpSourceUri", "ftp://someserver/logFolder");
@@ -154,7 +161,12 @@ namespace Tests.Stats.CollectAzureCdnLogs
             jobArgsDictionary.Add("AzureCdnCloudStorageAccount", "UseDevelopmentStorage=true;");
             jobArgsDictionary.Add("AzureCdnCloudStorageContainerName", "cdnLogs");
 
-            return jobArgsDictionary;
+            return CreateArgsDictionaryFromDictionary(jobArgsDictionary);
+        }
+
+        private static IArgumentsDictionary CreateArgsDictionaryFromDictionary(Dictionary<string, string> dictionary)
+        {
+            return new RefreshingArgumentsDictionary(new SecretReaderFactory().CreateSecretInjector(new EmptySecretReader()), dictionary);
         }
     }
 }

--- a/tests/Tests.Stats.CollectAzureCdnLogs/Tests.Stats.CollectAzureCdnLogs.csproj
+++ b/tests/Tests.Stats.CollectAzureCdnLogs/Tests.Stats.CollectAzureCdnLogs.csproj
@@ -143,6 +143,10 @@
       <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\NuGet.Services.KeyVault\NuGet.Services.KeyVault.csproj">
+      <Project>{C87D0EF1-54AA-4B0B-89DE-CFF2DC941D11}</Project>
+      <Name>NuGet.Services.KeyVault</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Stats.AzureCdnLogs.Common\Stats.AzureCdnLogs.Common.csproj">
       <Project>{f72c31a7-424d-48c6-924c-ebfd4be0918b}</Project>
       <Name>Stats.AzureCdnLogs.Common</Name>


### PR DESCRIPTION
Replaced the ordinary `Dictionary<string, string>` that stored config arguments with a `RefreshingArgumentsDictionary` which refreshes at an interval that can be passed in through the command line.

Additionally, job initialization is now done with every run of the job loop, so that each job gets the updated config values when they are refreshed.

I have tested that this works with Search.GenerateAuxilliaryData and looked at the rest of the jobs to make sure there is no caching of the `RefreshingArgumentsDictionary` by jobs (which would lead to key rotation bugs), but given the sheer number of jobs affected by this change I was unsure how to methodically test them.