### PR TITLE
Update NuGet.Versioning dependency to contain OriginalVersion fix

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
@@ -84,7 +84,7 @@
       <HintPath>..\..\packages\NuGet.Services.Logging.2.1.1\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2507\lib\net45\NuGet.Versioning.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2524\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.2.1\lib\net45\Serilog.dll</HintPath>

--- a/src/Stats.CreateAzureCdnWarehouseReports/packages.config
+++ b/src/Stats.CreateAzureCdnWarehouseReports/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="2.1.1" targetFramework="net452" />
-  <package id="NuGet.Versioning" version="4.3.0-preview1-2507" targetFramework="net452" />
+  <package id="NuGet.Versioning" version="4.3.0-preview1-2524" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
   <package id="Serilog.Enrichers.Process" version="2.0.0" targetFramework="net452" />

--- a/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
+++ b/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
@@ -87,7 +87,7 @@
       <HintPath>..\..\packages\NuGet.Services.Logging.2.1.1\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Versioning, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2507\lib\net45\NuGet.Versioning.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Versioning.4.3.0-preview1-2524\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.2.1\lib\net45\Serilog.dll</HintPath>

--- a/src/Stats.ImportAzureCdnStatistics/packages.config
+++ b/src/Stats.ImportAzureCdnStatistics/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Services.Logging" version="2.1.1" targetFramework="net452" />
-  <package id="NuGet.Versioning" version="4.3.0-preview1-2507" targetFramework="net452" />
+  <package id="NuGet.Versioning" version="4.3.0-preview1-2524" targetFramework="net452" />
   <package id="Serilog" version="2.2.1" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
   <package id="Serilog.Enrichers.Process" version="2.0.0" targetFramework="net452" />


### PR DESCRIPTION
Updating to pinned versions of NuGet.Versioning containing the OriginalVersion fix from https://github.com/NuGet/NuGet.Client/pull/1329