### PR TITLE
Added EventName property to the PackageValidationAuditEntry

### DIFF
--- a/src/Validation.Common/PackageValidationAuditEntry.cs
+++ b/src/Validation.Common/PackageValidationAuditEntry.cs
@@ -8,7 +8,8 @@ namespace NuGet.Jobs.Validation.Common
     public class PackageValidationAuditEntry
     {
         public string ValidatorName { get; set; }
-        public string EventName { get; set; }
+        public ValidationEvent EventId { get; set; }
+        public string EventName => EventId.ToString();
         public string Message { get; set; }
         public DateTimeOffset Timestamp { get; set; }
     }

--- a/src/Validation.Common/PackageValidationAuditEntry.cs
+++ b/src/Validation.Common/PackageValidationAuditEntry.cs
@@ -8,6 +8,7 @@ namespace NuGet.Jobs.Validation.Common
     public class PackageValidationAuditEntry
     {
         public string ValidatorName { get; set; }
+        public string EventName { get; set; }
         public string Message { get; set; }
         public DateTimeOffset Timestamp { get; set; }
     }

--- a/src/Validation.Common/Validation.Common.csproj
+++ b/src/Validation.Common/Validation.Common.csproj
@@ -189,6 +189,7 @@
     <Compile Include="TraceConstant.cs" />
     <Compile Include="TraceEvent.cs" />
     <Compile Include="TraceHelper.cs" />
+    <Compile Include="ValidationEvent.cs" />
     <Compile Include="Validators\IValidator.cs" />
     <Compile Include="Validators\Unzip\UnzipValidator.cs" />
     <Compile Include="Validators\ValidationResult.cs" />

--- a/src/Validation.Common/ValidationEvent.cs
+++ b/src/Validation.Common/ValidationEvent.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Validation.Common/ValidationEvent.cs
+++ b/src/Validation.Common/ValidationEvent.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs.Validation.Common
+{
+    public static class ValidationEvent
+    {
+        /// <summary>
+        /// Virus scan request is about to be sent
+        /// </summary>
+        public const string BeforeVirusScanRequest = "BeforeVirusScan";
+
+        /// <summary>
+        /// The validation queue item was deadlettered after several attempts of processing
+        /// </summary>
+        public const string Deadlettered = "Deadlettered";
+
+        /// <summary>
+        /// The detail item passed with a <see cref="PackageNotClean"/> result
+        /// </summary>
+        public const string NotCleanReason = "NotCleanReason";
+
+        /// <summary>
+        /// Virus scan service reported package as clean
+        /// </summary>
+        public const string PackageClean = "PackageClean";
+
+        /// <summary>
+        /// Packages download was successful
+        /// </summary>
+        public const string PackageDownloaded = "PackageDownloaded";
+
+        /// <summary>
+        /// Virus scan service reported package as not clean
+        /// </summary>
+        public const string PackageNotClean = "PackageNotClean";
+
+        /// <summary>
+        /// Virus scan service reported its failure to scan package (it does *not* mean package is not clean)
+        /// </summary>
+        public const string ScanFailed = "ScanFailed";
+
+        /// <summary>
+        /// The detail item passed with <see cref="ScanFailed"/> result
+        /// </summary>
+        public const string ScanFailureReason = "ScanFailureReason";
+
+        /// <summary>
+        /// An exception was thrown during validator execution
+        /// </summary>
+        public const string ValidatorException = "ValidatorException";
+
+        /// <summary>
+        /// The virus scan request was submitted
+        /// </summary>
+        public const string VirusScanRequestSent = "VirusScanRequestSent";
+
+        /// <summary>
+        /// Sending the virus scanning request had failed
+        /// </summary>
+        public const string VirusScanRequestFailed = "VirusScanRequestFailed";
+
+        /// <summary>
+        /// Package was successfully unzipped
+        /// </summary>
+        public const string UnzipSucceeeded = "UnzipSucceeeded";
+    }
+}

