### PR TITLE
Update build.cmd to build VCS callback server correctly

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -17,9 +17,9 @@ if not "%errorlevel%"=="0" goto failure
 REM Build VCS Callback Server
 %msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
-echo "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip"
-echo "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
-copy "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip" "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
+echo "src\Validation.Callback.Vcs\obj\%config%\_PublishedWebsites\Validation.Callback.Vcs_Package\Validation.Callback.Vcs.zip"
+echo "src\Validation.Callback.Vcs\obj\Validation.Callback.Vcs.zip"
+copy "src\Validation.Callback.Vcs\obj\Debug\_PublishedWebsites\Validation.Callback.Vcs_Package\Validation.Callback.Vcs.zip" "src\Validation.Callback.Vcs\obj\Validation.Callback.Vcs.zip"
 if not "%errorlevel%"=="0" goto failure
 
 REM Test

--- a/build.cmd
+++ b/build.cmd
@@ -10,8 +10,14 @@ Powershell.exe -NoProfile -ExecutionPolicy ByPass -Command "& '%cd%\restoreNuGet
 tools\nuget.exe restore NuGet.Jobs.sln -OutputDirectory %cd%\packages -NonInteractive -source "https://api.nuget.org/v3/index.json;https://www.myget.org/F/nugetbuild/api/v3/index.json"
 if not "%errorlevel%"=="0" goto failure
 
-REM Build
+REM Build Solution
 %msbuild% NuGet.Jobs.sln /p:Configuration="%config%" /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+if not "%errorlevel%"=="0" goto failure
+
+REM Build VCS Callback Server
+%msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
+if not "%errorlevel%"=="0" goto failure
+copy src/Validation.Callback.Vcs/obj/"%config%"/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip
 if not "%errorlevel%"=="0" goto failure
 
 REM Test

--- a/build.cmd
+++ b/build.cmd
@@ -17,6 +17,8 @@ if not "%errorlevel%"=="0" goto failure
 REM Build VCS Callback Server
 %msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
+echo "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip"
+echo "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
 copy "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip" "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
 if not "%errorlevel%"=="0" goto failure
 

--- a/build.cmd
+++ b/build.cmd
@@ -17,7 +17,7 @@ if not "%errorlevel%"=="0" goto failure
 REM Build VCS Callback Server
 %msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
-copy src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip
+copy "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip" "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
 if not "%errorlevel%"=="0" goto failure
 
 REM Test

--- a/build.cmd
+++ b/build.cmd
@@ -17,9 +17,9 @@ if not "%errorlevel%"=="0" goto failure
 REM Build VCS Callback Server
 %msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
-echo "src\Validation.Callback.Vcs\obj\%config%\_PublishedWebsites\Validation.Callback.Vcs_Package\Validation.Callback.Vcs.zip"
-echo "src\Validation.Callback.Vcs\obj\Validation.Callback.Vcs.zip"
-copy "src\Validation.Callback.Vcs\obj\Debug\_PublishedWebsites\Validation.Callback.Vcs_Package\Validation.Callback.Vcs.zip" "src\Validation.Callback.Vcs\obj\Validation.Callback.Vcs.zip"
+echo "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip"
+echo "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
+copy "src/Validation.Callback.Vcs/obj/Release/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip" "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
 if not "%errorlevel%"=="0" goto failure
 
 REM Test

--- a/build.cmd
+++ b/build.cmd
@@ -17,9 +17,7 @@ if not "%errorlevel%"=="0" goto failure
 REM Build VCS Callback Server
 %msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
-echo "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip"
-echo "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
-copy "src/Validation.Callback.Vcs/obj/Release/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip" "src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip"
+copy "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip" "src/Validation.Callback.Vcs/obj/"
 if not "%errorlevel%"=="0" goto failure
 
 REM Test

--- a/build.cmd
+++ b/build.cmd
@@ -17,7 +17,7 @@ if not "%errorlevel%"=="0" goto failure
 REM Build VCS Callback Server
 %msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
-copy "src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip" "src/Validation.Callback.Vcs/obj/"
+copy "src\Validation.Callback.Vcs\obj\%config%\_PublishedWebsites\Validation.Callback.Vcs_Package\Validation.Callback.Vcs.zip" "src\Validation.Callback.Vcs\obj\Validation.Callback.Vcs.zip"
 if not "%errorlevel%"=="0" goto failure
 
 REM Test

--- a/build.cmd
+++ b/build.cmd
@@ -17,7 +17,7 @@ if not "%errorlevel%"=="0" goto failure
 REM Build VCS Callback Server
 %msbuild% src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj /p:OutputPath=obj/"%config%" /t:Package /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
-copy src/Validation.Callback.Vcs/obj/"%config%"/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip
+copy src/Validation.Callback.Vcs/obj/%config%/_PublishedWebsites/Validation.Callback.Vcs_Package/Validation.Callback.Vcs.zip src/Validation.Callback.Vcs/obj/Validation.Callback.Vcs.zip
 if not "%errorlevel%"=="0" goto failure
 
 REM Test


### PR DESCRIPTION
Currently, `build.cmd` does not correctly build the VCS callback server, thus relying on the build agent to know that it needs to rebuild the project as a package and then copy the package into a directory. Adding these steps to the build script allows us to centralize them.