### PR TITLE
Fix tests broken by #72

### DIFF
--- a/src/ArchivePackages/ArchivePackages.Job.cs
+++ b/src/ArchivePackages/ArchivePackages.Job.cs
@@ -68,24 +68,24 @@ namespace ArchivePackages
         {
             try
             {
-                PackageDatabase = new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.PackageDatabase]);
+                PackageDatabase = new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
-                Source = CloudStorageAccount.Parse(jobArgsDictionary[JobArgumentNames.Source]);
+                Source = CloudStorageAccount.Parse(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.Source));
 
-                PrimaryDestination = CloudStorageAccount.Parse(jobArgsDictionary[JobArgumentNames.PrimaryDestination]);
+                PrimaryDestination = CloudStorageAccount.Parse(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PrimaryDestination));
 
-                var secondaryDestinationCstr = jobArgsDictionary.GetOrNull(JobArgumentNames.SecondaryDestination);
+                var secondaryDestinationCstr = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.SecondaryDestination);
                 SecondaryDestination = string.IsNullOrEmpty(secondaryDestinationCstr) ? null : CloudStorageAccount.Parse(secondaryDestinationCstr);
 
-                SourceContainerName = jobArgsDictionary.GetOrNull(JobArgumentNames.SourceContainerName) ?? DefaultPackagesContainerName;
+                SourceContainerName = jobArgsDictionary.GetOrDefault(JobArgumentNames.SourceContainerName, DefaultPackagesContainerName);
 
-                DestinationContainerName = jobArgsDictionary.GetOrNull(JobArgumentNames.DestinationContainerName) ?? DefaultPackagesArchiveContainerName;
+                DestinationContainerName = jobArgsDictionary.GetOrDefault(JobArgumentNames.DestinationContainerName, DefaultPackagesArchiveContainerName);
 
                 SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(SourceContainerName);
                 PrimaryDestinationContainer = PrimaryDestination.CreateCloudBlobClient().GetContainerReference(DestinationContainerName);
                 SecondaryDestinationContainer = SecondaryDestination?.CreateCloudBlobClient().GetContainerReference(DestinationContainerName);
 
-                CursorBlobName = jobArgsDictionary.GetOrNull(JobArgumentNames.CursorBlob) ?? DefaultCursorBlobName;
+                CursorBlobName = jobArgsDictionary.GetOrDefault(JobArgumentNames.CursorBlob, DefaultCursorBlobName);
 
                 // Initialized successfully
                 return true;

--- a/src/ArchivePackages/ArchivePackages.csproj
+++ b/src/ArchivePackages/ArchivePackages.csproj
@@ -135,16 +135,17 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/src/ArchivePackages/ArchivePackages.csproj
+++ b/src/ArchivePackages/ArchivePackages.csproj
@@ -135,12 +135,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/ArchivePackages/packages.config
+++ b/src/ArchivePackages/packages.config
@@ -24,9 +24,10 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/src/ArchivePackages/packages.config
+++ b/src/ArchivePackages/packages.config
@@ -24,8 +24,8 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -121,12 +121,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -121,12 +121,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">
@@ -163,6 +163,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Gallery.CredentialExpiration/packages.config
+++ b/src/Gallery.CredentialExpiration/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
@@ -35,6 +35,7 @@
   <package id="System.Collections" version="4.0.11" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/Gallery.CredentialExpiration/packages.config
+++ b/src/Gallery.CredentialExpiration/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />

--- a/src/HandlePackageEdits/HandlePackageEdits.Job.cs
+++ b/src/HandlePackageEdits/HandlePackageEdits.Job.cs
@@ -68,24 +68,21 @@ namespace HandlePackageEdits
         {
             try
             {
-                var instrumentationKey = jobArgsDictionary.GetOrNull(JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 var loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = loggerFactory.CreateLogger<Job>();
 
-                var retrievedMaxManifestSize = jobArgsDictionary.GetOrNull<int>(JobArgumentNames.MaxManifestSize);
-                MaxManifestSize = retrievedMaxManifestSize == null
-                    ? DefaultMaxAllowedManifestBytes
-                    : Convert.ToInt64(retrievedMaxManifestSize);
+                MaxManifestSize = jobArgsDictionary.GetOrDefault(JobArgumentNames.MaxManifestSize, DefaultMaxAllowedManifestBytes);
 
-                PackageDatabase = new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.PackageDatabase]);
+                PackageDatabase = new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
-                Source = CloudStorageAccount.Parse(jobArgsDictionary[JobArgumentNames.SourceStorage]);
-                Backups = CloudStorageAccount.Parse(jobArgsDictionary[JobArgumentNames.BackupStorage]);
+                Source = CloudStorageAccount.Parse(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.SourceStorage));
+                Backups = CloudStorageAccount.Parse(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.BackupStorage));
 
-                SourceContainerName = jobArgsDictionary.GetOrNull(JobArgumentNames.SourceContainerName) ?? DefaultSourceContainerName;
-                BackupsContainerName = jobArgsDictionary.GetOrNull(JobArgumentNames.BackupContainerName) ?? DefaultBackupContainerName;
+                SourceContainerName = jobArgsDictionary.GetOrDefault(JobArgumentNames.SourceContainerName, DefaultSourceContainerName);
+                BackupsContainerName = jobArgsDictionary.GetOrDefault(JobArgumentNames.BackupContainerName, DefaultBackupContainerName);
 
                 SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(SourceContainerName);
                 BackupsContainer = Backups.CreateCloudBlobClient().GetContainerReference(BackupsContainerName);