--- a/src/Validation.Common/ValidationEvent.cs
+++ b/src/Validation.Common/ValidationEvent.cs
@@ -1,74 +1,68 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace NuGet.Jobs.Validation.Common
 {
-    public static class ValidationEvent
+    public enum ValidationEvent
     {
         /// <summary>
         /// Virus scan request is about to be sent
         /// </summary>
-        public const string BeforeVirusScanRequest = "BeforeVirusScan";
+        BeforeVirusScanRequest,
 
         /// <summary>
         /// The validation queue item was deadlettered after several attempts of processing
         /// </summary>
-        public const string Deadlettered = "Deadlettered";
+        Deadlettered,
 
         /// <summary>
         /// The detail item passed with a <see cref="PackageNotClean"/> result
         /// </summary>
-        public const string NotCleanReason = "NotCleanReason";
+        NotCleanReason,
 
         /// <summary>
         /// Virus scan service reported package as clean
         /// </summary>
-        public const string PackageClean = "PackageClean";
+        PackageClean,
 
         /// <summary>
         /// Packages download was successful
         /// </summary>
-        public const string PackageDownloaded = "PackageDownloaded";
+        PackageDownloaded,
 
         /// <summary>
         /// Virus scan service reported package as not clean
         /// </summary>
-        public const string PackageNotClean = "PackageNotClean";
+        PackageNotClean,
 
         /// <summary>
         /// Virus scan service reported its failure to scan package (it does *not* mean package is not clean)
         /// </summary>
-        public const string ScanFailed = "ScanFailed";
+        ScanFailed,
 
         /// <summary>
         /// The detail item passed with <see cref="ScanFailed"/> result
         /// </summary>
-        public const string ScanFailureReason = "ScanFailureReason";
+        ScanFailureReason,
 
         /// <summary>
         /// An exception was thrown during validator execution
         /// </summary>
-        public const string ValidatorException = "ValidatorException";
+        ValidatorException,
 
         /// <summary>
         /// The virus scan request was submitted
         /// </summary>
-        public const string VirusScanRequestSent = "VirusScanRequestSent";
+        VirusScanRequestSent,
 
         /// <summary>
         /// Sending the virus scanning request had failed
         /// </summary>
-        public const string VirusScanRequestFailed = "VirusScanRequestFailed";
+        VirusScanRequestFailed,
 
         /// <summary>
         /// Package was successfully unzipped
         /// </summary>
-        public const string UnzipSucceeeded = "UnzipSucceeeded";
+        UnzipSucceeeded,
     }
 }

--- a/src/Validation.Common/Validators/Unzip/UnzipValidator.cs
+++ b/src/Validation.Common/Validators/Unzip/UnzipValidator.cs
@@ -47,7 +47,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Unzip
                             await packageStream.CopyToAsync(packageFileStream);
 
                             _logger.LogInformation($"Downloaded package from {{{TraceConstant.Url}}}", message.Package.DownloadUrl);
-                            WriteAuditEntry(auditEntries, $"Downloaded package from {message.Package.DownloadUrl}");
+                            WriteAuditEntry(auditEntries, $"Downloaded package from {message.Package.DownloadUrl}",
+                                ValidationEvent.PackageDownloaded);
 
                             packageFileStream.Position = 0;
                             
@@ -55,7 +56,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Unzip
                             {
                                 var parts = packageZipStream.GetParts();
                                 _logger.LogInformation("Found {PartsCount} parts in package.", parts.Count());
-                                WriteAuditEntry(auditEntries, $"Found {parts.Count()} parts in package.");
+                                WriteAuditEntry(auditEntries, $"Found {parts.Count()} parts in package.",
+                                    ValidationEvent.UnzipSucceeeded);
 
                                 return ValidationResult.Succeeded;
                             }
@@ -65,7 +67,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Unzip
                 catch (Exception ex)
                 {
                     _logger.TrackValidatorException(ValidatorName, message.ValidationId, ex, message.PackageId, message.PackageVersion);
-                    WriteAuditEntry(auditEntries, $"Exception thrown during validation - {ex.Message}\r\n{ex.StackTrace}");
+                    WriteAuditEntry(auditEntries, $"Exception thrown during validation - {ex.Message}\r\n{ex.StackTrace}",
+                        ValidationEvent.ValidatorException);
                     return ValidationResult.Failed;
                 }
                 finally

--- a/src/Validation.Common/Validators/ValidatorBase.cs
+++ b/src/Validation.Common/Validators/ValidatorBase.cs
@@ -22,14 +22,14 @@ namespace NuGet.Jobs.Validation.Common.Validators
 
         public abstract Task<ValidationResult> ValidateAsync(PackageValidationMessage message, List<PackageValidationAuditEntry> auditEntries);
 
