### PR TITLE
Increase command timeout for the Stats.CreateAzureCdnWarehouseReports job

### DIFF
--- a/src/Gallery.CredentialExpiration/Job.cs
+++ b/src/Gallery.CredentialExpiration/Job.cs
@@ -20,7 +20,7 @@ namespace Gallery.CredentialExpiration
 {
     public class Job : JobBase
     {
-        private const int DefaultCommandTimeout = 1800; // 30 minutes max
+        private readonly TimeSpan _defaultCommandTimeout = TimeSpan.FromMinutes(30);
 
         private readonly ConcurrentDictionary<string, DateTimeOffset> _contactedUsers = new ConcurrentDictionary<string, DateTimeOffset>();
         private readonly string _cursorFile = "cursor.json";
@@ -65,7 +65,7 @@ namespace Gallery.CredentialExpiration
                 var smtpUri = new SmtpUri(new Uri(smtpConnectionString));
                 _smtpClient = CreateSmtpClient(smtpUri);
 
-                _warnDaysBeforeExpiration = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, MyJobArgumentNames.WarnDaysBeforeExpiration) 
+                _warnDaysBeforeExpiration = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, MyJobArgumentNames.WarnDaysBeforeExpiration)
                     ?? _warnDaysBeforeExpiration;
 
                 _allowEmailResendAfterDays = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, MyJobArgumentNames.AllowEmailResendAfterDays)
@@ -113,7 +113,7 @@ namespace Gallery.CredentialExpiration
                     expiredCredentials = (await galleryConnection.QueryWithRetryAsync<ExpiredCredentialData>(
                         string.Format(Strings.GetExpiredCredentialsQuery, _warnDaysBeforeExpiration),
                         maxRetries: 3,
-                        commandTimeout: DefaultCommandTimeout)).ToList();
+                        commandTimeout: _defaultCommandTimeout)).ToList();
 
                     _logger.LogInformation("Retrieved {ExpiredCredentials} expired credentials.",
                         expiredCredentials.Count);
@@ -246,7 +246,7 @@ namespace Gallery.CredentialExpiration
                 : string.Format(Strings.ApiKeyExpiring, description, (int)expiryInDays);
 
             // \u2022 - Unicode for bullet point.
-            return "\u2022 "+ message + Environment.NewLine;
+            return "\u2022 " + message + Environment.NewLine;
         }
 
         private SmtpClient CreateSmtpClient(SmtpUri smtpUri)

--- a/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
@@ -96,7 +96,7 @@ namespace Stats.AggregateCdnDownloadsInGallery
                             _storedProcedureName,
                             transaction: statisticsDatabaseTransaction,
                             commandType: CommandType.StoredProcedure,
-                            commandTimeout: (int)TimeSpan.FromMinutes(15).TotalSeconds,
+                            commandTimeout: TimeSpan.FromMinutes(15),
                             maxRetries: 3))
                         .ToList();
                 }
@@ -174,7 +174,7 @@ namespace Stats.AggregateCdnDownloadsInGallery
                         _logger.LogDebug("Updating destination database Download Counts... ({RecordCount} package registrations to process).", packageRegistrationGroups.Count());
 
                         await destinationDatabase.ExecuteAsync(_updateFromTempTable,
-                            timeout: (int)TimeSpan.FromMinutes(30).TotalSeconds);
+                            commandTimeout: TimeSpan.FromMinutes(30));
 
                         _logger.LogInformation("Updated destination database Download Counts.");
                     }
@@ -199,7 +199,7 @@ namespace Stats.AggregateCdnDownloadsInGallery
             // Ensure results are sorted deterministically.
             var packageRegistrationData = (await sqlConnection.QueryWithRetryAsync<PackageRegistrationData>(
                     "SELECT [Key], LOWER([Id]) AS LowercasedId, [Id] AS OriginalId FROM [dbo].[PackageRegistrations] (NOLOCK) ORDER BY [Id] ASC",
-                    commandTimeout: (int)TimeSpan.FromMinutes(10).TotalSeconds,
+                    commandTimeout: TimeSpan.FromMinutes(10),
                     maxRetries: 5)).ToList();
 
             // We are not using .ToDictionary() and instead explicitly looping through these items to be able to detect

--- a/src/Stats.CreateAzureCdnWarehouseReports/DownloadCountReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/DownloadCountReport.cs
@@ -18,7 +18,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
         : ReportBase
     {
         private const string _storedProcedureName = "[dbo].[SelectTotalDownloadCountsPerPackageVersion]";
-        private const int _defaultCommandTimeout = 1800; // 30 minutes max
+        private readonly TimeSpan _defaultCommandTimeout = TimeSpan.FromMinutes(30);
         internal const string ReportName = "downloads.v1.json";
 
         public DownloadCountReport(IEnumerable<StorageContainerTarget> targets, SqlConnectionStringBuilder statisticsDatabase, SqlConnectionStringBuilder galleryDatabase)

--- a/src/Stats.CreateAzureCdnWarehouseReports/DownloadsPerToolVersionReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/DownloadsPerToolVersionReport.cs
@@ -18,7 +18,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
         : ReportBase
     {
         private const string _storedProcedureName = "[dbo].[SelectTotalDownloadCountsPerToolVersion]";
-        private const int _defaultCommandTimeout = 1800; // 30 minutes max
+        private readonly TimeSpan _defaultCommandTimeout = TimeSpan.FromMinutes(30);
         internal const string ReportName = "tools.v1.json";
 
         public DownloadsPerToolVersionReport(CloudStorageAccount cloudStorageAccount, string statisticsContainerName, SqlConnectionStringBuilder statisticsDatabase, SqlConnectionStringBuilder galleryDatabase)

--- a/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
@@ -23,7 +23,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
         internal const string ReportName = "stats-totals.json";
 
         public GalleryTotalsReport(CloudStorageAccount cloudStorageAccount, string statisticsContainerName, SqlConnectionStringBuilder statisticsDatabase, SqlConnectionStringBuilder galleryDatabase)
-            : base(new [] { new StorageContainerTarget(cloudStorageAccount, statisticsContainerName) }, statisticsDatabase, galleryDatabase)
+            : base(new[] { new StorageContainerTarget(cloudStorageAccount, statisticsContainerName) }, statisticsDatabase, galleryDatabase)
         {
         }
 
@@ -47,7 +47,10 @@ namespace Stats.CreateAzureCdnWarehouseReports
             using (var transaction = connection.BeginTransaction(IsolationLevel.Snapshot))
             {
                 totalsData.Downloads = (await connection.ExecuteScalarWithRetryAsync<long>(
-                    WarehouseStoredProcedureName, commandType: CommandType.StoredProcedure, transaction: transaction));
+                    WarehouseStoredProcedureName,
+                    commandType: CommandType.StoredProcedure,
+                    commandTimeout: TimeSpan.FromMinutes(5),
+                    transaction: transaction));
             }
             Trace.TraceInformation("Total downloads: {0}", totalsData.Downloads);
 


### PR DESCRIPTION
Fix NuGet/NuGetGallery#3726.

[This](https://github.com/NuGet/NuGet.Jobs/compare/master-dtivel-increase-command-timeout?expand=1#diff-ecfe46cd1bda6541ee1a0f8f0737e17cR52) is the fix.

The remaining changes are either file reformattings or changes to the command timeout data type.