--- a/src/HandlePackageEdits/HandlePackageEdits.csproj
+++ b/src/HandlePackageEdits/HandlePackageEdits.csproj
@@ -186,12 +186,12 @@
       <HintPath>..\..\packages\NuGet.Packaging.Core.Types.3.5.0-beta-final\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/HandlePackageEdits/HandlePackageEdits.csproj
+++ b/src/HandlePackageEdits/HandlePackageEdits.csproj
@@ -186,12 +186,12 @@
       <HintPath>..\..\packages\NuGet.Packaging.Core.Types.3.5.0-beta-final\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/HandlePackageEdits/packages.config
+++ b/src/HandlePackageEdits/packages.config
@@ -36,8 +36,8 @@
   <package id="NuGet.Packaging" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGet.Packaging.Core" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGet.Packaging.Core.Types" version="3.5.0-beta-final" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGetGallery.Core" version="3.0.2118-r-master" targetFramework="net452" />

--- a/src/HandlePackageEdits/packages.config
+++ b/src/HandlePackageEdits/packages.config
@@ -36,8 +36,8 @@
   <package id="NuGet.Packaging" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGet.Packaging.Core" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGet.Packaging.Core.Types" version="3.5.0-beta-final" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="NuGet.Versioning" version="3.5.0-beta-final" targetFramework="net452" />
   <package id="NuGetGallery.Core" version="3.0.2118-r-master" targetFramework="net452" />
@@ -51,6 +51,7 @@
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -41,7 +41,7 @@ namespace NuGet.Jobs
         public const string DestinationContainerName = "DestinationContainerName";
         public const string CursorBlob = "CursorBlob";
 
-        //Arguments specific to CreateWarehouseReports job
+        // Arguments specific to CreateWarehouseReports job
         public const string WarehouseReportName = "WarehouseReportName";
 
         // Arguments specific to Search* jobs
@@ -51,36 +51,40 @@ namespace NuGet.Jobs
         public const string IndexFolder = "IndexFolder";
         public const string ContainerName = "ContainerName";
 
-        //Other
+        // Other
         public const string CommandTimeOut = "CommandTimeOut";
         public const string RetryCount = "RetryCount";
         public const string MaxManifestSize = "MaxManifestSize";
         public const string OutputDirectory = "OutputDirectory";
 
-        //Arguments specific to HandlePackageEdits
+        // Arguments specific to HandlePackageEdits
         public const string SourceStorage = "SourceStorage";
         public const string BackupStorage = "BackupStorage";
         public const string BackupContainerName = "BackupContainerName";
 
-        //Arguments specific to UpdateLicenseReports
+        // Arguments specific to UpdateLicenseReports
         public const string LicenseReportService = "LicenseReportService";
         public const string LicenseReportUser = "LicenseReportUser";
         public const string LicenseReportPassword = "LicenseReportPassword";
 
-        //Arguments specific to CollectAzureCdnLogs
+        // Arguments specific to CollectAzureCdnLogs
         public const string FtpSourceUri = "FtpSourceUri";
         public const string FtpSourceUsername = "FtpSourceUsername";
         public const string FtpSourcePassword = "FtpSourcePassword";
         public const string AzureCdnAccountNumber = "AzureCdnAccountNumber";
         public const string AzureCdnPlatform = "AzureCdnPlatform";
 
-        //Arguments shared by CollectAzureCdnLogs and ParseAzureCdnLogs
+        // Arguments shared by CollectAzureCdnLogs and ParseAzureCdnLogs
         public const string AzureCdnCloudStorageAccount = "AzureCdnCloudStorageAccount";
         public const string AzureCdnCloudStorageContainerName = "AzureCdnCloudStorageContainerName";
 
-        //Arguments specific to ParseAzureCdnLogs
+        // Arguments specific to ParseAzureCdnLogs
         public const string AzureCdnCloudStorageTableName = "AzureCdnCloudStorageTableName";
         public const string AggregatesOnly = "AggregatesOnly";
+
+        // Arguments specific to RefreshClientDimension
+        public const string TargetClientName = "TargetClientName";
+        public const string UserAgentFilter = "UserAgentFilter";
 
         // Arguments specific to RollUpDownloadFacts
         public const string MinAgeInDays = "MinAgeInDays";

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -64,11 +64,11 @@ namespace NuGet.Jobs
                 // Set JobTraceListener. This will be done on every job run as well
                 SetJobTraceListener(job, consoleLogOnly, jobArgsDictionary);
 
