### PR TITLE
Fix file ending in ".download" causes CollectAzureCdnLogs to fail

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/LogEvents.cs
+++ b/src/Stats.AzureCdnLogs.Common/LogEvents.cs
@@ -16,5 +16,10 @@ namespace Stats.AzureCdnLogs.Common
         public static EventId FailedBlobLease = new EventId(506, "Failed to lease blob");
         public static EventId FailedDimensionRetrieval = new EventId(507, "Failed to retrieve dimension");
         public static EventId FailedToParseLogFileEntry = new EventId(508, "Failed to parse log file entry");
+        public static EventId FailedToProcessLogStream = new EventId(509, "Error processing log stream");
+        public static EventId UnknownAzureCdnPlatform = new EventId(510, "Unknown Azure CDN platform");
+        public static EventId InvalidRawLogFileName = new EventId(511, "Invalid raw log filename");
+        public static EventId FailedToGetFtpResponse = new EventId(512, "Failed to get FTP response");
+        public static EventId JobRunFailed = new EventId(550, "Job run failed");
     }
 }

--- a/src/Stats.CollectAzureCdnLogs/Blob/CloudBlobRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/Blob/CloudBlobRawLogClient.cs
@@ -64,16 +64,16 @@ namespace Stats.CollectAzureCdnLogs.Blob
             return await blob.OpenWriteAsync();
         }
 
-        public async Task<bool> CheckIfBlobExistsAsync(CloudBlobContainer targetContainer, RawLogFileInfo logFile)
+        public async Task<bool> CheckIfBlobExistsAsync(CloudBlobContainer targetContainer, string fileName)
         {
-            using (_logger.BeginScope("Checking if file '{FileName}' exists.", logFile.FileName))
+            using (_logger.BeginScope("Checking if file '{FileName}' exists.", fileName))
             {
                 try
                 {
-                    var blob = targetContainer.GetBlockBlobReference(logFile.FileName);
+                    var blob = targetContainer.GetBlockBlobReference(fileName);
                     var exists = await blob.ExistsAsync();
 
-                    _logger.LogInformation("Finished checking if file '{FileName}' exists (exists = {FileExists}).", logFile.FileName, exists);
+                    _logger.LogInformation("Finished checking if file '{FileName}' exists (exists = {FileExists}).", fileName, exists);
 
                     return exists;
                 }

--- a/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
@@ -61,7 +61,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
                 if (result != FtpStatusCode.FileActionOK)
                 {
                     // Failed (multiple times) to rename the file on the origin. No point in continuing with this file.
-                    Logger.LogError("Failed to rename file. Processing aborted.");
+                    Logger.LogError("Failed to rename file. Processing aborted. (FtpStatusCode={FtpStatusCode})", result.ToString());
 
                     return false;
                 }

--- a/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
@@ -147,7 +147,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
                 catch (WebException exception)
                 {
                     var response = exception.Response as FtpWebResponse;
-                    if (response != null)
+                    if (response != null && attempts == 4)
                     {
                         return response.StatusCode;
                     }

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -164,10 +164,12 @@ namespace Stats.CollectAzureCdnLogs
                         else
                         {
                             // Delete the ".download" file if it already exists, as we may be reprocessing this file.
-                            await ftpClient.DeleteAsync(new Uri(rawLogFile.Uri + FileExtensions.Download));
+                            var downloadFileUri = new Uri(rawLogFile.Uri + FileExtensions.Download);
+                            await ftpClient.DeleteAsync(downloadFileUri);
 
                             // Rename the file on the origin to ensure we're not locking a file that still can be written to.
-                            rawLogUri = await ftpClient.RenameAsync(rawLogFile, rawLogFile.FileName + FileExtensions.Download);
+                            var downloadFileName = rawLogFile.FileName + FileExtensions.Download;
+                            rawLogUri = await ftpClient.RenameAsync(rawLogFile, downloadFileName);
 
                             if (rawLogUri == null)
                             {
@@ -226,7 +228,11 @@ namespace Stats.CollectAzureCdnLogs
                                         }
                                         catch (Exception exception)
                                         {
-                                            _logger.LogError(LogEvents.FailedBlobUpload, exception, LogMessages.FailedBlobUpload);
+                                            _logger.LogError(
+                                                LogEvents.FailedBlobUpload,
+                                                exception,
+                                                LogMessages.FailedBlobUpload,
+                                                rawLogUri);
                                         }
                                     }
                                 }
@@ -242,12 +248,18 @@ namespace Stats.CollectAzureCdnLogs
                     catch (UnknownAzureCdnPlatformException exception)
                     {
                         // Trace, but ignore the failing file. Other files should go through just fine.
-                        _logger.LogWarning(LogEvents.UnknownAzureCdnPlatform, exception, LogMessages.UnknownAzureCdnPlatform);
+                        _logger.LogWarning(
+                            LogEvents.UnknownAzureCdnPlatform,
+                            exception,
+                            LogMessages.UnknownAzureCdnPlatform);
                     }
                     catch (InvalidRawLogFileNameException exception)
                     {
                         // Trace, but ignore the failing file. Other files should go through just fine.
-                        _logger.LogWarning(LogEvents.InvalidRawLogFileName, exception, LogMessages.InvalidRawLogFileName);
+                        _logger.LogWarning(
+                            LogEvents.InvalidRawLogFileName,
+                            exception,
+                            LogMessages.InvalidRawLogFileName);
                     }
                 }
             }

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -163,6 +163,9 @@ namespace Stats.CollectAzureCdnLogs
                         }
                         else
                         {
+                            // Delete the ".download" file if it already exists, as we may be reprocessing this file.
+                            await ftpClient.DeleteAsync(new Uri(rawLogFile.Uri + FileExtensions.Download));
+
                             // Rename the file on the origin to ensure we're not locking a file that still can be written to.
                             rawLogUri = await ftpClient.RenameAsync(rawLogFile, rawLogFile.FileName + FileExtensions.Download);
 

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -226,7 +226,7 @@ namespace Stats.CollectAzureCdnLogs
                                         }
                                         catch (Exception exception)
                                         {
-                                            _logger.LogError("Failed to upload file. {Exception}", exception);
+                                            _logger.LogError(LogEvents.FailedBlobUpload, exception, LogMessages.FailedBlobUpload);
                                         }
                                     }
                                 }
