### PR TITLE
Made msbuild to take no build action on the Deploy.ps1

### DIFF
--- a/src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj
+++ b/src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj
@@ -117,7 +117,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config" />
-    <Content Include="Deploy.ps1" />
+    <None Include="Deploy.ps1" />
     <Content Include="Validation.Callback.Vcs.nuspec" />
     <Content Include="ApplicationInsights.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Putting the `Deploy.ps1` into the `None` node instead of the `Content` prevents `nuget.exe` from copying to under the `Content` directory in the .nupkg, which in turn prevents Octopus from complaining about `Deploy.ps1` being under `Content`. Deployment did not produce a warning when built from this branch.

A fix for the [#3665](https://github.com/NuGet/NuGetGallery/issues/3665)