### PR TITLE
Build and test scripts fixes

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -101,7 +101,7 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
             "$PSScriptRoot\src\Validation.Helper\Properties\AssemblyInfo.g.cs",
             "$PSScriptRoot\src\CopyAzureContainer\Properties\AssemblyInfo.g.cs",
             "$PSScriptRoot\src\NuGetCDNRedirect\Properties\AssemblyInfo.g.cs",
-            "$PSScriptRoot\src\Validation.Orchestrator\Properties\AssemblyInfo.g.cs",
+            "$PSScriptRoot\src\NuGet.Services.Validation.Orchestrator\Properties\AssemblyInfo.g.cs",
  	    "$PSScriptRoot\src\Stats.CollectAzureChinaCDNLogs\Properties\AssemblyInfo.g.cs"
 
             
@@ -148,7 +148,7 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/Validation.Helper/Validation.Helper.csproj", `
             "src/CopyAzureContainer/CopyAzureContainer.csproj", `
             "src/NuGetCDNRedirect/NuGetCDNRedirect.csproj", `
-            "src/Validation.Orchestrator/Validation.Orchestrator.csproj", `
+            "src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj", `
 	    "src/Stats.CollectAzureChinaCDNLogs/Stats.CollectAzureChinaCDNLogs.csproj"
 
         Foreach ($Project in $Projects) {

--- a/test.ps1
+++ b/test.ps1
@@ -30,7 +30,7 @@ Function Run-Tests {
         "tests\Tests.Stats.ImportAzureCdnStatistics\bin\$Configuration\Tests.Stats.ImportAzureCdnStatistics.dll", `
         "tests\Validation.Helper.Tests\bin\$Configuration\Validation.Helper.Tests.dll",`
 	"tests\Tests.Stats.CollectAzureChinaCDNLogs\bin\$Configuration\Tests.Stats.CollectAzureChinaCDNLogs.dll", `
-        "tests\Tests.Validation.Orchestrator\bin\$Configuration\Tests.Validation.Orchestrator.dll"
+        "tests\NuGet.Services.Validation.Orchestrator.Tests\bin\$Configuration\NuGet.Services.Validation.Orchestrator.Tests.dll"
 
     
     $TestCount = 0


### PR DESCRIPTION
Didn't update the build and test script paths when renamed projects.