@@ -242,18 +242,18 @@ namespace Stats.CollectAzureCdnLogs
                     catch (UnknownAzureCdnPlatformException exception)
                     {
                         // Trace, but ignore the failing file. Other files should go through just fine.
-                        _logger.LogWarning("Unknown Azure CDN platform. {Exception}", exception);
+                        _logger.LogWarning(LogEvents.UnknownAzureCdnPlatform, exception, LogMessages.UnknownAzureCdnPlatform);
                     }
                     catch (InvalidRawLogFileNameException exception)
                     {
                         // Trace, but ignore the failing file. Other files should go through just fine.
-                        _logger.LogWarning("Invalid raw log filename. {Exception}", exception);
+                        _logger.LogWarning(LogEvents.InvalidRawLogFileName, exception, LogMessages.InvalidRawLogFileName);
                     }
                 }
             }
             catch (Exception exception)
             {
-                _logger.LogCritical("Job run failed! {Exception}", exception);
+                _logger.LogCritical(LogEvents.JobRunFailed, exception, LogMessages.JobRunFailed);
 
                 return false;
             }
@@ -289,7 +289,7 @@ namespace Stats.CollectAzureCdnLogs
                     catch (SharpZipBaseException e)
                     {
                         // this raw log file may be corrupt...
-                        _logger.LogError("Error processing log stream. {Exception}", e);
+                        _logger.LogError(LogEvents.FailedToProcessLogStream, e, LogMessages.ProcessingLogStreamFailed);
 
                         throw;
                     }

