### PR TITLE
Added logging of the request body when scanning request was marked as failed

### DIFF
--- a/src/Validation.Common/TraceHelper.cs
+++ b/src/Validation.Common/TraceHelper.cs
@@ -23,7 +23,7 @@ namespace NuGet.Jobs.Validation.Common
                     $"{{{TraceConstant.ValidatorName}}} " +
                     $"ValidationId: {{{TraceConstant.ValidationId}}} " +
                     $"for package {{{TraceConstant.PackageId}}} " +
-                    $"v.{{{TraceConstant.PackageVersion}}} " +
+                    $"{{{TraceConstant.PackageVersion}}} " +
                     $"resulted in {{Result}}",
                 "ValidatorResult",
                 validatorName,
@@ -49,7 +49,7 @@ namespace NuGet.Jobs.Validation.Common
                     $"{{{TraceConstant.ValidatorName}}} " +
                     $"ValidationId: {{{TraceConstant.ValidationId}}} " +
                     $"for package {{{TraceConstant.PackageId}}} " +
-                    $"v.{{{TraceConstant.PackageVersion}}} " +
+                    $"{{{TraceConstant.PackageVersion}}} " +
                     $"resulted in {{Result}}, " +
                     $"additional info: {{AdditionalInformation}}",
                 "ValidatorResult",
@@ -76,7 +76,7 @@ namespace NuGet.Jobs.Validation.Common
                     $"{{{TraceConstant.EventName}}} " +
                     $"occurred while running {{{TraceConstant.ValidatorName}}} {{{TraceConstant.ValidationId}}}" +
                     $"on package {{{TraceConstant.PackageId}}}" +
-                    $"v. {{{TraceConstant.PackageVersion}}}", 
+                    $"{{{TraceConstant.PackageVersion}}}", 
                 "ValidatorException",
                 validationId,
                 validatorName,

--- a/src/Validation.Common/TraceHelper.cs
+++ b/src/Validation.Common/TraceHelper.cs
@@ -34,6 +34,34 @@ namespace NuGet.Jobs.Validation.Common
         }
 
         /// <summary>
+        /// Tracks the result of the validation with additional information
+        /// </summary>
+        /// <param name="logger">Logger object to use</param>
+        /// <param name="validatorName">The name of validator attempted</param>
+        /// <param name="validationId">Validation ID of the finished validator</param>
+        /// <param name="result">Validation result</param>
+        /// <param name="packageId">Package ID</param>
+        /// <param name="packageVersion">Package name</param>
+        /// <param name="additionalInformation">Additional information you'd want logged</param>
+        public static void TrackValidatorResult(this ILogger logger, string validatorName, Guid validationId, string result, string packageId, string packageVersion, string additionalInformation)
+        {
+            logger.LogInformation($"{{{TraceConstant.EventName}}}: " +
+                    $"{{{TraceConstant.ValidatorName}}} " +
+                    $"ValidationId: {{{TraceConstant.ValidationId}}} " +
+                    $"for package {{{TraceConstant.PackageId}}} " +
+                    $"v.{{{TraceConstant.PackageVersion}}} " +
+                    $"resulted in {{Result}}, " +
+                    $"additional info: {{AdditionalInformation}}",
+                "ValidatorResult",
+                validatorName,
+                validationId,
+                packageId,
+                packageVersion,
+                result,
+                additionalInformation);
+        }
+
+        /// <summary>
         /// Tracks the exception occured during validation
         /// </summary>
         /// <param name="logger">Logger object to use</param>

--- a/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
@@ -241,13 +241,18 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                             validationEntity.ValidatorCompleted(VcsValidator.ValidatorName, ValidationResult.Failed);
                             await _packageValidationTable.StoreAsync(validationEntity);
 
