### PR TITLE
Fix Gallery.Maintenance branch artifact

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -101,7 +101,7 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj", `
             "src/UpdateLicenseReports/UpdateLicenseReports.csproj", `
             "src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj", `
-            "src/Gallery.Maintenance/Gallery.Maintenance.csproj", `
+            "src/Gallery.Maintenance/Gallery.Maintenance.nuspec", `
             "src/ArchivePackages/ArchivePackages.csproj", `
             "src/Search.GenerateAuxiliaryData/Search.GenerateAuxiliaryData.csproj", `
             "src/HandlePackageEdits/HandlePackageEdits.csproj", `

--- a/src/Gallery.Maintenance/Gallery.Maintenance.csproj
+++ b/src/Gallery.Maintenance/Gallery.Maintenance.csproj
@@ -87,6 +87,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="Gallery.Maintenance.nuspec">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="project.json" />
     <None Include="Scripts\Functions.ps1" />
     <None Include="Scripts\Gallery.Maintenance.cmd" />

--- a/src/Gallery.Maintenance/Gallery.Maintenance.nuspec
+++ b/src/Gallery.Maintenance/Gallery.Maintenance.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Gallery.Maintenance.$branch$</id>
+    <id>Gallery.Maintenance</id>
     <version>$version$</version>
     <title>Gallery.Maintenance</title>
     <authors>.NET Foundation</authors>

--- a/src/Gallery.Maintenance/Gallery.Maintenance.nuspec
+++ b/src/Gallery.Maintenance/Gallery.Maintenance.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Gallery.Maintenance.$branch$</id>
+    <version>$version$</version>
+    <title>Gallery.Maintenance</title>
+    <authors>.NET Foundation</authors>
+    <owners>.NET Foundation</owners>
+    <description>Gallery.Maintenance</description>
+    <copyright>Copyright .NET Foundation</copyright>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\*.*" target="bin"/>
+	
+    <file src="Scripts\Gallery.Maintenance.cmd" />
+	
+    <file src="Scripts\Functions.ps1" />
+    <file src="Scripts\PreDeploy.ps1" />
+    <file src="Scripts\PostDeploy.ps1" />
+    <file src="Scripts\nssm.exe" />
+  </files>
+</package>


### PR DESCRIPTION
Add missing nuspec for Gallery.Maintenance job, which generates branch-specific artifact (i.e.: Gallery.Maintenance.zlocal.1.0.0-zlocal.nupkg)

Updating build.ps1 to pack from nuspec instead of csproj, required since it uses project.json.