--- a/src/Stats.CollectAzureCdnLogs/LogMessages.Designer.cs
+++ b/src/Stats.CollectAzureCdnLogs/LogMessages.Designer.cs
@@ -61,7 +61,7 @@ namespace Stats.CollectAzureCdnLogs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to upload file..
+        ///   Looks up a localized string similar to Failed to upload file: {fileName}..
         /// </summary>
         internal static string FailedBlobUpload {
             get {
@@ -70,7 +70,7 @@ namespace Stats.CollectAzureCdnLogs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to InvalidRawLogFileName.
+        ///   Looks up a localized string similar to Invalid raw log file name..
         /// </summary>
         internal static string InvalidRawLogFileName {
             get {

--- a/src/Stats.CollectAzureCdnLogs/LogMessages.Designer.cs
+++ b/src/Stats.CollectAzureCdnLogs/LogMessages.Designer.cs
@@ -61,11 +61,56 @@ namespace Stats.CollectAzureCdnLogs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to upload file..
+        /// </summary>
+        internal static string FailedBlobUpload {
+            get {
+                return ResourceManager.GetString("FailedBlobUpload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to InvalidRawLogFileName.
+        /// </summary>
+        internal static string InvalidRawLogFileName {
+            get {
+                return ResourceManager.GetString("InvalidRawLogFileName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Job run failed!.
+        /// </summary>
+        internal static string JobRunFailed {
+            get {
+                return ResourceManager.GetString("JobRunFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to parse W3C log entry in {LogFileName} at line {LineNumber}..
         /// </summary>
         internal static string ParseLogEntryLineFailed {
             get {
                 return ResourceManager.GetString("ParseLogEntryLineFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error processing log stream..
+        /// </summary>
+        internal static string ProcessingLogStreamFailed {
+            get {
+                return ResourceManager.GetString("ProcessingLogStreamFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown Azure CDN platform..
+        /// </summary>
+        internal static string UnknownAzureCdnPlatform {
+            get {
+                return ResourceManager.GetString("UnknownAzureCdnPlatform", resourceCulture);
             }
         }
     }

--- a/src/Stats.CollectAzureCdnLogs/LogMessages.resx
+++ b/src/Stats.CollectAzureCdnLogs/LogMessages.resx
@@ -117,7 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FailedBlobUpload" xml:space="preserve">
+    <value>Failed to upload file.</value>
+  </data>
+  <data name="InvalidRawLogFileName" xml:space="preserve">
+    <value>InvalidRawLogFileName</value>
+  </data>
+  <data name="JobRunFailed" xml:space="preserve">
+    <value>Job run failed!</value>
+  </data>
   <data name="ParseLogEntryLineFailed" xml:space="preserve">
     <value>Failed to parse W3C log entry in {LogFileName} at line {LineNumber}.</value>
+  </data>
+  <data name="ProcessingLogStreamFailed" xml:space="preserve">
+    <value>Error processing log stream.</value>
+  </data>
+  <data name="UnknownAzureCdnPlatform" xml:space="preserve">
+    <value>Unknown Azure CDN platform.</value>
   </data>
 </root>

--- a/src/Stats.CollectAzureCdnLogs/LogMessages.resx
+++ b/src/Stats.CollectAzureCdnLogs/LogMessages.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FailedBlobUpload" xml:space="preserve">
-    <value>Failed to upload file.</value>
+    <value>Failed to upload file: {fileName}.</value>
   </data>
   <data name="InvalidRawLogFileName" xml:space="preserve">
-    <value>InvalidRawLogFileName</value>
+    <value>Invalid raw log file name.</value>
   </data>
   <data name="JobRunFailed" xml:space="preserve">
     <value>Job run failed!</value>


### PR DESCRIPTION
Attempt to fix https://github.com/NuGet/NuGetGallery/issues/3496

Improved the `FtpRawLogClient.GetResponseAsync` method to return the actual response status code, and catch WebExceptions if they occur. Still attempting up to 5 times before bailing out and returning the status code of the exception to cover for FTP protocol flakiness...

In the situation where the FTP source `CollectAzureCdnLogs` is reading from has these two files:

```
wpc_DB16_20170119_0070.log.gz             9,728 KB
wpc_DB16_20170119_0070.log.gz.download    8,080 KB
```

The job processes `wpc_DB16_20170119_0070.log.gz` first, and will now first attempt to delete the file `wpc_DB16_20170119_0070.log.gz.download`, before attempting the rename operation (which would currently fail as the file already exists).

Note that I'm not doing an explicit FTP request to check for file existence, and simply let the delete command fail gracefully. If the file didn't exist (and thus could not be deleted), the FtpStatusCode returned should be `FtpStatusCode.ActionNotTakenFileUnavailable`. If it exists and failed, a warning will be logged, and the rename attempt will still fail (however, the `WebException` is now captured and logged).

Also fixed a bunch of error logging statements that still happily compiled after a breaking API change in the logging component, but did not send the exception information along anymore...

cc @shishirx34 @skofman1 @joelverhagen @ryuyu 