### PR TITLE
Added another success condition for the VCS callback service

### DIFF
--- a/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
@@ -22,6 +22,13 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
     public class VcsCallbackServerStartup
     {
         private readonly VcsStatusCallbackParser _callbackParser = new VcsStatusCallbackParser();
+        private readonly HashSet<string> SuccessResults = new HashSet<string>
+        {
+            "Pass",
+            "PassWithInfo",
+            "PassManual",
+            "PassWithWarn",
+        };
 
         private readonly PackageValidationTable _packageValidationTable;
         private readonly PackageValidationAuditor _packageValidationAuditor;
@@ -220,7 +227,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                     // This denotes scan has completed and we have a pass (or results)
                     if (result.State == State.Complete || result.State == State.Released)
                     {
-                        if (result.Result == "Pass" || result.Result == "PassWithInfo" || result.Result == "PassManual" || result.Result == "PassWithWarn")
+                        if (SuccessResults.Contains(result.Result))
                         {
                             // The result is clean.
                             processedRequest = true;

--- a/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsCallbackServer.cs
@@ -220,7 +220,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
                     // This denotes scan has completed and we have a pass (or results)
                     if (result.State == State.Complete || result.State == State.Released)
                     {
-                        if (result.Result == "Pass" || result.Result == "PassWithInfo" || result.Result == "PassManual")
+                        if (result.Result == "Pass" || result.Result == "PassWithInfo" || result.Result == "PassManual" || result.Result == "PassWithWarn")
                         {
                             // The result is clean.
                             processedRequest = true;


### PR DESCRIPTION
As per communication with DTS service owners, `PassWithWarn` should be treated as success.

Background: we started receiving such callbacks few hours ago.