-                var runContinuously = !jobArgsDictionary.GetOrNull<bool>(JobArgumentNames.Once) ?? true;
-                var sleepDuration = jobArgsDictionary.GetOrNull<int>(JobArgumentNames.Sleep); // sleep is in milliseconds
+                var runContinuously = !jobArgsDictionary.GetOrDefault(JobArgumentNames.Once, true);
+                var sleepDuration = jobArgsDictionary.GetOrDefault<int?>(JobArgumentNames.Sleep); // sleep is in milliseconds
                 if (!sleepDuration.HasValue)
                 {
-                    sleepDuration = jobArgsDictionary.GetOrNull<int>(JobArgumentNames.Interval);
+                    sleepDuration = jobArgsDictionary.GetOrDefault<int?>(JobArgumentNames.Interval);
                     if (sleepDuration.HasValue)
                     {
                         sleepDuration = sleepDuration.Value * 1000; // interval is in seconds
@@ -127,12 +127,12 @@ namespace NuGet.Jobs
 
         private static void JobSetup(JobBase job, bool consoleLogOnly, IDictionary<string, string> jobArgsDictionary, ref int? sleepDuration)
         {
-            if (jobArgsDictionary.GetOrNull<bool>("dbg") ?? false)
+            if (jobArgsDictionary.GetOrDefault<bool>("dbg"))
             {
                 throw new ArgumentException("-dbg is a special argument and should be the first argument...");
             }
 
-            if (jobArgsDictionary.GetOrNull<bool>("ConsoleLogOnly") ?? false)
+            if (jobArgsDictionary.GetOrDefault<bool>("ConsoleLogOnly"))
             {
                 throw new ArgumentException("-ConsoleLogOnly is a special argument and should be the first argument (can be the second if '-dbg' is used)...");
             }

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -144,12 +144,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -144,16 +144,17 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />

--- a/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
@@ -13,7 +13,7 @@ namespace NuGet.Jobs
     {
         public ISecretReader CreateSecretReader(IDictionary<string, string> settings)
         {
-            var vaultName = settings.GetOrNull(JobArgumentNames.VaultName);
+            var vaultName = settings.GetOrDefault<string>(JobArgumentNames.VaultName);
             if (vaultName == null)
             {
                 return new EmptySecretReader();
@@ -24,12 +24,12 @@ namespace NuGet.Jobs
                     vaultName,
                     settings[JobArgumentNames.ClientId],
                     settings[JobArgumentNames.CertificateThumbprint],
-                    settings.GetOrNull<StoreName>(JobArgumentNames.StoreName) ?? StoreName.My,
-                    settings.GetOrNull<StoreLocation>(JobArgumentNames.StoreLocation) ?? StoreLocation.LocalMachine,
-                    settings.GetOrNull<bool>(JobArgumentNames.ValidateCertificate) ?? true);
+                    settings.GetOrDefault(JobArgumentNames.StoreName, StoreName.My),
+                    settings.GetOrDefault(JobArgumentNames.StoreLocation, StoreLocation.LocalMachine),
+                    settings.GetOrDefault(JobArgumentNames.ValidateCertificate, true));
 
-            var refreshIntervalSec = settings.GetOrNull<int>(JobArgumentNames.RefreshIntervalSec) ??
-                                     CachingSecretReader.DefaultRefreshIntervalSec;
+            var refreshIntervalSec = settings.GetOrDefault<int>(JobArgumentNames.RefreshIntervalSec,
+                CachingSecretReader.DefaultRefreshIntervalSec);
 
             return new CachingSecretReader(new KeyVaultReader(keyVaultConfiguration), refreshIntervalSec);
         }

--- a/src/NuGet.Jobs.Common/packages.config
+++ b/src/NuGet.Jobs.Common/packages.config
@@ -27,8 +27,8 @@
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.2" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />

--- a/src/NuGet.Jobs.Common/packages.config
+++ b/src/NuGet.Jobs.Common/packages.config
@@ -27,9 +27,10 @@
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.2" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/src/Search.GenerateAuxiliaryData/Job.cs
+++ b/src/Search.GenerateAuxiliaryData/Job.cs
@@ -39,15 +39,14 @@ namespace Search.GenerateAuxiliaryData
 
         public override bool Init(IDictionary<string, string> jobArgsDictionary)
         {
-            var packageDatabaseConnString = new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.PackageDatabase]).ToString();
+            var packageDatabaseConnString = new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase)).ToString();
 
-            var statisticsDatabaseConnString = new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.StatisticsDatabase]).ToString();
+            var statisticsDatabaseConnString = new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase)).ToString();
 
-            var destination = CloudStorageAccount.Parse(jobArgsDictionary[JobArgumentNames.PrimaryDestination]);
+            var destination = CloudStorageAccount.Parse(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PrimaryDestination));
 
             var destinationContainerName =
-                            jobArgsDictionary.GetOrNull(JobArgumentNames.DestinationContainerName)
-                            ?? DefaultContainerName;
+                jobArgsDictionary.GetOrDefault(JobArgumentNames.DestinationContainerName, DefaultContainerName);
 
             _destContainer = destination.CreateCloudBlobClient().GetContainerReference(destinationContainerName);
 

--- a/src/Search.GenerateAuxiliaryData/Search.GenerateAuxiliaryData.csproj
+++ b/src/Search.GenerateAuxiliaryData/Search.GenerateAuxiliaryData.csproj
@@ -127,16 +127,17 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />

--- a/src/Search.GenerateAuxiliaryData/Search.GenerateAuxiliaryData.csproj
+++ b/src/Search.GenerateAuxiliaryData/Search.GenerateAuxiliaryData.csproj
@@ -127,12 +127,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Search.GenerateAuxiliaryData/packages.config
+++ b/src/Search.GenerateAuxiliaryData/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />

--- a/src/Search.GenerateAuxiliaryData/packages.config
+++ b/src/Search.GenerateAuxiliaryData/packages.config
@@ -22,9 +22,10 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/src/Search.RebuildIndex/Search.RebuildIndex.Job.cs
+++ b/src/Search.RebuildIndex/Search.RebuildIndex.Job.cs
@@ -40,19 +40,19 @@ namespace Search.RebuildIndex
         public override bool Init(IDictionary<string, string> jobArgsDictionary)
         {
             PackageDatabase =
-            new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.PackageDatabase]);
+            new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
             DataStorageAccount =
-                CloudStorageAccount.Parse(jobArgsDictionary[JobArgumentNames.DataStorageAccount]);
+                CloudStorageAccount.Parse(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount));
 
-            DataContainerName = jobArgsDictionary.GetOrNull(JobArgumentNames.DataContainerName);
+            DataContainerName = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DataContainerName);
 
             if (string.IsNullOrEmpty(DataContainerName))
             {
                 DataContainerName = DefaultDataContainerName;
             }
 