-        protected void WriteAuditEntry(List<PackageValidationAuditEntry> auditEntries, string message, string eventName)
+        protected void WriteAuditEntry(List<PackageValidationAuditEntry> auditEntries, string message, ValidationEvent validationEvent)
         {
             auditEntries.Add(new PackageValidationAuditEntry
             {
                 Timestamp = DateTimeOffset.UtcNow,
                 ValidatorName = Name,
                 Message = message,
-                EventName = eventName
+                EventId = validationEvent,
             });
         }
     }

--- a/src/Validation.Common/Validators/ValidatorBase.cs
+++ b/src/Validation.Common/Validators/ValidatorBase.cs
@@ -22,13 +22,14 @@ namespace NuGet.Jobs.Validation.Common.Validators
 
         public abstract Task<ValidationResult> ValidateAsync(PackageValidationMessage message, List<PackageValidationAuditEntry> auditEntries);
 
-        protected void WriteAuditEntry(List<PackageValidationAuditEntry> auditEntries, string message)
+        protected void WriteAuditEntry(List<PackageValidationAuditEntry> auditEntries, string message, string eventName)
         {
             auditEntries.Add(new PackageValidationAuditEntry
             {
                 Timestamp = DateTimeOffset.UtcNow,
                 ValidatorName = Name,
-                Message = message
+                Message = message,
+                EventName = eventName
             });
         }
     }

--- a/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
@@ -179,7 +179,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                 Timestamp = DateTimeOffset.UtcNow,
                                 ValidatorName = VcsValidator.ValidatorName,
                                 Message = "Package did not scan clean.",
-                                EventName = ValidationEvent.PackageNotClean
+                                EventId = ValidationEvent.PackageNotClean,
                             });
 
                             if (result.ResultReasons?.ResultReason != null)
@@ -191,7 +191,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                         Timestamp = DateTimeOffset.UtcNow,
                                         ValidatorName = VcsValidator.ValidatorName,
                                         Message = resultReason.RefId + " " + resultReason.Result + " " + resultReason.Determination,
-                                        EventName = ValidationEvent.NotCleanReason
+                                        EventId = ValidationEvent.NotCleanReason,
                                     });
                                 }
                             }
@@ -234,7 +234,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                     Timestamp = DateTimeOffset.UtcNow,
                                     ValidatorName = VcsValidator.ValidatorName,
                                     Message = "Package scanned clean.",
-                                    EventName = ValidationEvent.PackageClean
+                                    EventId = ValidationEvent.PackageClean,
                                 });
                         }
                         else if (result.Result == "Results" || result.Result == "Fail")
@@ -256,7 +256,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                 Timestamp = DateTimeOffset.UtcNow,
                                 ValidatorName = VcsValidator.ValidatorName,
                                 Message = $"Package scan failed. Response: {body}",
-                                EventName = ValidationEvent.ScanFailed
+                                EventId = ValidationEvent.ScanFailed,
                             });
 
                             if (result.ResultReasons?.ResultReason != null)
@@ -268,7 +268,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                         Timestamp = DateTimeOffset.UtcNow,
                                         ValidatorName = VcsValidator.ValidatorName,
                                         Message = resultReason.RefId + " " + resultReason.Result + " " + resultReason.Determination,
-                                        EventName = ValidationEvent.ScanFailureReason
+                                        EventId = ValidationEvent.ScanFailureReason,
                                     });
                                 }
                             }

--- a/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
@@ -178,7 +178,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                             {
                                 Timestamp = DateTimeOffset.UtcNow,
                                 ValidatorName = VcsValidator.ValidatorName,
-                                Message = "Package did not scan clean."
+                                Message = "Package did not scan clean.",
+                                EventName = ValidationEvent.PackageNotClean
                             });
 
                             if (result.ResultReasons?.ResultReason != null)
@@ -189,7 +190,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                     {
                                         Timestamp = DateTimeOffset.UtcNow,
                                         ValidatorName = VcsValidator.ValidatorName,
-                                        Message = resultReason.RefId + " " + resultReason.Result + " " + resultReason.Determination
+                                        Message = resultReason.RefId + " " + resultReason.Result + " " + resultReason.Determination,
+                                        EventName = ValidationEvent.NotCleanReason
                                     });
                                 }
                             }
@@ -231,7 +233,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                 {
                                     Timestamp = DateTimeOffset.UtcNow,
                                     ValidatorName = VcsValidator.ValidatorName,
-                                    Message = "Package scanned clean."
+                                    Message = "Package scanned clean.",
+                                    EventName = ValidationEvent.PackageClean
                                 });
                         }
                         else if (result.Result == "Results" || result.Result == "Fail")
