### PR TITLE
Deployment scripts for SupportRequest.Notifications job

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -104,7 +104,8 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/HandlePackageEdits/HandlePackageEdits.csproj", `
             "src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj", `
             "src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj", `
-            "src/Validation.Runner/Validation.Runner.csproj"
+            "src/Validation.Runner/Validation.Runner.csproj",
+            "src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.csproj"
         
         Foreach ($Project in $Projects) {
             New-Package (Join-Path $PSScriptRoot "$Project") -Configuration $Configuration -BuildNumber $BuildNumber -ReleaseLabel $ReleaseLabel -Version $SemanticVersion -Branch $Branch

--- a/src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.nuspec
+++ b/src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>NuGet.SupportRequests.Notifications.$branch$</id>
+    <version>$version$</version>
+    <title>NuGet.SupportRequests.Notifications</title>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>NuGet.SupportRequests.Notifications</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="bin"/>
+	
+    <file src="Scripts\OnCallDailyNotification.cmd" />
+    <file src="Scripts\WeeklySummaryNotification.cmd" />
+  </files>
+</package>

--- a/src/NuGet.SupportRequests.Notifications/Scripts/OnCallDailyNotification.cmd
+++ b/src/NuGet.SupportRequests.Notifications/Scripts/OnCallDailyNotification.cmd
@@ -1,0 +1,14 @@
+@echo OFF
+	
+cd bin
+
+:Top
+	echo "Starting job - NuGet - SupportRequests.Notifications.OnCallDailyNotification.cmd"
+	
+	title #{Jobs.supportrequests.notifications.Title}
+
+	start /w nuget.supportrequests.notifications.exe -ConsoleLogOnly -Task "OnCallDailyNotification" -SourceDatabase "Server=tcp:vz2xmz8oda.database.windows.net;Database=nuget-prod-supportrequest;Persist Security Info=False;User ID=$$Prod-SupportRequestDBReadOnly-UserName$$;Password=$$Prod-SupportRequestDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True" -PagerDutyAccountName "nuget" -PagerDutyApiKey "$$Prod-PagerDuty-ApiKey$$" -SmtpUri "smtps://nuget:$$Prod-SendGridSMTP-Password$$@smtp.sendgrid.net:587/" -VaultName "#{Deployment.Azure.KeyVault.VaultName}" -ClientId "#{Deployment.Azure.KeyVault.ClientId}" -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" -InstrumentationKey "#{Jobs.supportrequests.notifications.InstrumentationKey}" -verbose true -Once
+
+	echo "Finished job - NuGet - SupportRequests.Notifications.OnCallDailyNotification.cmd"
+
+	goto Top

--- a/src/NuGet.SupportRequests.Notifications/Scripts/WeeklySummaryNotification.cmd
+++ b/src/NuGet.SupportRequests.Notifications/Scripts/WeeklySummaryNotification.cmd
@@ -1,0 +1,14 @@
+@echo OFF
+	
+cd bin
+
+:Top
+	echo "Starting job - NuGet - SupportRequests.Notifications.WeeklySummaryNotification.cmd"
+	
+	title #{Jobs.supportrequests.notifications.Title}
+
+	start /w nuget.supportrequests.notifications.exe -ConsoleLogOnly -Task "WeeklySummaryNotification" -TargetEmailAddress "#{Jobs.supportrequests.notifications.weeklysummarynotification.TargetEmailAddress}" -SourceDatabase "Server=tcp:vz2xmz8oda.database.windows.net;Database=nuget-prod-supportrequest;Persist Security Info=False;User ID=$$Prod-SupportRequestDBReadOnly-UserName$$;Password=$$Prod-SupportRequestDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True" -PagerDutyAccountName "nuget" -PagerDutyApiKey "$$Prod-PagerDuty-ApiKey$$" -SmtpUri "smtps://nuget:$$Prod-SendGridSMTP-Password$$@smtp.sendgrid.net:587/" -VaultName "#{Deployment.Azure.KeyVault.VaultName}" -ClientId "#{Deployment.Azure.KeyVault.ClientId}" -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" -InstrumentationKey "#{Jobs.supportrequests.notifications.InstrumentationKey}" -verbose true -Once
+
+	echo "Finished job - NuGet - SupportRequests.Notifications.WeeklySummaryNotification.cmd"
+
+	goto Top


### PR DESCRIPTION
The PR contains an update to `build.ps1` to ensure the new job is compiled and packaged, and the package contains two separate startup scripts for the same job with different parameters.

OctopusDeploy pipeline created under `Jobs - Send support request notifications`. As discussed offline with @skofman1, we'll only target `PROD` environment to avoid noise on `DEV` and `INT`.