### PR TITLE
Exception logging for the Validation audit update.

### DIFF
--- a/src/Validation.Common/PackageValidationAuditor.cs
+++ b/src/Validation.Common/PackageValidationAuditor.cs
@@ -98,17 +98,31 @@ namespace NuGet.Jobs.Validation.Common
                 packageId, 
                 packageVersion);
 
-            await StoreAuditAsync(validationId, packageId, packageVersion, 
-                packageValidationAudit =>
-                {
-                    packageValidationAudit.Completed = completed;
-                    return packageValidationAudit;
-                });
+            try
+            {
+                await StoreAuditAsync(validationId, packageId, packageVersion, 
+                    packageValidationAudit =>
+                    {
+                        packageValidationAudit.Completed = completed;
+                        return packageValidationAudit;
+                    });
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(TraceEvent.PackageValidationAuditorException, e, "Failed to update the audit blob for " +
+                        $"validation {{{TraceConstant.ValidationId}}} " +
+                        $"- package {{{TraceConstant.PackageId}}} " +
+                        $"{{{TraceConstant.PackageVersion}}}",
+                    validationId,
+                    packageId,
+                    packageVersion);
+                return;
+            }
 
             _logger.LogInformation("Finished writing Complete PackageValidationAudit for " +
                     $"validation {{{TraceConstant.ValidationId}}} " +
                     $"- package {{{TraceConstant.PackageId}}} " +
-                    $"v. {{{TraceConstant.PackageVersion}}}.",
+                    $"{{{TraceConstant.PackageVersion}}}.",
                 validationId,
                 packageId,
                 packageVersion);

--- a/src/Validation.Common/PackageValidationAuditor.cs
+++ b/src/Validation.Common/PackageValidationAuditor.cs
@@ -116,7 +116,7 @@ namespace NuGet.Jobs.Validation.Common
                     validationId,
                     packageId,
                     packageVersion);
-                return;
+                throw;
             }
 
             _logger.LogInformation("Finished writing Complete PackageValidationAudit for " +

--- a/src/Validation.Common/TraceEvent.cs
+++ b/src/Validation.Common/TraceEvent.cs
@@ -13,6 +13,7 @@ namespace NuGet.Jobs.Validation.Common
         public static readonly EventId FailedToProcessArguments = CreateEventId(3, "Failed to process arguments");
         public static readonly EventId HelperFailed = CreateEventId(4, "Failed to run helper action");
         public static readonly EventId AuditBlobLeaseReleaseFailed = CreateEventId(5, "Exception occurred while trying to release the lease on audit blob");
+        public static readonly EventId PackageValidationAuditorException = CreateEventId(6, "Exception occurred while trying to update the package validation auditing blob");
 
         /// <summary>
         /// Random number used as a base for EventIds and to make sure they don't clash with 


### PR DESCRIPTION
Related to the [eng-492](https://github.com/NuGet/Engineering/issues/492).

It seems that the `blob.UploadTextAsync()` in `PackageValidationAuditor.StoreAuditAsync` call fails and we don't know why. This update should help identifying the reason and then we'd be able to properly fix it.