### PR TITLE
Fix CDN redirection service local build

### DIFF
--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
@@ -151,7 +151,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\AssemblyInfo.g.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="favicon.ico" />


### PR DESCRIPTION
When `Properties\AssemblyInfo.g.cs` is included in the `.csproj`, MSBuild expects the file to ALWAYS be there. Because the file only exists there if you run the build script, Visual Studio always fails to build when running locally.

By changing the reference to `Properties\AssemblyInfo.*.cs`, MSBuild no longer expects the file but simply searches for files that follow the pattern.