-                            _logger.TrackValidatorResult(VcsValidator.ValidatorName, validationId, ValidationResult.Failed.ToString(), validationEntity.PackageId, validationEntity.PackageVersion, body.Substring(0, ReasonableBodySize));
+                            _logger.TrackValidatorResult(VcsValidator.ValidatorName, 
+                                validationId, 
+                                ValidationResult.Failed.ToString(), 
+                                validationEntity.PackageId, 
+                                validationEntity.PackageVersion, 
+                                TruncateString(body, ReasonableBodySize));
                             var auditEntries = new List<PackageValidationAuditEntry>();
                             auditEntries.Add(new PackageValidationAuditEntry
                             {
                                 Timestamp = DateTimeOffset.UtcNow,
                                 ValidatorName = VcsValidator.ValidatorName,
-                                Message = "Package scan failed."
+                                Message = $"Package scan failed. Response: {body}"
                             });
 
                             if (result.ResultReasons?.ResultReason != null)
@@ -280,9 +285,27 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                     _logger.LogWarning(
                         "Callback was not handled for State={State}, Result={Result}. " +
                         "Request body: {RequestBody}",
-                        result?.State, result?.Result, body.Substring(0, ReasonableBodySize));
+                        result?.State, result?.Result, TruncateString(body, ReasonableBodySize));
                 }
             }
+        }
+
+        /// <summary>
+        /// Truncates the string leaving at most specified amount of characters and adds a "(truncated)" at the end
+        /// if it removes any portion of the string
+        /// </summary>
+        /// <param name="str">String to truncate</param>
+        /// <param name="length">Max amount of characters to keep if truncated</param>
+        /// <returns>Original string if it's length was less than specified length, otherwise, first 'length' characters of the string 
+        /// with "(truncated)" appended.</returns>
+        private static string TruncateString(string str, int length)
+        {
+            if (str.Length <= length)
+            {
+                return str;
+            }
+
+            return str.Substring(0, length) + "(truncated)";
         }
     }
 }

--- a/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
@@ -28,6 +28,17 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
         private readonly INotificationService _notificationService;
         private readonly ILogger<VcsCallbackServerStartup> _logger;
 
+        /// <summary>
+        /// Number of body characters to take for logging.
+        /// </summary>
+        /// <remarks>
+        /// Callback service is available to be queried from anywhere and hence the body may be of any size.
+        /// In situations when we want to log the body, we don't want to log potentially Multi-MB bodies, so, 
+        /// we'll only take a "reasonable" (that would fit most of the calls we really expect) amount from 
+        /// the beginning.
+        /// </remarks>
+        private const int ReasonableBodySize = 2048;
+
         private static class State
         {
             public const string Complete = "Complete";
@@ -230,7 +241,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                             validationEntity.ValidatorCompleted(VcsValidator.ValidatorName, ValidationResult.Failed);
                             await _packageValidationTable.StoreAsync(validationEntity);
 
-                            _logger.TrackValidatorResult(VcsValidator.ValidatorName, validationId, ValidationResult.Failed.ToString(), validationEntity.PackageId, validationEntity.PackageVersion);
+                            _logger.TrackValidatorResult(VcsValidator.ValidatorName, validationId, ValidationResult.Failed.ToString(), validationEntity.PackageId, validationEntity.PackageVersion, body.Substring(0, ReasonableBodySize));
                             var auditEntries = new List<PackageValidationAuditEntry>();
                             auditEntries.Add(new PackageValidationAuditEntry
                             {
@@ -266,13 +277,10 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
 
                 if (!processedRequest)
                 {
-                    // first 1024 bytes of the body are taken in order not to send potentially multi-MB long requests.
-                    // "Normal" callback calls are less than 1024 bytes, but since this service blindly accepts any
-                    // request, we may get some potentially long garbage and don't want it all logged.
                     _logger.LogWarning(
                         "Callback was not handled for State={State}, Result={Result}. " +
                         "Request body: {RequestBody}",
-                        result?.State, result?.Result, body.Substring(0, 1024));
+                        result?.State, result?.Result, body.Substring(0, ReasonableBodySize));
                 }
             }
         }


### PR DESCRIPTION
Logging more info for failed scans, to make investigations easier. [#398](https://github.com/NuGet/Engineering/issues/398)