### PR TITLE
Hotfix: stats total download counts overflow

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
@@ -46,7 +46,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
             using (var connection = await StatisticsDatabase.ConnectTo())
             using (var transaction = connection.BeginTransaction(IsolationLevel.Snapshot))
             {
-                totalsData.Downloads = (await connection.ExecuteScalarWithRetryAsync<int>(
+                totalsData.Downloads = (await connection.ExecuteScalarWithRetryAsync<long>(
                     WarehouseStoredProcedureName, commandType: CommandType.StoredProcedure, transaction: transaction));
             }
             Trace.TraceInformation("Total downloads: {0}", totalsData.Downloads);

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.SelectTotalDownloadCounts.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.SelectTotalDownloadCounts.sql
@@ -4,6 +4,6 @@ BEGIN
 	SET NOCOUNT ON;
 
 	-- select total # of downloads + correction for packages that can not be mapped
-	SELECT	SUM(ISNULL(F.[DownloadCount], 0)) - 21000000 AS [Downloads]
+	SELECT	SUM(CAST(ISNULL(F.[DownloadCount], 0) AS BIGINT)) - 21000000 AS [Downloads]
 	FROM	[dbo].[Fact_Download] (NOLOCK) AS F
 END


### PR DESCRIPTION
The CreateAzureCdnWarehouseReports job has been failing since approximately January 28th due to an arithmetic overflow error. The total number of package downloads has broken 2,147,483,647 (the maximum for int32) and the job was not prepared to handle it. This fix correctly persists the value as a long (BIGINT in SQL) so that the number does not overflow.