### PR TITLE
Updating to the latest NuGet.Services.KeyVault on all NuGet.Jobs projects

### DIFF
--- a/SnapshotAzureBlob/App.config
+++ b/SnapshotAzureBlob/App.config
@@ -13,6 +13,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/ArchivePackages/App.config
+++ b/src/ArchivePackages/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
@@ -32,6 +32,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/CopyAzureContainer/App.config
+++ b/src/CopyAzureContainer/App.config
@@ -13,6 +13,10 @@
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Gallery.CredentialExpiration/App.config
+++ b/src/Gallery.CredentialExpiration/App.config
@@ -41,6 +41,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/HandlePackageEdits/App.config
+++ b/src/HandlePackageEdits/App.config
@@ -53,6 +53,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -121,11 +121,11 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.2.1.0\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=2.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.2.2.3\lib\net452\NuGet.Services.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.1.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=2.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.2.3\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -171,7 +171,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Strings.resx" />

--- a/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
@@ -20,14 +20,17 @@ namespace NuGet.Jobs
             var storeName = JobConfigurationManager.TryGetArgument(settings, JobArgumentNames.StoreName);
             var storeLocation = JobConfigurationManager.TryGetArgument(settings, JobArgumentNames.StoreLocation);
 
+            var certificate = CertificateUtility.FindCertificateByThumbprint(
+                storeName != null ? (StoreName)Enum.Parse(typeof(StoreName), storeName) : StoreName.My,
+                storeLocation != null ? (StoreLocation)Enum.Parse(typeof(StoreLocation), storeLocation) : StoreLocation.LocalMachine,
+                JobConfigurationManager.GetArgument(settings, JobArgumentNames.CertificateThumbprint),
+                JobConfigurationManager.TryGetBoolArgument(settings, JobArgumentNames.ValidateCertificate, defaultValue: true));
+
             var keyVaultConfiguration =
                 new KeyVaultConfiguration(
                     JobConfigurationManager.GetArgument(settings, JobArgumentNames.VaultName),
                     JobConfigurationManager.GetArgument(settings, JobArgumentNames.ClientId),
-                    JobConfigurationManager.GetArgument(settings, JobArgumentNames.CertificateThumbprint),
-                    storeName != null ? (StoreName)Enum.Parse(typeof(StoreName), storeName) : StoreName.My,
-                    storeLocation != null ? (StoreLocation)Enum.Parse(typeof(StoreLocation), storeLocation) : StoreLocation.LocalMachine,
-                    JobConfigurationManager.TryGetBoolArgument(settings, JobArgumentNames.ValidateCertificate, defaultValue: true));
+                    certificate);
 
             var refreshIntervalSec = JobConfigurationManager.TryGetIntArgument(settings,
                 JobArgumentNames.RefreshIntervalSec) ?? CachingSecretReader.DefaultRefreshIntervalSec;

--- a/src/NuGet.Jobs.Common/app.config
+++ b/src/NuGet.Jobs.Common/app.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -29,6 +29,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.5.907" newVersion="3.13.5.907" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NuGet.Jobs.Common/packages.config
+++ b/src/NuGet.Jobs.Common/packages.config
@@ -27,8 +27,8 @@
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.2" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="2.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="2.1.0" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="2.2.3" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="2.2.3" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
   <package id="System.IO" version="4.1.0" targetFramework="net452" />

--- a/src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.csproj
+++ b/src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.csproj
@@ -105,14 +105,14 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Configuration, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Configuration.2.1.0\lib\net452\NuGet.Services.Configuration.dll</HintPath>
+    <Reference Include="NuGet.Services.Configuration, Version=2.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Configuration.2.2.3\lib\net452\NuGet.Services.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.1.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=2.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.2.3\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Logging, Version=2.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Logging.2.1.1\lib\net452\NuGet.Services.Logging.dll</HintPath>
+    <Reference Include="NuGet.Services.Logging, Version=2.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Logging.2.2.3\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
@@ -198,8 +198,12 @@
     <EmbeddedResource Include="Templates\EmailStyles.css" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\sign.targets" Condition="Exists('..\..\build\sign.targets')" />

--- a/src/NuGet.SupportRequests.Notifications/app.config
+++ b/src/NuGet.SupportRequests.Notifications/app.config
@@ -22,6 +22,10 @@
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/NuGet.SupportRequests.Notifications/packages.config
+++ b/src/NuGet.SupportRequests.Notifications/packages.config
@@ -22,9 +22,9 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.5" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="NuGet.Services.Configuration" version="2.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="2.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.Logging" version="2.1.1" targetFramework="net452" />
+  <package id="NuGet.Services.Configuration" version="2.2.3" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="2.2.3" targetFramework="net452" />
+  <package id="NuGet.Services.Logging" version="2.2.3" targetFramework="net452" />
   <package id="Serilog" version="2.0.0" targetFramework="net452" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net452" />
   <package id="Serilog.Enrichers.Process" version="2.0.0" targetFramework="net452" />

--- a/src/Search.GenerateAuxiliaryData/App.config
+++ b/src/Search.GenerateAuxiliaryData/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
@@ -32,6 +32,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Stats.AggregateCdnDownloadsInGallery/App.config
+++ b/src/Stats.AggregateCdnDownloadsInGallery/App.config
@@ -33,6 +33,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Stats.CollectAzureCdnLogs/App.config
+++ b/src/Stats.CollectAzureCdnLogs/App.config
@@ -50,6 +50,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Stats.CreateAzureCdnWarehouseReports/App.config
+++ b/src/Stats.CreateAzureCdnWarehouseReports/App.config
@@ -45,6 +45,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Stats.ImportAzureCdnStatistics/App.config
+++ b/src/Stats.ImportAzureCdnStatistics/App.config
@@ -41,6 +41,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Stats.RefreshClientDimension/App.config
+++ b/src/Stats.RefreshClientDimension/App.config
@@ -33,6 +33,10 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Stats.RollUpDownloadFacts/App.config
+++ b/src/Stats.RollUpDownloadFacts/App.config
@@ -41,6 +41,10 @@
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Tests.AppConfig.AzureJobTraceListener/App.config
+++ b/src/Tests.AppConfig.AzureJobTraceListener/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
@@ -39,6 +39,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Tests.Logger/App.config
+++ b/src/Tests.Logger/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
@@ -32,6 +32,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.4.878" newVersion="3.13.4.878" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/UpdateLicenseReports/App.config
+++ b/src/UpdateLicenseReports/App.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
@@ -32,6 +32,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/Tests.Stats.CollectAzureCdnLogs/app.config
+++ b/tests/Tests.Stats.CollectAzureCdnLogs/app.config
@@ -38,6 +38,10 @@
         <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/app.config
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/app.config
@@ -46,6 +46,10 @@
         <assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.3.0" newVersion="2.2.3.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>


### PR DESCRIPTION
Nuget.Jobs.Common was using old version of the NuGet.Services.KeyVault and called an old API that no longer existed in 2.2.3, assembly was remapped to 2.2.3 and this caused run time failures.
Updated `SecretReaderFactory` to call proper methods in the new version.