-            LocalIndexFolder = jobArgsDictionary[JobArgumentNames.LocalIndexFolder];
+            LocalIndexFolder = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.LocalIndexFolder);
 
             // Initialized successfully, return true
             return true;

--- a/src/Search.RebuildIndex/Search.RebuildIndex.csproj
+++ b/src/Search.RebuildIndex/Search.RebuildIndex.csproj
@@ -203,12 +203,12 @@
       <HintPath>..\..\packages\NuGet.Indexing.3.0.43-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGetGallery.Core, Version=3.0.102.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Search.RebuildIndex/Search.RebuildIndex.csproj
+++ b/src/Search.RebuildIndex/Search.RebuildIndex.csproj
@@ -203,12 +203,12 @@
       <HintPath>..\..\packages\NuGet.Indexing.3.0.43-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGetGallery.Core, Version=3.0.102.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Search.RebuildIndex/packages.config
+++ b/src/Search.RebuildIndex/packages.config
@@ -30,8 +30,8 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.43-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGetGallery.Core" version="3.0.102-r-master" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />

--- a/src/Search.RebuildIndex/packages.config
+++ b/src/Search.RebuildIndex/packages.config
@@ -30,11 +30,12 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.43-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGetGallery.Core" version="3.0.102-r-master" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/src/Search.UpdateIndex/Search.UpdateIndex.Job.cs
+++ b/src/Search.UpdateIndex/Search.UpdateIndex.Job.cs
@@ -38,19 +38,19 @@ namespace Search.UpdateIndex
         public override bool Init(IDictionary<string, string> jobArgsDictionary)
         {
             PackageDatabase =
-            new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.PackageDatabase]);
+            new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
             DataStorageAccount =
-                CloudStorageAccount.Parse(jobArgsDictionary[JobArgumentNames.DataStorageAccount]);
+                CloudStorageAccount.Parse(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount));
 
-            DataContainerName = jobArgsDictionary.GetOrNull(JobArgumentNames.DataContainerName);
+            DataContainerName = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.DataContainerName);
 
             if (string.IsNullOrEmpty(DataContainerName))
             {
                 DataContainerName = DefaultDataContainerName;
             }
 
-            ContainerName = jobArgsDictionary.GetOrNull(JobArgumentNames.ContainerName);
+            ContainerName = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.ContainerName);
 
             // Initialized successfully, return true
             return true;

--- a/src/Search.UpdateIndex/Search.UpdateIndex.csproj
+++ b/src/Search.UpdateIndex/Search.UpdateIndex.csproj
@@ -207,12 +207,12 @@
       <HintPath>..\..\packages\NuGet.Indexing.3.0.43-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=1.0.7.0, Culture=neutral, PublicKeyToken=2e465378e3b1a8dd, processorArchitecture=MSIL">

--- a/src/Search.UpdateIndex/Search.UpdateIndex.csproj
+++ b/src/Search.UpdateIndex/Search.UpdateIndex.csproj
@@ -207,12 +207,12 @@
       <HintPath>..\..\packages\NuGet.Indexing.3.0.43-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=1.0.7.0, Culture=neutral, PublicKeyToken=2e465378e3b1a8dd, processorArchitecture=MSIL">

--- a/src/Search.UpdateIndex/packages.config
+++ b/src/Search.UpdateIndex/packages.config
@@ -31,13 +31,14 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.43-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGet.Versioning" version="1.0.7" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.102-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/src/Search.UpdateIndex/packages.config
+++ b/src/Search.UpdateIndex/packages.config
@@ -31,8 +31,8 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.43-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Versioning" version="1.0.7" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.102-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />

--- a/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
@@ -59,18 +59,18 @@ namespace Stats.AggregateCdnDownloadsInGallery
         {
             try
             {
-                var instrumentationKey = jobArgsDictionary.GetOrNull(JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 _loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = _loggerFactory.CreateLogger<Job>();
                 
-                _statisticsDatabase = new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.StatisticsDatabase]);
-                _destinationDatabase = new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.DestinationDatabase]);
+                _statisticsDatabase = new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase));
+                _destinationDatabase = new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DestinationDatabase));
             }
             catch (Exception exception)
             {
-                _logger.LogCritical("Failed to initialize job! {Exception}", exception);
+                _logger?.LogCritical("Failed to initialize job! {Exception}", exception);
 
                 return false;
             }

--- a/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
@@ -151,12 +151,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">
@@ -193,6 +193,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />

--- a/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
@@ -151,12 +151,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Stats.AggregateCdnDownloadsInGallery/packages.config
+++ b/src/Stats.AggregateCdnDownloadsInGallery/packages.config
@@ -28,8 +28,8 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
@@ -41,6 +41,7 @@
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/Stats.AggregateCdnDownloadsInGallery/packages.config
+++ b/src/Stats.AggregateCdnDownloadsInGallery/packages.config
@@ -28,8 +28,8 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -39,19 +39,19 @@ namespace Stats.CollectAzureCdnLogs
         {
             try
             {
-                var instrumentationKey = jobArgsDictionary.GetOrNull(JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 _loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var ftpLogFolder = jobArgsDictionary[JobArgumentNames.FtpSourceUri];
-                var azureCdnPlatform = jobArgsDictionary[JobArgumentNames.AzureCdnPlatform];
-                var cloudStorageAccount = jobArgsDictionary[JobArgumentNames.AzureCdnCloudStorageAccount];
-                _cloudStorageContainerName = jobArgsDictionary[JobArgumentNames.AzureCdnCloudStorageContainerName];
-                _azureCdnAccountNumber = jobArgsDictionary[JobArgumentNames.AzureCdnAccountNumber];
-                _ftpUsername = jobArgsDictionary[JobArgumentNames.FtpSourceUsername];
-                _ftpPassword = jobArgsDictionary[JobArgumentNames.FtpSourcePassword];
+                var ftpLogFolder = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.FtpSourceUri);
+                var azureCdnPlatform = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnPlatform);
+                var cloudStorageAccount = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
+                _cloudStorageContainerName = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageContainerName);
+                _azureCdnAccountNumber = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnAccountNumber);
+                _ftpUsername = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.FtpSourceUsername);
+                _ftpPassword = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.FtpSourcePassword);
 
                 _ftpServerUri = ValidateFtpUri(ftpLogFolder);
                 _azureCdnPlatform = ValidateAzureCdnPlatform(azureCdnPlatform);
