### PR TITLE
NuGetCDNRedirect dev box build issue fix

### DIFF
--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
@@ -184,7 +184,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\AssemblyInfo.g.cs" />
+    <Compile Include="Properties\AssemblyInfo.*.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="favicon.ico" />


### PR DESCRIPTION
Fixed local build failure: if build script is not run .g.cs file is not created (build fails in VS).
