### PR TITLE
Add configuration for the VcsValidator and integrate with DI

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -5,12 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Autofac;
+using Autofac.Core;
 using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs;
+using NuGet.Jobs.Validation.Common;
 using NuGet.Services.Configuration;
+using NuGet.Services.Validation.Vcs;
 
 namespace NuGet.Services.Validation.Orchestrator
 {
@@ -20,7 +25,10 @@ namespace NuGet.Services.Validation.Orchestrator
         private const string ValidateArgument = "Validate";
 
         private const string ConfigurationSectionName = "Configuration";
+        private const string VcsSectionName = "Vcs";
         private const string ValidateOnlyConfigurationKey = nameof(ValidateOnlyConfiguration.ValidateOnly);
+
+        private const string VcsBindingKey = VcsSectionName;
 
         private string _configurationFilename;
         private bool _validateOnly;
@@ -89,14 +97,48 @@ namespace NuGet.Services.Validation.Orchestrator
         private void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
             services.Configure<ValidationConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
+            services.Configure<VcsConfiguration>(configurationRoot.GetSection(VcsSectionName));
             services.Configure<ValidateOnlyConfiguration>(configurationRoot);
             services.AddTransient<ConfigurationValidator>();
+            services.AddTransient<VcsValidator>();
         }
 
         private static IServiceProvider CreateProvider(IServiceCollection services)
         {
             var containerBuilder = new ContainerBuilder();
             containerBuilder.Populate(services);
+
+            /// Initialize dependencies for the <see cref="VcsValidator"/>. There is some additional complexity here
+            /// because the implementations require ambiguous types (such as a <see cref="string"/> and a
+            /// <see cref="CloudStorageAccount"/> which there may be more than one configuration of).
+            containerBuilder
+                .Register(c =>
+                {
+                    var vcsConfiguration = c.Resolve<IOptionsSnapshot<VcsConfiguration>>();
+                    var cloudStorageAccount = CloudStorageAccount.Parse(vcsConfiguration.Value.DataStorageAccount);
+                    return cloudStorageAccount;
+                })
+                .Keyed<CloudStorageAccount>(VcsBindingKey);
+
+            containerBuilder
+                .RegisterType<PackageValidationService>()
+                .WithParameter(new ResolvedParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(CloudStorageAccount),
+                    (pi, ctx) => ctx.ResolveKeyed<CloudStorageAccount>(VcsBindingKey)))
+                .WithParameter(new ResolvedParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(string),
+                    (pi, ctx) => ctx.Resolve<IOptionsSnapshot<VcsConfiguration>>().Value.ContainerName))
+                .As<IPackageValidationService>();
+
+            containerBuilder
+                .RegisterType<PackageValidationAuditor>()
+                .WithParameter(new ResolvedParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(CloudStorageAccount),
+                    (pi, ctx) => ctx.ResolveKeyed<CloudStorageAccount>(VcsBindingKey)))
+                .WithParameter(new ResolvedParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(string),
+                    (pi, ctx) => ctx.Resolve<IOptionsSnapshot<VcsConfiguration>>().Value.ContainerName))
+                .As<IPackageValidationAuditor>();
 
             return new AutofacServiceProvider(containerBuilder.Build());
         }

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ValidateOnlyConfiguration.cs" />
     <Compile Include="ValidationConfiguration.cs" />
     <Compile Include="ValidationConfigurationItem.cs" />
+    <Compile Include="Vcs\VcsConfiguration.cs" />
     <Compile Include="Vcs\VcsValidator.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/Vcs/VcsConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Vcs/VcsConfiguration.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.Validation.Vcs
+{
+    /// <summary>
+    /// Configuration for initializing the <see cref="VcsValidator"/>.
+    /// </summary>
+    public class VcsConfiguration
+    {
+        /// <summary>
+        /// The container name to use for VCS storage resources (table, queue, and blob storage).
+        /// </summary>
+        public string ContainerName { get; set; }
+
+        /// <summary>
+        /// The connection string to use to connect to an Azure Storage account.
+        /// </summary>
+        public string DataStorageAccount { get; set; }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -8,6 +8,10 @@
       }
     ]
   },
+  "Vcs": {
+    "ContainerName": "validation",
+    "DataStorageAccount": "UseDevelopmentStorage=true"
+  },
   "KeyVault_VaultName": "",
   "KeyVault_ClientId": "",
   "KeyVault_CertificateThumbprint": "",


### PR DESCRIPTION
Follow up on https://github.com/NuGet/NuGet.Jobs/pull/218.  Address https://github.com/NuGet/Engineering/issues/764.

Since there are `CloudStorageAccount` and `string` dependencies in `PackageValidationService` and `IPackageValidationAuditor`, use Autofac's keyed bindings. It is quite likely more `CloudStorageAccount` instances will need to be registered with different connection strings.