@@ -59,7 +59,7 @@ namespace Stats.CollectAzureCdnLogs
             }
             catch (Exception ex)
             {
-                _logger.LogCritical("Job failed to initialize! {Exception}", ex);
+                _logger?.LogCritical("Job failed to initialize! {Exception}", ex);
 
                 return false;
             }

--- a/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj
+++ b/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj
@@ -153,12 +153,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.110.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.110-r-sb-getorthrow\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.110.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.110-r-sb-getorthrow\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj
+++ b/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj
@@ -153,12 +153,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.110.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.110-r-sb-getorthrow\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.110.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.110-r-sb-getorthrow\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">
@@ -195,6 +195,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />

--- a/src/Stats.CollectAzureCdnLogs/packages.config
+++ b/src/Stats.CollectAzureCdnLogs/packages.config
@@ -27,8 +27,8 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.110-r-sb-getorthrow" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.110-r-sb-getorthrow" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />

--- a/src/Stats.CollectAzureCdnLogs/packages.config
+++ b/src/Stats.CollectAzureCdnLogs/packages.config
@@ -27,8 +27,8 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.110-r-sb-getorthrow" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.110-r-sb-getorthrow" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
@@ -40,6 +40,7 @@
   <package id="System.Collections" version="4.0.11" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
@@ -47,25 +47,25 @@ namespace Stats.CreateAzureCdnWarehouseReports
         {
             try
             {
-                var instrumentationKey = jobArgsDictionary.GetOrNull(JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 var loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = loggerFactory.CreateLogger<Job>();
 
-                var cloudStorageAccountConnectionString = jobArgsDictionary[JobArgumentNames.AzureCdnCloudStorageAccount];
-                var statisticsDatabaseConnectionString = jobArgsDictionary[JobArgumentNames.StatisticsDatabase];
-                var galleryDatabaseConnectionString = jobArgsDictionary[JobArgumentNames.SourceDatabase];
-                var dataStorageAccountConnectionString = jobArgsDictionary[JobArgumentNames.DataStorageAccount];
+                var cloudStorageAccountConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
+                var statisticsDatabaseConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
+                var galleryDatabaseConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.SourceDatabase);
+                var dataStorageAccountConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount);
 
                 _cloudStorageAccount = ValidateAzureCloudStorageAccount(cloudStorageAccountConnectionString, JobArgumentNames.AzureCdnCloudStorageAccount);
-                _statisticsContainerName = ValidateAzureContainerName(jobArgsDictionary[JobArgumentNames.AzureCdnCloudStorageContainerName], JobArgumentNames.AzureCdnCloudStorageContainerName);
+                _statisticsContainerName = ValidateAzureContainerName(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageContainerName), JobArgumentNames.AzureCdnCloudStorageContainerName);
                 _dataStorageAccount = ValidateAzureCloudStorageAccount(dataStorageAccountConnectionString, JobArgumentNames.DataStorageAccount);
-                _reportName = ValidateReportName(jobArgsDictionary.GetOrNull(JobArgumentNames.WarehouseReportName));
+                _reportName = ValidateReportName(jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.WarehouseReportName));
                 _statisticsDatabase = new SqlConnectionStringBuilder(statisticsDatabaseConnectionString);
                 _galleryDatabase = new SqlConnectionStringBuilder(galleryDatabaseConnectionString);
 
-                var containerNames = jobArgsDictionary[JobArgumentNames.DataContainerName]
+                var containerNames = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataContainerName)
                         .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var containerName in containerNames)
                 {
@@ -76,7 +76,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
             }
             catch (Exception exception)
             {
-                _logger.LogError("Failed to initialize job! {Exception}", exception);
+                _logger?.LogError("Failed to initialize job! {Exception}", exception);
 
                 return false;
             }

--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
@@ -159,12 +159,12 @@
       <HintPath>..\..\packages\NuGet.Core.2.10.1\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">
@@ -201,6 +201,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />

--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
@@ -159,12 +159,12 @@
       <HintPath>..\..\packages\NuGet.Core.2.10.1\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Stats.CreateAzureCdnWarehouseReports/packages.config
+++ b/src/Stats.CreateAzureCdnWarehouseReports/packages.config
@@ -30,8 +30,8 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
@@ -43,6 +43,7 @@
   <package id="System.Collections" version="4.0.11" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/Stats.CreateAzureCdnWarehouseReports/packages.config
+++ b/src/Stats.CreateAzureCdnWarehouseReports/packages.config
@@ -30,8 +30,8 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />

