### PR TITLE
Added more verbose logging for the case when callback was not handled by the VCS callback.

### DIFF
--- a/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
@@ -287,10 +287,27 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
 
                 if (!processedRequest)
                 {
-                    _logger.LogWarning(
-                        "Callback was not handled for State={State}, Result={Result}. " +
-                        "Request body: {RequestBody}",
-                        result?.State, result?.Result, TruncateString(body, ReasonableBodySize));
+                    if (validationEntity == null)
+                    {
+                        _logger.LogWarning(
+                            "Callback was not handled for State={State}, Result={Result}. " +
+                            "Request body: {RequestBody}",
+                            result?.State, result?.Result, TruncateString(body, ReasonableBodySize));
+                    }
+                    else
+                    {
+                        _logger.LogWarning(
+                            "Callback was not handled for State={State}, Result={Result}," +
+                            $"{{{TraceConstant.ValidationId}}}, " +
+                            $"Package: {{{TraceConstant.PackageId}}} {{{TraceConstant.PackageVersion}}}. " +
+                            "Request body: {RequestBody}",
+                            result?.State,
+                            result?.Result,
+                            validationEntity.ValidationId,
+                            validationEntity.PackageId,
+                            validationEntity.PackageVersion,
+                            TruncateString(body, ReasonableBodySize));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Currently, even if we have package information for the unhandled VCS callback we don't log it in the "Callback not handled" log message. It makes it more difficult to discover such messages while investigating scan failures for some particular package.