@@ -252,7 +255,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                             {
                                 Timestamp = DateTimeOffset.UtcNow,
                                 ValidatorName = VcsValidator.ValidatorName,
-                                Message = $"Package scan failed. Response: {body}"
+                                Message = $"Package scan failed. Response: {body}",
+                                EventName = ValidationEvent.ScanFailed
                             });
 
                             if (result.ResultReasons?.ResultReason != null)
@@ -263,7 +267,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                                     {
                                         Timestamp = DateTimeOffset.UtcNow,
                                         ValidatorName = VcsValidator.ValidatorName,
-                                        Message = resultReason.RefId + " " + resultReason.Result + " " + resultReason.Determination
+                                        Message = resultReason.RefId + " " + resultReason.Result + " " + resultReason.Determination,
+                                        EventName = ValidationEvent.ScanFailureReason
                                     });
                                 }
                             }

--- a/src/Validation.Common/Validators/Vcs/VcsValidator.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsValidator.cs
@@ -48,7 +48,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                 message.ValidationId,
                 message.PackageId,
                 message.PackageVersion);
-            WriteAuditEntry(auditEntries, $"Submitting virus scan job with description \"{description}\"...");
+            WriteAuditEntry(auditEntries, $"Submitting virus scan job with description \"{description}\"...",
+                ValidationEvent.BeforeVirusScanRequest);
 
             string errorMessage;
             try
@@ -72,7 +73,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                         result.RegionCode);
                     WriteAuditEntry(auditEntries, $"Submission completed. Request id: {result.RequestId} " +
                         $"- job id: {result.JobId} " +
-                        $"- region code: {result.RegionCode}");
+                        $"- region code: {result.RegionCode}", 
+                        ValidationEvent.VirusScanRequestSent);
                     return ValidationResult.Asynchronous;
                 }
                 else
@@ -96,7 +98,8 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                 _logger.TrackValidatorException(ValidatorName, message.ValidationId, ex, message.PackageId, message.PackageVersion);
             }
 
-            WriteAuditEntry(auditEntries, $"Submission failed. Error message: {errorMessage}");
+            WriteAuditEntry(auditEntries, $"Submission failed. Error message: {errorMessage}", 
+                ValidationEvent.VirusScanRequestFailed);
             return ValidationResult.Failed;
         }
 

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -177,7 +177,7 @@ namespace NuGet.Jobs.Validation.Runner
                         Timestamp = DateTimeOffset.UtcNow,
                         ValidatorName = validator.Name,
                         Message = $"Message has been attempted too many times and is being deadlettered. Aborting validator.",
-                        EventName = ValidationEvent.Deadlettered
+                        EventId = ValidationEvent.Deadlettered,
                     });
                 }
 
@@ -217,7 +217,7 @@ namespace NuGet.Jobs.Validation.Runner
                             Timestamp = DateTimeOffset.UtcNow,
                             ValidatorName = validator.Name,
                             Message = $"Exception thrown during validation - {ex.Message}\r\n{ex.StackTrace}",
-                            EventName = ValidationEvent.ValidatorException
+                            EventId = ValidationEvent.ValidatorException,
                         });
 
                         _logger.LogError(TraceEvent.ValidatorException, ex, 

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -176,7 +176,8 @@ namespace NuGet.Jobs.Validation.Runner
                     {
                         Timestamp = DateTimeOffset.UtcNow,
                         ValidatorName = validator.Name,
-                        Message = $"Message has been attempted too many times and is being deadlettered. Aborting validator."
+                        Message = $"Message has been attempted too many times and is being deadlettered. Aborting validator.",
+                        EventName = ValidationEvent.Deadlettered
                     });
                 }
 
@@ -215,7 +216,8 @@ namespace NuGet.Jobs.Validation.Runner
                         {
                             Timestamp = DateTimeOffset.UtcNow,
                             ValidatorName = validator.Name,
-                            Message = $"Exception thrown during validation - {ex.Message}\r\n{ex.StackTrace}"
+                            Message = $"Exception thrown during validation - {ex.Message}\r\n{ex.StackTrace}",
+                            EventName = ValidationEvent.ValidatorException
                         });
 
                         _logger.LogError(TraceEvent.ValidatorException, ex, 


### PR DESCRIPTION
For the [#405](https://github.com/NuGet/Engineering/issues/405).
Needed a way to easily distinguish between audit entries for the monitoring.