--- a/src/Stats.ImportAzureCdnStatistics/Job.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Job.cs
@@ -35,24 +35,24 @@ namespace Stats.ImportAzureCdnStatistics
         {
             try
             {
-                var instrumentationKey = jobArgsDictionary.GetOrNull(JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 var loggerConfiguration = LoggingSetup.CreateDefaultLoggerConfiguration(ConsoleLogOnly);
                 _loggerFactory = LoggingSetup.CreateLoggerFactory(loggerConfiguration);
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var azureCdnPlatform = jobArgsDictionary[JobArgumentNames.AzureCdnPlatform];
-                var cloudStorageAccountConnectionString = jobArgsDictionary[JobArgumentNames.AzureCdnCloudStorageAccount];
-                var databaseConnectionString = jobArgsDictionary[JobArgumentNames.StatisticsDatabase];
+                var azureCdnPlatform = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnPlatform);
+                var cloudStorageAccountConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageAccount);
+                var databaseConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
                 _cloudStorageAccount = ValidateAzureCloudStorageAccount(cloudStorageAccountConnectionString);
 
                 _targetDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
-                _azureCdnAccountNumber = jobArgsDictionary[JobArgumentNames.AzureCdnAccountNumber];
+                _azureCdnAccountNumber = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnAccountNumber);
                 _azureCdnPlatform = ValidateAzureCdnPlatform(azureCdnPlatform);
-                _cloudStorageContainerName = ValidateAzureContainerName(jobArgsDictionary[JobArgumentNames.AzureCdnCloudStorageContainerName]);
+                _cloudStorageContainerName = ValidateAzureContainerName(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.AzureCdnCloudStorageContainerName));
 
-                _aggregatesOnly = jobArgsDictionary.GetOrNull<bool>(JobArgumentNames.AggregatesOnly) ?? false;
+                _aggregatesOnly = jobArgsDictionary.GetOrDefault(JobArgumentNames.AggregatesOnly, false);
 
                 // construct a cloud blob client for the configured storage account
                 _cloudBlobClient = _cloudStorageAccount.CreateCloudBlobClient();
@@ -65,7 +65,7 @@ namespace Stats.ImportAzureCdnStatistics
             }
             catch (Exception exception)
             {
-                _logger.LogCritical("Failed to initialize job! {Exception}", exception);
+                _logger?.LogCritical("Failed to initialize job! {Exception}", exception);
 
                 return false;
             }

--- a/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
+++ b/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
@@ -158,12 +158,12 @@
       <HintPath>..\..\packages\NuGet.Core.2.10.1\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
+++ b/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
@@ -158,12 +158,12 @@
       <HintPath>..\..\packages\NuGet.Core.2.10.1\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">
@@ -200,6 +200,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Stats.ImportAzureCdnStatistics/packages.config
+++ b/src/Stats.ImportAzureCdnStatistics/packages.config
@@ -29,8 +29,8 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net451" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
@@ -42,6 +42,7 @@
   <package id="System.Collections" version="4.0.11" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/Stats.ImportAzureCdnStatistics/packages.config
+++ b/src/Stats.ImportAzureCdnStatistics/packages.config
@@ -29,8 +29,8 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Core" version="2.10.1" targetFramework="net451" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />

--- a/src/Stats.RefreshClientDimension/Program.cs
+++ b/src/Stats.RefreshClientDimension/Program.cs
@@ -143,11 +143,11 @@ namespace Stats.RefreshClientDimension
         {
             try
             {
-                var databaseConnectionString = jobArgsDictionary[JobArgumentNames.StatisticsDatabase];
+                var databaseConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
                 _targetDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
 
-                _targetClientName = jobArgsDictionary.GetOrNull("TargetClientName");
-                _userAgentFilter = jobArgsDictionary.GetOrNull("UserAgentFilter");
+                _targetClientName = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.TargetClientName);
+                _userAgentFilter = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.UserAgentFilter);
 
                 return true;
             }

--- a/src/Stats.RefreshClientDimension/Stats.RefreshClientDimension.csproj
+++ b/src/Stats.RefreshClientDimension/Stats.RefreshClientDimension.csproj
@@ -107,12 +107,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Stats.RefreshClientDimension/Stats.RefreshClientDimension.csproj
+++ b/src/Stats.RefreshClientDimension/Stats.RefreshClientDimension.csproj
@@ -107,16 +107,17 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Stats.RefreshClientDimension/packages.config
+++ b/src/Stats.RefreshClientDimension/packages.config
@@ -18,9 +18,10 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net46" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net46" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net46" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net46" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net46" />
   <package id="System.Collections" version="4.0.11" targetFramework="net46" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />
   <package id="System.IO" version="4.1.0" targetFramework="net46" />
   <package id="System.Linq" version="4.1.0" targetFramework="net46" />

--- a/src/Stats.RefreshClientDimension/packages.config
+++ b/src/Stats.RefreshClientDimension/packages.config
@@ -18,8 +18,8 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net46" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net46" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net46" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net46" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net46" />
   <package id="System.Collections" version="4.0.11" targetFramework="net46" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net46" />

--- a/src/Stats.RollUpDownloadFacts/Job.cs
+++ b/src/Stats.RollUpDownloadFacts/Job.cs
@@ -31,23 +31,23 @@ namespace Stats.RollUpDownloadFacts
         {
             try
             {
-                var instrumentationKey = jobArgsDictionary.GetOrNull(JobArgumentNames.InstrumentationKey);
+                var instrumentationKey = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.InstrumentationKey);
                 ApplicationInsights.Initialize(instrumentationKey);
 
                 _loggerFactory = LoggingSetup.CreateLoggerFactory();
                 _logger = _loggerFactory.CreateLogger<Job>();
 
-                var databaseConnectionString = jobArgsDictionary[JobArgumentNames.StatisticsDatabase];
+                var databaseConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.StatisticsDatabase);
                 _targetDatabase = new SqlConnectionStringBuilder(databaseConnectionString);
 
