### PR TITLE
Add VCS validator for integration with the orchestrator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Error.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Error.cs
@@ -9,5 +9,8 @@ namespace NuGet.Services.Validation.Orchestrator
     {
         public static EventId ConfigurationReadFailure = new EventId(1, "Failed to process configuration");
         public static EventId ConfigurationValidationFailure = new EventId(2, "Configuration is invalid");
+        public static EventId VcsValidationAlreadyStarted = new EventId(3, "VCS validation already started");
+        public static EventId VcsValidationFailureAuditFound = new EventId(4, "VCS validation failure audit found");
+        public static EventId VcsValidationUnexpectedAuditFound = new EventId(5, "VCS validation unexpected audit found");
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ValidateOnlyConfiguration.cs" />
     <Compile Include="ValidationConfiguration.cs" />
     <Compile Include="ValidationConfigurationItem.cs" />
+    <Compile Include="Vcs\VcsValidator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -91,6 +92,12 @@
     <PackageReference Include="NuGet.Services.Logging">
       <Version>2.2.5</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation">
+      <Version>2.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Versioning">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>
     </PackageReference>
@@ -100,11 +107,18 @@
     <PackageReference Include="Serilog.Sinks.Console">
       <Version>3.1.0</Version>
     </PackageReference>
+    <PackageReference Include="WindowsAzure.Storage">
+      <Version>7.1.2</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Validation.Common\Validation.Common.csproj">
+      <Project>{2539ddf3-0cc5-4a03-b5f9-39b47744a7bd}</Project>
+      <Name>Validation.Common</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Validation.Orchestrator/Vcs/VcsValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Vcs/VcsValidator.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage;
+using NuGet.Jobs.Validation.Common;
+using NuGet.Services.Validation.Orchestrator;
+using NuGet.Versioning;
+
+namespace NuGet.Services.Validation.Vcs
+{
+    public class VcsValidator : IValidator
+    {
+        private const string ValidatorName = Jobs.Validation.Common.Validators.Vcs.VcsValidator.ValidatorName;
+
+        private readonly IPackageValidationService _validationService;
+        private readonly IPackageValidationAuditor _validationAuditor;
+        private readonly ILogger<VcsValidator> _logger;
+
+        public VcsValidator(
+            IPackageValidationService validationService,
+            IPackageValidationAuditor validationAuditor,
+            ILogger<VcsValidator> logger)
+        {
+            _validationService = validationService ?? throw new ArgumentNullException(nameof(validationService));
+            _validationAuditor = validationAuditor ?? throw new ArgumentNullException(nameof(validationAuditor));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<ValidationStatus> GetStatusAsync(IValidationRequest request)
+        {
+            var audit = await _validationAuditor.ReadAuditAsync(
+                request.ValidationId,
+                NormalizePackageId(request.PackageId),
+                NormalizePackageVersion(request.PackageVersion));
+
+            if (audit == null)
+            {
+                return ValidationStatus.NotStarted;
+            }
+
+            var validationStatusList = audit
+                .Entries
+                .Where(x => x.ValidatorName == ValidatorName)
+                .Select(x => GetValidationStatus(request, x.EventId))
+                .ToList();
+
+            return validationStatusList.FirstOrDefault(x => x == ValidationStatus.Failed) ??
+                validationStatusList.FirstOrDefault(x => x == ValidationStatus.Succeeded) ??
+                ValidationStatus.Incomplete;
+        }
+
+        private ValidationStatus? GetValidationStatus(IValidationRequest request, ValidationEvent validationEvent)
+        {
+            switch (validationEvent)
+            {
+                case ValidationEvent.ValidatorException:
+                case ValidationEvent.BeforeVirusScanRequest:
+                case ValidationEvent.VirusScanRequestSent:
+                    return ValidationStatus.Incomplete;
+                case ValidationEvent.PackageClean:
+                    return ValidationStatus.Succeeded;
+                case ValidationEvent.PackageNotClean:
+                case ValidationEvent.NotCleanReason:
+                case ValidationEvent.ScanFailed:
+                case ValidationEvent.ScanFailureReason:
+                    _logger.LogError(
+                        Error.VcsValidationFailureAuditFound,
+                        "A failed audit result was found for {validationId} ({packageId} {packageVersion}): {validationEvent}.",
+                        request.ValidationId,
+                        request.PackageId,
+                        request.PackageVersion,
+                        validationEvent);
+                    return ValidationStatus.Failed;
+                default:
+                    _logger.LogError(
+                        Error.VcsValidationUnexpectedAuditFound,
+                        "An unexpected audit result was found for {validationId} ({packageId} {packageVersion}): {validationEvent}.",
+                        request.ValidationId,
+                        request.PackageId,
+                        request.PackageVersion,
+                        validationEvent);
+                    return ValidationStatus.Failed;
+            }
+        }
+
+        public async Task<ValidationStatus> StartValidationAsync(IValidationRequest request)
+        {
+            var normalizedPackageId = NormalizePackageId(request.PackageId);
+            var normalizedPackageVerison = NormalizePackageVersion(request.PackageVersion);
+
+            try
+            {
+                await _validationService.StartValidationProcessAsync(
+                    new NuGetPackage
+                    {
+                        Id = normalizedPackageId,
+                        NormalizedVersion = normalizedPackageVerison,
+                        Version = normalizedPackageVerison,
+                        DownloadUrl = new Uri(request.NupkgUrl),
+                    },
+                    new[] { ValidatorName },
+                    request.ValidationId);
+            }
+            catch (StorageException e) when (e.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.Conflict
+                                             || e.RequestInformation?.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
+            {
+                // This means the validation has already started. This is acceptable so we should move on.
+                _logger.LogWarning(
+                    Error.VcsValidationAlreadyStarted,
+                    e,
+                    "The VCS validation for {validationId} ({packageId} {packageVersion}) has already been started.",
+                    request.ValidationId,
+                    request.PackageId,
+                    request.PackageVersion);
+            }
+
+            return await GetStatusAsync(request);
+        }
+
+        private static string NormalizePackageVersion(string packageVersion)
+        {
+            return NuGetVersion
+                .Parse(packageVersion)
+                .ToNormalizedString()
+                .ToLowerInvariant();
+        }
+
+        private static string NormalizePackageId(string packageId)
+        {
+            return packageId.ToLowerInvariant();
+        }
+    }
+}

--- a/src/Validation.Common/IPackageValidationAuditor.cs
+++ b/src/Validation.Common/IPackageValidationAuditor.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs.Validation.Common
+{
+    /// <summary>
+    /// The interface for reading package audit information. Only the VCS validation is initiated using this interface.
+    /// </summary>
+    public interface IPackageValidationAuditor
+    {
+        /// <summary>
+        /// Reads the validation audit information. The three parameters comprise the audit key.
+        /// </summary>
+        /// <param name="validationId">The validation ID.</param>
+        /// <param name="packageId">The package ID.</param>
+        /// <param name="packageVersion">The package version.</param>
+        /// <returns>The package audit information. <code>null</code> if the audit does not exist.</returns>
+        Task<PackageValidationAudit> ReadAuditAsync(Guid validationId, string packageId, string packageVersion);
+    }
+}

--- a/src/Validation.Common/IPackageValidationService.cs
+++ b/src/Validation.Common/IPackageValidationService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs.Validation.Common
+{
+    /// <summary>
+    /// The interface for starting validations. Only the VCS validation is initiated using this interface.
+    /// </summary>
+    public interface IPackageValidationService
+    {
+        /// <summary>
+        /// Start a validation of the specified package. The validation ID is provided by the caller.
+        /// </summary>
+        /// <param name="package">The package to validate.</param>
+        /// <param name="validators">The well-known names of validators to run.</param>
+        /// <param name="validationId">The validation ID to use.</param>
+        /// <returns>A task that completes when the validation has started.</returns>
+        /// <exception cref="Microsoft.WindowsAzure.Storage.StorageException">Thrown when the validation has already been started.</exception>
+        Task StartValidationProcessAsync(NuGetPackage package, string[] validators, Guid validationId);
+    }
+}

--- a/src/Validation.Common/PackageValidationService.cs
+++ b/src/Validation.Common/PackageValidationService.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -10,7 +9,7 @@ using Microsoft.WindowsAzure.Storage;
 
 namespace NuGet.Jobs.Validation.Common
 {
-    public class PackageValidationService
+    public class PackageValidationService : IPackageValidationService
     {
         private readonly PackageValidationTable _packageValidationTable;
         private readonly PackageValidationQueue _packageValidationQueue;
@@ -27,9 +26,16 @@ namespace NuGet.Jobs.Validation.Common
             _logger = loggerFactory.CreateLogger<PackageValidationService>();
         }
 
-        public async Task StartValidationProcessAsync(NuGetPackage package, string[] validators)
+        public Task StartValidationProcessAsync(NuGetPackage package, string[] validators)
         {
-            var validationId = Guid.NewGuid();
+            return StartValidationProcessAsync(
+                package,
+                validators,
+                Guid.NewGuid());
+        }
+
+        public async Task StartValidationProcessAsync(NuGetPackage package, string[] validators, Guid validationId)
+        {
             var packageId = package.Id;
             var packageVersion = package.GetVersion();
             var created = DateTimeOffset.UtcNow;

--- a/src/Validation.Common/Validation.Common.csproj
+++ b/src/Validation.Common/Validation.Common.csproj
@@ -170,6 +170,8 @@
     <Compile Include="Configuration\IConfigurationService.cs" />
     <Compile Include="INotificationService.cs" />
     <Compile Include="Configuration\ISecretReaderFactory.cs" />
+    <Compile Include="IPackageValidationAuditor.cs" />
+    <Compile Include="IPackageValidationService.cs" />
     <Compile Include="NotificationService.cs" />
     <Compile Include="NugetPackageExtensions.cs" />
     <Compile Include="NuGetPackageQueueExtensions.cs" />

--- a/src/Validation.Common/Validators/Vcs/VcsValidator.cs
+++ b/src/Validation.Common/Validators/Vcs/VcsValidator.cs
@@ -54,8 +54,21 @@ namespace NuGet.Jobs.Validation.Common.Validators.Vcs
             string errorMessage;
             try
             {
+                string packageUrl;
+                if (message.Package.DownloadUrl != null)
+                {
+                    packageUrl = message.Package.DownloadUrl.ToString();
+                }
+                else
+                {
+                    packageUrl = BuildStorageUrl(message.Package.Id, message.PackageVersion);
+                }
+
                 var result = await _scanningService.CreateVirusScanJobAsync(
-                    BuildStorageUrl(message.Package.Id, message.PackageVersion), _callbackUrl, description, message.ValidationId);
+                    packageUrl,
+                    _callbackUrl,
+                    description,
+                    message.ValidationId);
 
                 if (string.IsNullOrEmpty(result.ErrorMessage))
                 {

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="ConfigurationFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Vcs\VcsValidatorFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
@@ -63,6 +64,10 @@
     <ProjectReference Include="..\..\src\NuGet.Services.Validation.Orchestrator\NuGet.Services.Validation.Orchestrator.csproj">
       <Project>{E6D094FB-9068-4578-B176-116F97E7506B}</Project>
       <Name>NuGet.Services.Validation.Orchestrator</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Validation.Common\Validation.Common.csproj">
+      <Project>{2539DDF3-0CC5-4A03-B5F9-39B47744A7BD}</Project>
+      <Name>Validation.Common</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Vcs/VcsValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Vcs/VcsValidatorFacts.cs
@@ -1,0 +1,382 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage;
+using Moq;
+using NuGet.Jobs.Validation.Common;
+using Xunit;
+
+namespace NuGet.Services.Validation.Vcs
+{
+    public class VcsValidatorFacts
+    {
+        private const int PackageKey = 1001;
+        private const string PackageId = "NuGet.Versioning";
+        private const string PackageVersion = "4.3.0.0-ALPHA+git";
+        private static readonly Guid ValidationId = new Guid("fb9c0bac-3d4d-4cc7-ac2d-b3940e15b94d");
+        private const string NupkgUrl = "https://example/nuget.versioning/4.3.0/package.nupkg";
+
+        private const string ValidatorName = "validator-vcs";
+
+        private const string NormalizedPackageId = "nuget.versioning";
+        private const string NormalizedPackageVersion = "4.3.0-alpha";
+
+        public class TheGetStatusMethod : FactsBase
+        {
+            private static readonly ISet<ValidationEvent> IncompleteEvents = new HashSet<ValidationEvent>
+            {
+                ValidationEvent.ValidatorException,
+                ValidationEvent.BeforeVirusScanRequest,
+                ValidationEvent.VirusScanRequestSent,
+            };
+
+            private static readonly ISet<ValidationEvent> SucceededEvents = new HashSet<ValidationEvent>
+            {
+                ValidationEvent.PackageClean,
+            };
+
+            private static readonly ISet<ValidationEvent> FailedEvents = new HashSet<ValidationEvent>(
+                new[] { (ValidationEvent)(-1) }.Concat(Enum
+                    .GetValues(typeof(ValidationEvent))
+                    .Cast<ValidationEvent>()
+                    .Except(IncompleteEvents)
+                    .Except(SucceededEvents)));
+
+            [Fact]
+            public async Task ReturnsNotStartedForNullAudit()
+            {
+                // Arrange & Act
+                var actual = await _target.GetStatusAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.NotStarted, actual);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(ValidationId, NormalizedPackageId, NormalizedPackageVersion),
+                    Times.Once);
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()),
+                    Times.Never);
+            }
+
+            [Theory]
+            [MemberData(nameof(FailedTestData))]
+            public async Task ReturnsFailedIfAuditHasAnyFailedEvents(ValidationEvent validationEvent)
+            {
+                // Arrange
+                _validationAuditor
+                    .Setup(x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(new PackageValidationAudit
+                    {
+                        Entries = new List<PackageValidationAuditEntry>
+                        {
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = ValidatorName,
+                                EventId = IncompleteEvents.First(),
+                            },
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = ValidatorName,
+                                EventId = SucceededEvents.First(),
+                            },
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = ValidatorName,
+                                EventId = validationEvent,
+                            },
+                        },
+                    });
+
+                // Act
+                var actual = await _target.GetStatusAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.Failed, actual);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(ValidationId, NormalizedPackageId, NormalizedPackageVersion),
+                    Times.Once);
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()),
+                    Times.Never);
+            }
+
+            [Theory]
+            [MemberData(nameof(SucceededTestData))]
+            public async Task ReturnsSucceededIfAuditHasNoFailedEvents(ValidationEvent validationEvent)
+            {
+                // Arrange
+                _validationAuditor
+                    .Setup(x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(new PackageValidationAudit
+                    {
+                        Entries = new List<PackageValidationAuditEntry>
+                        {
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = ValidatorName,
+                                EventId = IncompleteEvents.First(),
+                            },
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = ValidatorName,
+                                EventId = validationEvent,
+                            },
+                        },
+                    });
+
+                // Act
+                var actual = await _target.GetStatusAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.Succeeded, actual);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(ValidationId, NormalizedPackageId, NormalizedPackageVersion),
+                    Times.Once);
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()),
+                    Times.Never);
+            }
+
+            [Theory]
+            [MemberData(nameof(IncompleteTestData))]
+            public async Task ReturnsIncompleteIfAuditHasNoFailedOrSucceededEvents(ValidationEvent validationEvent)
+            {
+                // Arrange
+                _validationAuditor
+                    .Setup(x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(new PackageValidationAudit
+                    {
+                        Entries = new List<PackageValidationAuditEntry>
+                        {
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = ValidatorName,
+                                EventId = validationEvent,
+                            },
+                        },
+                    });
+
+                // Act
+                var actual = await _target.GetStatusAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.Incomplete, actual);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(ValidationId, NormalizedPackageId, NormalizedPackageVersion),
+                    Times.Once);
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task ReturnsIncompleteIfAuditHasEventsWithCorrectValidatorName()
+            {
+                // Arrange
+                var someOtherValidatorName = "some-other-validator";
+                _validationAuditor
+                    .Setup(x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(new PackageValidationAudit
+                    {
+                        Entries = new List<PackageValidationAuditEntry>
+                        {
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = someOtherValidatorName,
+                                EventId = ValidationEvent.ScanFailed,
+                            },
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = someOtherValidatorName,
+                                EventId = ValidationEvent.UnzipSucceeeded,
+                            },
+                            new PackageValidationAuditEntry
+                            {
+                                ValidatorName = someOtherValidatorName,
+                                EventId = ValidationEvent.BeforeVirusScanRequest,
+                            },
+                        },
+                    });
+
+                // Act
+                var actual = await _target.GetStatusAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.Incomplete, actual);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(ValidationId, NormalizedPackageId, NormalizedPackageVersion),
+                    Times.Once);
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()),
+                    Times.Never);
+            }
+
+            public static IEnumerable<object[]> IncompleteTestData => IncompleteEvents.Select(e => new object[] { e });
+            public static IEnumerable<object[]> SucceededTestData => SucceededEvents.Select(e => new object[] { e });
+            public static IEnumerable<object[]> FailedTestData => FailedEvents.Select(e => new object[] { e });
+        }
+
+        public class TheStartValidationMethod : FactsBase
+        {
+            private readonly IList<StartedValidation> _started = new List<StartedValidation>();
+
+            public TheStartValidationMethod()
+            {
+                _validationService
+                    .Setup(x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()))
+                    .Returns(Task.FromResult(0))
+                    .Callback<NuGetPackage, string[], Guid>((p, v, i) => _started.Add(new StartedValidation(p, v, i)));
+
+                _validationAuditor
+                    .Setup(x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
+                    .ReturnsAsync(new PackageValidationAudit());
+            }
+
+            [Fact]
+            public async Task UsesTheCorrectPackageForValidation()
+            {
+                // Arrange & Act
+                var status = await _target.StartValidationAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(1, _started.Count);
+                var started = _started[0];
+                Assert.Equal(ValidationId, started.ValidationId);
+                Assert.NotNull(started.Package);
+                Assert.Equal(NormalizedPackageId, started.Package.Id);
+                Assert.Equal(NormalizedPackageVersion, started.Package.Version);
+                Assert.Equal(NormalizedPackageVersion, started.Package.NormalizedVersion);
+                Assert.Equal(NupkgUrl, started.Package.DownloadUrl.ToString());
+                Assert.Equal(new[] { ValidatorName }, started.Validators);
+                Assert.Equal(ValidationStatus.Incomplete, status);
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(
+                        It.IsAny<NuGetPackage>(),
+                        It.IsAny<string[]>(),
+                        It.IsAny<Guid>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+            }
+
+            [Theory]
+            [InlineData(HttpStatusCode.Conflict)]
+            [InlineData(HttpStatusCode.PreconditionFailed)]
+            public async Task IgnoresExceptionsFromAlreadyStartedValidation(HttpStatusCode statusCode)
+            {
+                // Arrange
+                _validationService
+                    .Setup(x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()))
+                    .Throws(new StorageException(
+                        new RequestResult { HttpStatusCode = (int)statusCode },
+                        "Storage exception",
+                        inner: null));
+
+                // Act
+                var status = await _target.StartValidationAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.Incomplete, status);
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(
+                        It.IsAny<NuGetPackage>(),
+                        It.IsAny<string[]>(),
+                        It.IsAny<Guid>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task DoesNotSwallowUnexpectedExceptions()
+            {
+                // Arrange
+                var expected = new FormatException("Something!");
+                _validationService
+                    .Setup(x => x.StartValidationProcessAsync(It.IsAny<NuGetPackage>(), It.IsAny<string[]>(), It.IsAny<Guid>()))
+                    .Throws(expected);
+
+                // Act & Assert
+                var actual = await Assert.ThrowsAsync(
+                    expected.GetType(),
+                    () => _target.StartValidationAsync(_validationRequest.Object));
+                Assert.Same(expected, actual);            
+
+                _validationService.Verify(
+                    x => x.StartValidationProcessAsync(
+                        It.IsAny<NuGetPackage>(),
+                        It.IsAny<string[]>(),
+                        It.IsAny<Guid>()),
+                    Times.Once);
+                _validationAuditor.Verify(
+                    x => x.ReadAuditAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Never);
+            }
+
+            private class StartedValidation
+            {
+                public StartedValidation(NuGetPackage package, string[] validators, Guid validationId)
+                {
+                    Package = package;
+                    Validators = validators;
+                    ValidationId = validationId;
+                }
+
+                public NuGetPackage Package { get; }
+                public string[] Validators { get; }
+                public Guid ValidationId { get; }
+            }
+        }
+
+        public abstract class FactsBase
+        {
+            protected readonly Mock<IPackageValidationService> _validationService;
+            protected readonly Mock<IPackageValidationAuditor> _validationAuditor;
+            protected readonly Mock<ILogger<VcsValidator>> _logger;
+            protected readonly Mock<IValidationRequest> _validationRequest;
+            protected readonly VcsValidator _target;
+
+            public FactsBase()
+            {
+                _validationService = new Mock<IPackageValidationService>();
+                _validationAuditor = new Mock<IPackageValidationAuditor>();
+                _logger = new Mock<ILogger<VcsValidator>>();
+
+                _validationRequest = new Mock<IValidationRequest>();
+                _validationRequest.Setup(x => x.NupkgUrl).Returns(NupkgUrl);
+                _validationRequest.Setup(x => x.PackageId).Returns(PackageId);
+                _validationRequest.Setup(x => x.PackageKey).Returns(PackageKey);
+                _validationRequest.Setup(x => x.PackageVersion).Returns(PackageVersion);
+                _validationRequest.Setup(x => x.ValidationId).Returns(ValidationId);
+
+                _target = new VcsValidator(
+                    _validationService.Object,
+                    _validationAuditor.Object,
+                    _logger.Object);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/764.

Note that this PR is depending on a non-existent NuGet.Services.Validation 2.3.0 package. I won't merge this PR till this package exists (blocked by signing).

This integrates the orchestrator with our existing VCS validator. The persistent store that the validator is using to store its own validation state is the Azure Blob Storage audit trail. This is just like how our VCS monitoring works (by reading the audit state).

The existing VCS validator code will always see a lowercase package ID and a normalized + lowercase package version. This is to avoid casing and normalization issues in audit store.

In general, any non-Success and non-Incomplete audit event is considered a failure. Failure events take precedence over Succeeded. Succeeded takes precedence over Incomplete.