### PR TITLE
Made VcsValidator to throw exception in case submission fails 

### DIFF
--- a/src/Validation.Common/Validation.Common.csproj
+++ b/src/Validation.Common/Validation.Common.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Validators\Unzip\UnzipValidator.cs" />
     <Compile Include="Validators\ValidationResult.cs" />
     <Compile Include="Validators\ValidatorBase.cs" />
+    <Compile Include="Validators\ValidationException.cs" />
     <Compile Include="Validators\Vcs\VcsValidator.cs" />
     <Compile Include="Validators\Vcs\VcsCallbackServer.cs" />
   </ItemGroup>

--- a/src/Validation.Common/Validators/ValidationException.cs
+++ b/src/Validation.Common/Validators/ValidationException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace NuGet.Jobs.Validation.Common.Validators.Vcs
+{
+    [Serializable]
+    internal class ValidationException : Exception
+    {
+        public ValidationException(string message) : base(message)
+        {
+        }
+
+        public ValidationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected ValidationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Validation.Common/Validators/Vcs/VcsValidator.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsValidator.cs
@@ -90,17 +90,20 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                         message.PackageId,
                         message.PackageVersion,
                         errorMessage);
+                    WriteAuditEntry(auditEntries, $"Submission failed. Error message: {errorMessage}",
+                        ValidationEvent.VirusScanRequestFailed);
+
+                    throw new ValidationException(errorMessage);
                 }
             }
             catch (Exception ex)
             {
                 errorMessage = ex.Message;
                 _logger.TrackValidatorException(ValidatorName, message.ValidationId, ex, message.PackageId, message.PackageVersion);
+                WriteAuditEntry(auditEntries, $"Submission failed. Error message: {errorMessage}",
+                    ValidationEvent.VirusScanRequestFailed);
+                throw;
             }
-
-            WriteAuditEntry(auditEntries, $"Submission failed. Error message: {errorMessage}", 
-                ValidationEvent.VirusScanRequestFailed);
-            return ValidationResult.Failed;
         }
 
         private string BuildStorageUrl(string packageId, string packageVersion)


### PR DESCRIPTION
The calling code retries the submission when exception is thrown instead of failing it right away (if failure was returned).

Added the `ValidationException` class to pass the failure information.