-                _minAgeInDays = jobArgsDictionary.GetOrNull<int>(JobArgumentNames.MinAgeInDays) ?? DefaultMinAgeInDays;
+                _minAgeInDays = jobArgsDictionary.GetOrDefault(JobArgumentNames.MinAgeInDays, DefaultMinAgeInDays);
                 Trace.TraceInformation("Min age in days: " + _minAgeInDays);
 
                 return true;
             }
             catch (Exception exception)
             {
-                _logger.LogCritical("Job failed to initialize. {Exception}", exception);
+                _logger?.LogCritical("Job failed to initialize. {Exception}", exception);
             }
 
             return false;

--- a/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
+++ b/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
@@ -123,12 +123,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">
@@ -165,6 +165,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />

--- a/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
+++ b/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
@@ -123,12 +123,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=1.0.21.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Stats.RollUpDownloadFacts/packages.config
+++ b/src/Stats.RollUpDownloadFacts/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
@@ -35,6 +35,7 @@
   <package id="System.Collections" version="4.0.11" targetFramework="net451" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net451" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net451" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net451" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net451" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/Stats.RollUpDownloadFacts/packages.config
+++ b/src/Stats.RollUpDownloadFacts/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="1.0.21-r-develop" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />

--- a/src/Tests.Logger/Tests.AzureJobTraceListener.csproj
+++ b/src/Tests.Logger/Tests.AzureJobTraceListener.csproj
@@ -107,12 +107,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Tests.Logger/Tests.AzureJobTraceListener.csproj
+++ b/src/Tests.Logger/Tests.AzureJobTraceListener.csproj
@@ -107,16 +107,17 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/src/Tests.Logger/Tests.Logger.Job.cs
+++ b/src/Tests.Logger/Tests.Logger.Job.cs
@@ -26,18 +26,14 @@ namespace Tests.AzureJobTraceListener
                         6 for job that calls Trace.Close from multiple threads,
                         7 for job that calls Job.JobTraceListener.Close from multiple threads";
 
-        private int? JobScenario { get; set; }
+        private int JobScenario { get; set; }
 
         private int? LogCount { get; set; }
         public override bool Init(IDictionary<string, string> jobArgsDictionary)
         {
-            JobScenario = jobArgsDictionary.GetOrNull<int>(ScenarioArgumentName);
-            if(JobScenario == null)
-            {
-                throw new ArgumentException("Argument '"+ ScenarioArgumentName +"' is mandatory." + HelpMessage);
-            }
+            JobScenario = jobArgsDictionary.GetOrThrow<int>(ScenarioArgumentName);
 
-            LogCount = jobArgsDictionary.GetOrNull<int>(LogCountArgumentName);
+            LogCount = jobArgsDictionary.GetOrDefault<int>(LogCountArgumentName);
 
             return true;
         }

--- a/src/Tests.Logger/packages.config
+++ b/src/Tests.Logger/packages.config
@@ -18,8 +18,8 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />

--- a/src/Tests.Logger/packages.config
+++ b/src/Tests.Logger/packages.config
@@ -18,9 +18,10 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/src/UpdateLicenseReports/UpdateLicenseReports.Job.cs
+++ b/src/UpdateLicenseReports/UpdateLicenseReports.Job.cs
@@ -57,13 +57,13 @@ namespace UpdateLicenseReports
 
         public override bool Init(IDictionary<string, string> jobArgsDictionary)
         {
-            _packageDatabase = new SqlConnectionStringBuilder(jobArgsDictionary[JobArgumentNames.PackageDatabase]);
+            _packageDatabase = new SqlConnectionStringBuilder(jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.PackageDatabase));
 
-            _retryCount = jobArgsDictionary.GetOrNull<int>(JobArgumentNames.RetryCount);
+            _retryCount = jobArgsDictionary.GetOrDefault<int>(JobArgumentNames.RetryCount);
 
-            _licenseReportService = new Uri(jobArgsDictionary.GetOrNull(JobArgumentNames.LicenseReportService));
-            _licenseReportUser = jobArgsDictionary.GetOrNull(JobArgumentNames.LicenseReportUser);
-            _licenseReportPassword = jobArgsDictionary.GetOrNull(JobArgumentNames.LicenseReportPassword);
+            _licenseReportService = new Uri(jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.LicenseReportService));
+            _licenseReportUser = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.LicenseReportUser);
+            _licenseReportPassword = jobArgsDictionary.GetOrDefault<string>(JobArgumentNames.LicenseReportPassword);
 
             // Build credentials
             if (!string.IsNullOrEmpty(_licenseReportUser))

--- a/src/UpdateLicenseReports/UpdateLicenseReports.csproj
+++ b/src/UpdateLicenseReports/UpdateLicenseReports.csproj
@@ -135,16 +135,17 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.68-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.68.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.68-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/src/UpdateLicenseReports/UpdateLicenseReports.csproj
+++ b/src/UpdateLicenseReports/UpdateLicenseReports.csproj
@@ -135,12 +135,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/UpdateLicenseReports/packages.config
+++ b/src/UpdateLicenseReports/packages.config
@@ -24,9 +24,10 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.68-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.68-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />
   <package id="System.Linq" version="4.1.0" targetFramework="net452" />

