### PR TITLE
Fix ImportAzureCdnStatistics bugs: #3408, #3410

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,7 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 *.webtestresult
+
+# Vs2015
+
+.vs/config/applicationhost.config

--- a/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
@@ -8,6 +8,8 @@ namespace Stats.ImportAzureCdnStatistics
 {
     public class PackageDimension
     {
+        private static CultureInfo EnUsCulture = CultureInfo.GetCultureInfo("en-US");
+
         public PackageDimension(string packageId, string packageVersion)
         {
             PackageId = packageId;
@@ -16,14 +18,14 @@ namespace Stats.ImportAzureCdnStatistics
 
         protected bool Equals(PackageDimension other)
         {
-            return string.Equals(PackageId.ToLower(CultureInfo.GetCultureInfo("en-US")), other.PackageId.ToLower(CultureInfo.GetCultureInfo("en-US"))) && string.Equals(PackageVersion, other.PackageVersion, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(PackageId.ToLower(EnUsCulture), other.PackageId.ToLower(EnUsCulture)) && string.Equals(PackageVersion, other.PackageVersion, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((PackageId != null ? PackageId.ToLower(CultureInfo.GetCultureInfo("en-US")).GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
+                return ((PackageId != null ? PackageId.ToLower(EnUsCulture).GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
             }
         }
 

--- a/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Stats.ImportAzureCdnStatistics
 {
@@ -22,7 +23,7 @@ namespace Stats.ImportAzureCdnStatistics
         {
             unchecked
             {
-                return ((PackageId != null ? PackageId.GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
+                return ((PackageId != null ? PackageId.ToLower().GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
             }
         }
 

--- a/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
@@ -23,7 +23,7 @@ namespace Stats.ImportAzureCdnStatistics
         {
             unchecked
             {
-                return ((PackageId != null ? PackageId.ToLower().GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
+                return ((PackageId != null ? PackageId.ToLowerInvariant().GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
             }
         }
 

--- a/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 
 namespace Stats.ImportAzureCdnStatistics
 {
@@ -15,14 +16,14 @@ namespace Stats.ImportAzureCdnStatistics
 
         protected bool Equals(PackageDimension other)
         {
-            return string.Equals(PackageId, other.PackageId, StringComparison.OrdinalIgnoreCase) && string.Equals(PackageVersion, other.PackageVersion, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(PackageId.ToLower(CultureInfo.GetCultureInfo("en-US")), other.PackageId.ToLower(CultureInfo.GetCultureInfo("en-US"))) && string.Equals(PackageVersion, other.PackageVersion, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((PackageId != null ? PackageId.ToLowerInvariant().GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
+                return ((PackageId != null ? PackageId.ToLower(CultureInfo.GetCultureInfo("en-US")).GetHashCode() : 0)*397) ^ (PackageVersion != null ? PackageVersion.GetHashCode() : 0);
             }
         }
 

--- a/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Dimensions/PackageDimension.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 
 namespace Stats.ImportAzureCdnStatistics
 {

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -713,6 +713,7 @@ namespace Stats.ImportAzureCdnStatistics
                         {
                             results.Add(package);
                         }
+
                         if (!_cachedPackageDimensions.Contains(package))
                         {
                             _cachedPackageDimensions.Add(package);
@@ -1062,7 +1063,10 @@ namespace Stats.ImportAzureCdnStatistics
                             _cachedUserAgentFacts.Add(userAgent, userAgentId);
                         }
 
-                        results.Add(userAgent, userAgentId);
+                        if (!results.ContainsKey(userAgent))
+                        {
+                            results.Add(userAgent, userAgentId);
+                        }
                     }
                 }
             }

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDimensionFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDimensionFacts.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Stats.ImportAzureCdnStatistics;
+using Xunit;
+
+namespace Tests.Stats.ImportAzureCdnStatistics
+{
+    public class PackageDimensionFacts
+    {
+        [Theory]
+        [InlineData("abc", "1.0.0", "ABC", "1.0.0", true)] // Lowercase and uppercase are equal
+        [InlineData("İ", "1.0.0", "i", "1.0.0", false)] // Turkish capital i is not like regular i
+        [InlineData("abc", "1.0.0", "cbd", "1.0.0", false)] // Different package ids
+        [InlineData("abc", "1.0.0", "abc", "2.0.0", false)] // Different package versions
+        public void ComparesPackageDimensionsCorrectly(string packageId1, string version1, string packageId2, string version2, bool expectedAreEqual)
+        {
+            // Arrange
+            var dimension1 = new PackageDimension(packageId1, version1);
+            var dimension2 = new PackageDimension(packageId2, version2);
+
+            // Act
+            bool areEqualHashCode = dimension1.GetHashCode() == dimension2.GetHashCode();
+            bool areEqualEquals = dimension1.Equals(dimension2);
+
+            // Assert
+            Assert.Equal(expectedAreEqual, areEqualHashCode);
+            Assert.Equal(expectedAreEqual, areEqualEquals);
+        }
+    }
+}

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDimensionFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDimensionFacts.cs
@@ -10,7 +10,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
     {
         [Theory]
         [InlineData("abc", "1.0.0", "ABC", "1.0.0", true)] // Lowercase and uppercase are equal
-        [InlineData("İ", "1.0.0", "i", "1.0.0", false)] // Turkish capital i is not like regular i
+        [InlineData("İ", "1.0.0", "i", "1.0.0", true)] // Turkish capital i is like regular i
         [InlineData("abc", "1.0.0", "cbd", "1.0.0", false)] // Different package ids
         [InlineData("abc", "1.0.0", "abc", "2.0.0", false)] // Different package versions
         public void ComparesPackageDimensionsCorrectly(string packageId1, string version1, string packageId2, string version2, bool expectedAreEqual)

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
@@ -119,6 +119,7 @@
   <ItemGroup>
     <Compile Include="CdnLogCustomFieldParserFacts.cs" />
     <Compile Include="PackageDefinitionFacts.cs" />
+    <Compile Include="PackageDimensionFacts.cs" />
     <Compile Include="PackageTranslatorFacts.cs" />
     <Compile Include="StatisticsParserFacts.cs" />
     <Compile Include="ToolStatisticsParserFacts.cs" />


### PR DESCRIPTION
Fix for: ImportAzureCDNStatistics fails when the same package appears in different casings (https://github.com/NuGet/NuGetGallery/issues/3408)
Fix for: ImportAzureCDNStatistics fails when the same user agent appears in different casings (https://github.com/NuGet/NuGetGallery/issues/3410)