### PR TITLE
Fix binding invalid binding redirects for Microsoft.Azure.KeyVault

### DIFF
--- a/src/Tests.Logger/App.config
+++ b/src/Tests.Logger/App.config
@@ -23,7 +23,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.1.0" newVersion="2.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/Validation.Callback.Vcs/Web.config
+++ b/src/Validation.Callback.Vcs/Web.config
@@ -5,7 +5,7 @@
   -->
 <configuration>
   <appSettings>
-    <add key="DataStorageAccount" value="UseDevelopmentStorage=True;" />
+    <add key="DataStorageAccount" value="UseDevelopmentStorage=true" />
     <add key="ContainerName" value="validation" />
     <add key="KeyVault:VaultName" value="" />
     <add key="KeyVault:ClientId" value="" />
@@ -52,7 +52,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.1.0" newVersion="2.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform" publicKeyToken="31bf3856ad364e35" culture="neutral" />


### PR DESCRIPTION
Reproduced by adding KeyVault configuration locally and launching the website.
Fixed by making the binding the binding directory for KeyVault match the other projects in the solution.

Also, fixed an invalid storage emulator key, which is necessary for F5 of the website locally.