--- a/src/UpdateLicenseReports/packages.config
+++ b/src/UpdateLicenseReports/packages.config
@@ -24,8 +24,8 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -13,6 +13,7 @@ using NuGet.Jobs.Validation.Common.OData;
 using NuGet.Jobs.Validation.Common.Validators;
 using NuGet.Jobs.Validation.Common.Validators.Unzip;
 using NuGet.Jobs.Validation.Common.Validators.Vcs;
+using NuGet.Services.Configuration;
 
 namespace NuGet.Jobs.Validation.Runner
 {
@@ -32,15 +33,15 @@ namespace NuGet.Jobs.Validation.Runner
             try
             {
                 // Configure job
-                _galleryBaseAddress = jobArgsDictionary[JobArgumentNames.GalleryBaseAddress];
+                _galleryBaseAddress = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.GalleryBaseAddress);
 
-                var storageConnectionString = jobArgsDictionary[JobArgumentNames.DataStorageAccount];
+                var storageConnectionString = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.DataStorageAccount);
                 _cloudStorageAccount = CreateCloudStorageAccount(JobArgumentNames.DataStorageAccount, storageConnectionString);
 
-                _containerName = jobArgsDictionary[JobArgumentNames.ContainerName];
+                _containerName = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.ContainerName);
 
-                _runValidationTasks = jobArgsDictionary[JobArgumentNames.RunValidationTasks].Split(';');
-                _requestValidationTasks = jobArgsDictionary[JobArgumentNames.RequestValidationTasks].Split(';');
+                _runValidationTasks = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.RunValidationTasks).Split(';');
+                _requestValidationTasks = jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.RequestValidationTasks).Split(';');
 
                 // Add validators
                 if (_runValidationTasks.Contains(UnzipValidator.ValidatorName))
@@ -50,10 +51,10 @@ namespace NuGet.Jobs.Validation.Runner
                 if (_runValidationTasks.Contains(VcsValidator.ValidatorName))
                 {
                     _validators.Add(new VcsValidator(
-                        jobArgsDictionary[JobArgumentNames.VcsValidatorServiceUrl],
-                        jobArgsDictionary[JobArgumentNames.VcsValidatorCallbackUrl],
-                        jobArgsDictionary[JobArgumentNames.VcsValidatorAlias],
-                        jobArgsDictionary[JobArgumentNames.VcsPackageUrlTemplate]));
+                        jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsValidatorServiceUrl),
+                        jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsValidatorCallbackUrl),
+                        jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsValidatorAlias),
+                        jobArgsDictionary.GetOrThrow<string>(JobArgumentNames.VcsPackageUrlTemplate)));
                 }
 
                 return true;

--- a/src/Validation.Runner/Validation.Runner.csproj
+++ b/src/Validation.Runner/Validation.Runner.csproj
@@ -131,12 +131,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.111-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.111.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.111-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Validation.Runner/Validation.Runner.csproj
+++ b/src/Validation.Runner/Validation.Runner.csproj
@@ -35,6 +35,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Common, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Common.2.0.4\lib\net45\Microsoft.Azure.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.Common.2.0.4\lib\net45\Microsoft.Azure.Common.NetFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.KeyVault, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.1.0.0\lib\net45\Microsoft.Azure.KeyVault.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
@@ -49,6 +65,46 @@
     </Reference>
     <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.1.0.0\lib\netstandard1.1\Microsoft.Extensions.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.FileExtensions.1.0.0\lib\net451\Microsoft.Extensions.Configuration.FileExtensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Json, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Json.1.0.0\lib\net451\Microsoft.Extensions.Configuration.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Physical.1.0.0\lib\net451\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileSystemGlobbing.1.0.0\lib\net451\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.1.0.0\lib\netstandard1.0\Microsoft.Extensions.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.5.907, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.5\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.13.5.907, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.5\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -75,7 +131,17 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="NuGet.Services.Configuration, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.1.0.106-r-develop\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Services.KeyVault, Version=1.0.106.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.1.0.106-r-develop\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Validation.Runner/packages.config
+++ b/src/Validation.Runner/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Hyak.Common" version="1.0.2" targetFramework="net452" />
+  <package id="Microsoft.Azure.Common" version="2.0.4" targetFramework="net452" />
+  <package id="Microsoft.Azure.Common.Dependencies" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
@@ -7,9 +11,30 @@
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net452" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Configuration" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Configuration.Json" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.Primitives" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.IO" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
   <package id="WindowsAzure.Storage" version="7.1.2" targetFramework="net452" />
 </packages>

--- a/src/Validation.Runner/packages.config
+++ b/src/Validation.Runner/packages.config
@@ -23,8 +23,8 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="1.0.106-r-develop" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="1.0.106-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="1.0.111-r-develop" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="1.0.111-r-develop" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.ComponentModel.Annotations" version="4.0.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />


### PR DESCRIPTION
Fixes https://github.com/NuGet/NuGet.Jobs/issues/73.

Basically, there were test cases that put a null/empty value into the configuration dictionary and expected it to throw. Since we were not using the latest implementation of the [dictionary extensions](https://github.com/NuGet/ServerCommon/blob/develop/src/NuGet.Services.Configuration/DictionaryExtensions.cs), which were a replacement for another method that had the correct behavior, the configuration accesses did not throw.

`GetOrNull<T>` was a method that returned a converted value from the dictionary or null if no value exists. It has been replaced by `GetOrDefault<T>`, a method that returns a converted value from the dictionary or a default (`default(T)` or a value specified by a parameter).

TODO:
- [x] Update with newest references to `Server.Common` packages when [this PR](https://github.com/NuGet/ServerCommon/pull/14) is done.