### PR TITLE
Fix stats missing for System.Version versions

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/DownloadCountReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/DownloadCountReport.cs
@@ -53,9 +53,9 @@ namespace Stats.CreateAzureCdnWarehouseReports
                     foreach (var gv in group)
                     {
                         // downloads.v1.json should only contain normalized versions - ignore others
-                        SemanticVersion semanticVersion;
+                        NuGetVersion semanticVersion;
                         if (!string.IsNullOrEmpty(gv.PackageVersion)
-                            && SemanticVersion.TryParse(gv.PackageVersion, out semanticVersion)
+                            && NuGetVersion.TryParse(gv.PackageVersion, out semanticVersion)
                             && gv.PackageVersion == semanticVersion.ToNormalizedString())
                         {
                             var version = new JArray(gv.PackageVersion, gv.TotalDownloadCount);

--- a/src/Stats.ImportAzureCdnStatistics/PackageStatisticsParser.cs
+++ b/src/Stats.ImportAzureCdnStatistics/PackageStatisticsParser.cs
@@ -51,9 +51,9 @@ namespace Stats.ImportAzureCdnStatistics
         private static string NormalizeSemanticVersion(string packageVersion)
         {
             // Normalize package version
-            SemanticVersion semanticVersion;
+            NuGetVersion semanticVersion;
             if (!string.IsNullOrEmpty(packageVersion)
-                && SemanticVersion.TryParse(packageVersion, out semanticVersion))
+                && NuGetVersion.TryParse(packageVersion, out semanticVersion))
             {
                 packageVersion = semanticVersion.ToNormalizedString();
             }

--- a/src/Stats.ImportAzureCdnStatistics/PackageStatisticsParser.cs
+++ b/src/Stats.ImportAzureCdnStatistics/PackageStatisticsParser.cs
@@ -26,7 +26,10 @@ namespace Stats.ImportAzureCdnStatistics
                 return null;
             }
 
-            packageDefinition = _packageTranslator.TranslatePackageDefinition(packageDefinition);
+            if (_packageTranslator != null)
+            {
+                packageDefinition = _packageTranslator.TranslatePackageDefinition(packageDefinition);
+            }
 
             var statistic = new PackageStatistics();
             statistic.EdgeServerTimeDelivered = cdnLogEntry.EdgeServerTimeDelivered;

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/PackageStatisticsParserFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/PackageStatisticsParserFacts.cs
@@ -1,0 +1,45 @@
+﻿using Stats.AzureCdnLogs.Common;
+using Stats.ImportAzureCdnStatistics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Tests.Stats.ImportAzureCdnStatistics
+{
+    public class PackageStatisticsParserFacts
+    {
+        [Theory]
+        [InlineData("SemVer1Version", "1.0.0", "1.0.0")]
+        [InlineData("SemVer1VersionPreRel", "1.0.0-beta", "1.0.0-beta")]
+        [InlineData("SemVer2Version", "1.0.0-1.0", "1.0.0-1.0")]
+        [InlineData("System.VersionEndZero", "1.0.0.0", "1.0.0")]
+        [InlineData("System.VersionEndNonZero", "1.0.0.2", "1.0.0.2")]
+        public void PackageVersionsAreParsedCorrectly(string packageId, string packageVersion, string expectedVersion)
+        {
+            // Arrange
+            var logEntry = GetCdnLogEntry($"http://test.me/{packageId}.{packageVersion}.nupkg");
+            var statsParser = new PackageStatisticsParser(null);
+
+            // Act
+            var stats = statsParser.FromCdnLogEntry(logEntry);
+
+            // Assert
+            Assert.Equal(packageId, stats.PackageId);
+            Assert.Equal(expectedVersion, stats.PackageVersion);
+        }
+
+        private CdnLogEntry GetCdnLogEntry(string requestUrl)
+        {
+            return new CdnLogEntry
+            {
+                RequestUrl = requestUrl,
+                EdgeServerTimeDelivered = DateTime.UtcNow,
+                EdgeServerIpAddress = "0.0.0.0",
+                UserAgent = "fakeAgent"
+            };
+        }
+    }
+}

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/PackageStatisticsParserFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/PackageStatisticsParserFacts.cs
@@ -1,10 +1,9 @@
-﻿using Stats.AzureCdnLogs.Common;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Stats.AzureCdnLogs.Common;
 using Stats.ImportAzureCdnStatistics;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Tests.Stats.ImportAzureCdnStatistics

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
@@ -124,6 +124,7 @@
     <Compile Include="LogFileProcessorFacts.cs" />
     <Compile Include="PackageDefinitionFacts.cs" />
     <Compile Include="PackageDimensionFacts.cs" />
+    <Compile Include="PackageStatisticsParserFacts.cs" />
     <Compile Include="PackageTranslatorFacts.cs" />
     <Compile Include="StatisticsParserFacts.cs" />
     <Compile Include="ToolDimensionFacts.cs" />


### PR DESCRIPTION
We are currently missing stats for System.Version versions when we write downloads.v1.json and when the totals are written to the DB.
This was caused by the move from NuGet.Core to NuGet.Versioning.
SemanticVersion from NuGet.Versioning requires strict semVer versions for TryParse, whereas the SemanticVersion from NuGet.Core behaves more like NuGetVersion and allows System.Version versions to parse.

Using NuGetVersion from NuGet.Versioning instead of SemanticVersion fixes this issue.
See https://github.com/NuGet/NuGetGallery/issues/3888 for additional information.

@xavierdecoster @joelverhagen @skofman1 