### PR TITLE
 Added basic Package Signature Validator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Error.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Error.cs
@@ -12,5 +12,7 @@ namespace NuGet.Services.Validation.Orchestrator
         public static EventId VcsValidationAlreadyStarted = new EventId(3, "VCS validation already started");
         public static EventId VcsValidationFailureAuditFound = new EventId(4, "VCS validation failure audit found");
         public static EventId VcsValidationUnexpectedAuditFound = new EventId(5, "VCS validation unexpected audit found");
+
+        public static EventId PackageSigningValidationAlreadyStarted = new EventId(100, "Package Signing validation already started");
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
@@ -8,37 +8,39 @@ namespace NuGet.Services.Validation.Orchestrator
     /// <summary>
     /// A service used to persist a <see cref="IValidator"/>'s validation statuses.
     /// </summary>
-    /// <typeparam name="TValidator">The validator whose statuses this service persists.</typeparam>
-    public interface IValidatorStateService<TValidator>
-        where TValidator : IValidator
+    public interface IValidatorStateService
     {
         /// <summary>
         /// Get the persisted <see cref="ValidatorStatus"/> for the given <see cref="IValidationRequest"/>.
         /// </summary>
+        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
         /// <param name="request">The request whose status should be fetched.</param>
         /// <returns>The persisted status of the validation request, or, a new ValidatorStatus if no status has been persisted.</returns>
-        ValidatorStatus GetStatus(IValidationRequest request);
+        Task<ValidatorStatus> GetStatusAsync(string validatorName, IValidationRequest request);
 
         /// <summary>
         /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/> by
         /// a different validation request.
         /// </summary>
+        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
         /// <param name="request">The package validation request.</param>
         /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package in a different validation request.</returns>
-        bool IsRevalidationRequest(IValidationRequest request);
+        Task<bool> IsRevalidationRequestAsync(string validatorName, IValidationRequest request);
 
         /// <summary>
         /// Persist the status of a new validation request.
         /// </summary>
+        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
         /// <param name="status">The status of the given validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        Task AddStatusAsync(ValidatorStatus status);
+        Task AddStatusAsync(string validatorName, ValidatorStatus status);
 
         /// <summary>
         /// Persist the status of an already existing validation request.
         /// </summary>
+        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
         /// <param name="status">The updated status for the validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        Task SaveStatusAsync(ValidatorStatus status);
+        Task SaveStatusAsync(string validatorName, ValidatorStatus status);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    /// <summary>
+    /// A service used to persist a <see cref="IValidator"/>'s validation statuses.
+    /// </summary>
+    /// <typeparam name="TValidator">The validator whose statuses this service persists.</typeparam>
+    public interface IValidatorStateService<TValidator>
+        where TValidator : IValidator
+    {
+        /// <summary>
+        /// Get the persisted <see cref="ValidationStatus"/> for the given <see cref="IValidationRequest"/>.
+        /// </summary>
+        /// <param name="request">The request whose status should be fetched.</param>
+        /// <returns>The persisted status of the validation request.</returns>
+        ValidationStatus GetStatus(IValidationRequest request);
+
+        /// <summary>
+        /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/>.
+        /// </summary>
+        /// <param name="request">The package validation request.</param>
+        /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package.</returns>
+        bool IsRevalidationRequest(IValidationRequest request);
+
+        /// <summary>
+        /// Persist the status of a new validation request.
+        /// </summary>
+        /// <param name="request">The validation request whose state has never been persisted before.</param>
+        /// <param name="status">The status of the given validation request.</param>
+        /// <returns>A task that completes when the status has been persisted.</returns>
+        Task AddStatusAsync(IValidationRequest request, ValidationStatus status);
+
+        /// <summary>
+        /// Persist the status of an already existing validation request.
+        /// </summary>
+        /// <param name="request">The validation request whose status will be updated.</param>
+        /// <param name="status">The updated status for the validation request.</param>
+        /// <returns>A task that completes when the status has been persisted.</returns>
+        Task SaveStatusAsync(IValidationRequest request, ValidationStatus status);
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
@@ -41,6 +41,7 @@ namespace NuGet.Services.Validation.Orchestrator
         /// <param name="validatorName">The unique name for the validator performing the validation.</param>
         /// <param name="status">The updated status for the validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
+        /// <exception cref="System.Data.Entity.Infrastructure.DbUpdateConcurrencyException">Thrown when the status had already been updated.</exception>
         Task SaveStatusAsync(string validatorName, ValidatorStatus status);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
@@ -13,33 +13,32 @@ namespace NuGet.Services.Validation.Orchestrator
         where TValidator : IValidator
     {
         /// <summary>
-        /// Get the persisted <see cref="ValidationStatus"/> for the given <see cref="IValidationRequest"/>.
+        /// Get the persisted <see cref="ValidatorStatus"/> for the given <see cref="IValidationRequest"/>.
         /// </summary>
         /// <param name="request">The request whose status should be fetched.</param>
-        /// <returns>The persisted status of the validation request.</returns>
-        ValidationStatus GetStatus(IValidationRequest request);
+        /// <returns>The persisted status of the validation request, or, a new ValidatorStatus if no status has been persisted.</returns>
+        ValidatorStatus GetStatus(IValidationRequest request);
 
         /// <summary>
-        /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/>.
+        /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/> by
+        /// a different validation request.
         /// </summary>
         /// <param name="request">The package validation request.</param>
-        /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package.</returns>
+        /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package in a different validation request.</returns>
         bool IsRevalidationRequest(IValidationRequest request);
 
         /// <summary>
         /// Persist the status of a new validation request.
         /// </summary>
-        /// <param name="request">The validation request whose state has never been persisted before.</param>
         /// <param name="status">The status of the given validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        Task AddStatusAsync(IValidationRequest request, ValidationStatus status);
+        Task AddStatusAsync(ValidatorStatus status);
 
         /// <summary>
         /// Persist the status of an already existing validation request.
         /// </summary>
-        /// <param name="request">The validation request whose status will be updated.</param>
         /// <param name="status">The updated status for the validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        Task SaveStatusAsync(IValidationRequest request, ValidationStatus status);
+        Task SaveStatusAsync(ValidatorStatus status);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidatorStateService.cs
@@ -6,6 +6,41 @@ using System.Threading.Tasks;
 namespace NuGet.Services.Validation.Orchestrator
 {
     /// <summary>
+    /// The possible results for <see cref="IValidatorStateService.AddStatusAsync(string, ValidatorStatus)"/>.
+    /// </summary>
+    public enum AddStatusResult
+    {
+        /// <summary>
+        /// Successfully persisted the <see cref="ValidatorStatus"/>.
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// Failed to persist the <see cref="ValidatorStatus"/> as a status already
+        /// exists with the same validation id.
+        /// </summary>
+        StatusAlreadyExists,
+    }
+
+    /// <summary>
+    /// The possible results for <see cref="IValidatorStateService.SaveStatusAsync(string, ValidatorStatus)"/>.
+    /// </summary>
+    public enum SaveStatusResult
+    {
+        /// <summary>
+        /// Successfully persisted the updated <see cref="ValidatorStatus"/>
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// The <see cref="ValidatorStatus"/> is stale. The status should be refetched using
+        /// <see cref="IValidatorStateService.GetStatusAsync(string, IValidationRequest)"/> before attempting
+        /// to save again.
+        /// </summary>
+        StaleStatus,
+    }
+
+    /// <summary>
     /// A service used to persist a <see cref="IValidator"/>'s validation statuses.
     /// </summary>
     public interface IValidatorStateService
@@ -13,35 +48,34 @@ namespace NuGet.Services.Validation.Orchestrator
         /// <summary>
         /// Get the persisted <see cref="ValidatorStatus"/> for the given <see cref="IValidationRequest"/>.
         /// </summary>
-        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
+        /// <typeparam name="T">The <see cref="IValidator"/> whose status should be fetched.</typeparam>
         /// <param name="request">The request whose status should be fetched.</param>
         /// <returns>The persisted status of the validation request, or, a new ValidatorStatus if no status has been persisted.</returns>
-        Task<ValidatorStatus> GetStatusAsync(string validatorName, IValidationRequest request);
+        Task<ValidatorStatus> GetStatusAsync<T>(IValidationRequest request) where T : IValidator;
 
         /// <summary>
         /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/> by
         /// a different validation request.
         /// </summary>
-        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
+        /// <typeparam name="T">The <see cref="IValidator"/> whose statuses should be evaluated.</typeparam>
         /// <param name="request">The package validation request.</param>
         /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package in a different validation request.</returns>
-        Task<bool> IsRevalidationRequestAsync(string validatorName, IValidationRequest request);
+        Task<bool> IsRevalidationRequestAsync<T>(IValidationRequest request) where T : IValidator;
 
         /// <summary>
         /// Persist the status of a new validation request.
         /// </summary>
-        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
+        /// <typeparam name="T">The <see cref="IValidator"/> whose status should be added.</typeparam>
         /// <param name="status">The status of the given validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        Task AddStatusAsync(string validatorName, ValidatorStatus status);
+        Task<AddStatusResult> AddStatusAsync<T>(ValidatorStatus status) where T : IValidator;
 
         /// <summary>
         /// Persist the status of an already existing validation request.
         /// </summary>
-        /// <param name="validatorName">The unique name for the validator performing the validation.</param>
+        /// <typeparam name="T">The <see cref="IValidator"/> whose status should be saved.</typeparam>
         /// <param name="status">The updated status for the validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        /// <exception cref="System.Data.Entity.Infrastructure.DbUpdateConcurrencyException">Thrown when the status had already been updated.</exception>
-        Task SaveStatusAsync(string validatorName, ValidatorStatus status);
+        Task<SaveStatusResult> SaveStatusAsync<T>(ValidatorStatus status) where T : IValidator;
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -47,12 +47,16 @@
     <Compile Include="ConfigurationValidator.cs" />
     <Compile Include="Error.cs" />
     <Compile Include="Job.cs" />
+    <Compile Include="PackageSigning\IPackageSignatureVerifier.cs" />
+    <Compile Include="PackageSigning\PackageSignatureVerifier.cs" />
+    <Compile Include="PackageSigning\PackageSigningValidator.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="ValidateOnlyConfiguration.cs" />
     <Compile Include="ValidationConfiguration.cs" />
     <Compile Include="ValidationConfigurationItem.cs" />
+    <Compile Include="ValidatorStateService.cs" />
     <Compile Include="Vcs\VcsConfiguration.cs" />
     <Compile Include="Vcs\VcsValidator.cs" />
   </ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="ConfigurationValidator.cs" />
     <Compile Include="Error.cs" />
+    <Compile Include="IValidatorStateService.cs" />
     <Compile Include="Job.cs" />
     <Compile Include="PackageSigning\IPackageSignatureVerifier.cs" />
     <Compile Include="PackageSigning\PackageSignatureVerifier.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/IPackageSignatureVerifier.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/IPackageSignatureVerifier.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    /// <summary>
+    /// Kicks off package signature verification.
+    /// </summary>
+    public interface IPackageSignatureVerifier
+    {
+        /// <summary>
+        /// Kicks off the package verification process for the given request. Verification will begin when the
+        /// <see cref="ValidationEntitiesContext"/> has a <see cref="ValidatorStatus"/> that matches the
+        /// <see cref="IValidationRequest"/>'s validationId. Once verification completes, the <see cref="ValidatorStatus"/>'s
+        /// State will be updated to "Succeeded" or "Failed".
+        /// </summary>
+        /// <param name="request">The request that details the package to be verified.</param>
+        /// <returns>A task that will complete when the verification process has been queued.</returns>
+        Task StartVerificationAsync(IValidationRequest request);
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSignatureVerifier.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSignatureVerifier.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using NuGet.Services.ServiceBus;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    /// <summary>
+    /// Kicks off package signature verifications.
+    /// </summary>
+    public class PackageSignatureVerifier
+    {
+        private readonly ITopicClient _topicClient;
+
+        public PackageSignatureVerifier(ITopicClient topicClient)
+        {
+            _topicClient = topicClient ?? throw new ArgumentNullException(nameof(topicClient));
+        }
+
+        /// <summary>
+        /// Kicks off the package verification process for the given request. Verification will begin when the
+        /// <see cref="ValidationEntitiesContext"/> has a <see cref="ValidatorStatus"/> that matches the
+        /// <see cref="IValidationRequest"/>'s validationId. Once verification completes, the <see cref="ValidatorStatus"/>'s
+        /// State will be updated to "Succeeded" or "Failed".
+        /// </summary>
+        /// <param name="request">The request that details the package to be verified.</param>
+        /// <returns>A task that will complete when the verification process has been queued.</returns>
+        public Task StartVerificationAsync(IValidationRequest request)
+        {
+            // TODO:
+            // 1. Serialize the request into a IBrokeredMessage
+            // 2. _topicClient.SendAsync(message);
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSignatureVerifier.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSignatureVerifier.cs
@@ -10,7 +10,7 @@ namespace NuGet.Services.Validation.PackageSigning
     /// <summary>
     /// Kicks off package signature verifications.
     /// </summary>
-    public class PackageSignatureVerifier
+    public class PackageSignatureVerifier : IPackageSignatureVerifier
     {
         private readonly ITopicClient _topicClient;
 

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningValidator.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.Validation.Orchestrator;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    using ValidatorStateService = IValidatorStateService<PackageSigningValidator>;
+
+    public class PackageSigningValidator : IValidator
+    {
+        private readonly ValidatorStateService _validatorStateService;
+        private readonly IPackageSignatureVerifier _packageSignatureVerifier;
+        private readonly ILogger<PackageSigningValidator> _logger;
+
+        public PackageSigningValidator(
+            ValidatorStateService validatorStateService,
+            IPackageSignatureVerifier packageSignatureVerifier,
+            ILogger<PackageSigningValidator> logger)
+        {
+            _validatorStateService = validatorStateService ?? throw new ArgumentNullException(nameof(validatorStateService));
+            _packageSignatureVerifier = packageSignatureVerifier ?? throw new ArgumentNullException(nameof(packageSignatureVerifier));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task<ValidationStatus> GetStatusAsync(IValidationRequest request)
+        {
+            return Task.FromResult(_validatorStateService.GetStatus(request));
+        }
+
+        public async Task<ValidationStatus> StartValidationAsync(IValidationRequest request)
+        {
+            // Check that this is the first validation for this specific request.
+            var currentStatus = await GetStatusAsync(request);
+
+            if (currentStatus != ValidationStatus.NotStarted)
+            {
+                _logger.LogError(
+                    Error.PackageSigningValidationAlreadyStarted,
+                    "Package Signing validation with validationId {validationId} ({packageId} {packageVersion}) has already started.",
+                    request.ValidationId,
+                    request.PackageId,
+                    request.PackageVersion);
+
+                throw new Exception("TODO: What's the exception if the job has already started?");
+            }
+
+            // Kick off the verification process. Note that the jobs will not verify the package until the
+            // state of this validator has been persisted to the database.
+            await _packageSignatureVerifier.StartVerificationAsync(request);
+            await _validatorStateService.AddStatusAsync(request, ValidationStatus.Incomplete);
+
+            return ValidationStatus.Incomplete;
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/ValidatorStateService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidatorStateService.cs
@@ -7,44 +7,6 @@ using System.Threading.Tasks;
 
 namespace NuGet.Services.Validation.Orchestrator
 {
-    /// <summary>
-    /// A service used to persist a <see cref="IValidator"/>'s validation statuses.
-    /// </summary>
-    /// <typeparam name="TValidator">The validator whose statuses this service persists.</typeparam>
-    public interface IValidatorStateService<TValidator>
-        where TValidator : IValidator
-    {
-        /// <summary>
-        /// Get the persisted <see cref="ValidationStatus"/> for the given <see cref="IValidationRequest"/>.
-        /// </summary>
-        /// <param name="request">The request whose status should be fetched.</param>
-        /// <returns>The persisted status of the validation request.</returns>
-        ValidationStatus GetStatus(IValidationRequest request);
-
-        /// <summary>
-        /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/>.
-        /// </summary>
-        /// <param name="request">The package validation request.</param>
-        /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package.</returns>
-        bool IsRevalidationRequest(IValidationRequest request);
-
-        /// <summary>
-        /// Persist the status of a new validation request.
-        /// </summary>
-        /// <param name="request">The validation request whose state has never been persisted before.</param>
-        /// <param name="status">The status of the given validation request.</param>
-        /// <returns>A task that completes when the status has been persisted.</returns>
-        Task AddStatusAsync(IValidationRequest request, ValidationStatus status);
-
-        /// <summary>
-        /// Persist the status of an already existing validation request.
-        /// </summary>
-        /// <param name="request">The validation request whose status will be updated.</param>
-        /// <param name="status">The updated status for the validation request.</param>
-        /// <returns>A task that completes when the status has been persisted.</returns>
-        Task SaveStatusAsync(IValidationRequest request, ValidationStatus status);
-    }
-
     public class ValidatorStateService<TValidator> : IValidatorStateService<TValidator>
         where TValidator : IValidator
     {

--- a/src/NuGet.Services.Validation.Orchestrator/ValidatorStateService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidatorStateService.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    /// <summary>
+    /// A service used to persist a <see cref="IValidator"/>'s validation statuses.
+    /// </summary>
+    /// <typeparam name="TValidator">The validator whose statuses this service persists.</typeparam>
+    public interface IValidatorStateService<TValidator>
+        where TValidator : IValidator
+    {
+        /// <summary>
+        /// Get the persisted <see cref="ValidationStatus"/> for the given <see cref="IValidationRequest"/>.
+        /// </summary>
+        /// <param name="request">The request whose status should be fetched.</param>
+        /// <returns>The persisted status of the validation request.</returns>
+        ValidationStatus GetStatus(IValidationRequest request);
+
+        /// <summary>
+        /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/>.
+        /// </summary>
+        /// <param name="request">The package validation request.</param>
+        /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package.</returns>
+        bool IsRevalidationRequest(IValidationRequest request);
+
+        /// <summary>
+        /// Persist the status of a new validation request.
+        /// </summary>
+        /// <param name="request">The validation request whose state has never been persisted before.</param>
+        /// <param name="status">The status of the given validation request.</param>
+        /// <returns>A task that completes when the status has been persisted.</returns>
+        Task AddStatusAsync(IValidationRequest request, ValidationStatus status);
+
+        /// <summary>
+        /// Persist the status of an already existing validation request.
+        /// </summary>
+        /// <param name="request">The validation request whose status will be updated.</param>
+        /// <param name="status">The updated status for the validation request.</param>
+        /// <returns>A task that completes when the status has been persisted.</returns>
+        Task SaveStatusAsync(IValidationRequest request, ValidationStatus status);
+    }
+
+    public class ValidatorStateService<TValidator> : IValidatorStateService<TValidator>
+        where TValidator : IValidator
+    {
+        private IValidationEntitiesContext _validationContext;
+        private string _validatorName;
+
+        public ValidatorStateService(IValidationEntitiesContext validationContext)
+        {
+            _validationContext = validationContext ?? throw new ArgumentNullException(nameof(validationContext));
+            _validatorName = typeof(TValidator).Name;
+        }
+
+        public ValidationStatus GetStatus(IValidationRequest request)
+        {
+            var status = _validationContext
+                .ValidatorStatuses
+                .Where(s => s.ValidationId == request.ValidationId)
+                .FirstOrDefault();
+
+            return status?.State ?? ValidationStatus.NotStarted;
+        }
+
+        public bool IsRevalidationRequest(IValidationRequest request)
+        {
+            return _validationContext
+                        .ValidatorStatuses
+                        .Where(s => s.PackageKey == request.PackageKey)
+                        .Where(s => s.ValidatorName == _validatorName)
+                        .Where(s => s.ValidationId != request.ValidationId)
+                        .Any();
+        }
+
+        public async Task AddStatusAsync(IValidationRequest request, ValidationStatus status)
+        {
+            _validationContext.ValidatorStatuses.Add(new ValidatorStatus
+            {
+                ValidationId = request.ValidationId,
+                PackageKey = request.PackageKey,
+                ValidatorName = _validatorName,
+                State = status,
+            });
+
+            await _validationContext.SaveChangesAsync();
+        }
+
+        public async Task SaveStatusAsync(IValidationRequest request, ValidationStatus status)
+        {
+            var entity = _validationContext
+                            .ValidatorStatuses
+                            .Where(s => s.ValidationId == request.ValidationId)
+                            .First();
+
+            entity.State = status;
+
+            await _validationContext.SaveChangesAsync();
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -45,6 +45,8 @@
     <Compile Include="ConfigurationFacts.cs" />
     <Compile Include="PackageSigning\PackageSigningValidatorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ValidationContextHelpers.cs" />
+    <Compile Include="ValidatorStateServiceFacts.cs" />
     <Compile Include="Vcs\VcsValidatorFacts.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -43,6 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConfigurationFacts.cs" />
+    <Compile Include="PackageSigning\PackageSigningValidatorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Vcs\VcsValidatorFacts.cs" />
   </ItemGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
@@ -36,7 +36,7 @@ namespace NuGet.Services.Validation.PackageSigning
             {
                 // Arrange
                 _validatorStateService
-                    .Setup(x => x.GetStatusAsync(It.IsAny<string>(), It.IsAny<IValidationRequest>()))
+                    .Setup(x => x.GetStatusAsync<PackageSigningValidator>(It.IsAny<IValidationRequest>()))
                     .ReturnsAsync(new ValidatorStatus
                     {
                         ValidationId = ValidationId,
@@ -69,7 +69,7 @@ namespace NuGet.Services.Validation.PackageSigning
             {
                 // Arrange
                 _validatorStateService
-                     .Setup(x => x.GetStatusAsync(It.IsAny<string>(), It.IsAny<IValidationRequest>()))
+                     .Setup(x => x.GetStatusAsync<PackageSigningValidator>(It.IsAny<IValidationRequest>()))
                      .ReturnsAsync(new ValidatorStatus
                      {
                          ValidationId = ValidationId,
@@ -85,7 +85,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     .Verify(x => x.StartVerificationAsync(It.IsAny<IValidationRequest>()), Times.Never);
 
                 _validatorStateService
-                    .Verify(x => x.AddStatusAsync(It.IsAny<string>(), It.IsAny<ValidatorStatus>()), Times.Never);
+                    .Verify(x => x.AddStatusAsync<PackageSigningValidator>(It.IsAny<ValidatorStatus>()), Times.Never);
             }
 
             [Fact]
@@ -97,7 +97,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 bool verificationQueuedBeforeStatePersisted = false;
 
                 _validatorStateService
-                     .Setup(x => x.GetStatusAsync(It.IsAny<string>(), It.IsAny<IValidationRequest>()))
+                     .Setup(x => x.GetStatusAsync<PackageSigningValidator>(It.IsAny<IValidationRequest>()))
                      .ReturnsAsync(new ValidatorStatus
                      {
                          ValidationId = ValidationId,
@@ -115,12 +115,12 @@ namespace NuGet.Services.Validation.PackageSigning
                     .Returns(Task.FromResult(0));
 
                 _validatorStateService
-                    .Setup(x => x.AddStatusAsync(It.IsAny<string>(), It.IsAny<ValidatorStatus>()))
+                    .Setup(x => x.AddStatusAsync<PackageSigningValidator>(It.IsAny<ValidatorStatus>()))
                     .Callback(() =>
                     {
                         statePersisted = true;
                     })
-                    .Returns(Task.FromResult(0));
+                    .Returns(Task.FromResult(AddStatusResult.Success));
 
                 // Act
                 var actualStatus = await _target.StartValidationAsync(_validationRequest.Object);
@@ -131,8 +131,7 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _validatorStateService
                     .Verify(
-                        x => x.AddStatusAsync(
-                                It.IsAny<string>(),
+                        x => x.AddStatusAsync<PackageSigningValidator>(
                                 It.Is<ValidatorStatus>(s => s.State == ValidationStatus.Incomplete)),
                         Times.Once);
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Services.Validation.Orchestrator;
+using Xunit;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    public class PackageSigningValidatorFacts
+    {
+        private const int PackageKey = 1001;
+        private const string PackageId = "NuGet.Versioning";
+        private const string PackageVersion = "4.3.0.0-ALPHA+git";
+        private static readonly Guid ValidationId = new Guid("fb9c0bac-3d4d-4cc7-ac2d-b3940e15b94d");
+        private const string NupkgUrl = "https://example/nuget.versioning/4.3.0/package.nupkg";
+
+        public class TheGetStatusMethod : FactsBase
+        {
+            private static readonly ValidationStatus[] possibleValidationStatuses = new ValidationStatus[]
+            {
+                ValidationStatus.Failed,
+                ValidationStatus.Incomplete,
+                ValidationStatus.NotStarted,
+                ValidationStatus.Succeeded,
+            };
+
+            [Theory]
+            [MemberData(nameof(PossibleValidationStatuses))]
+            public async Task ReturnsPersistedStatus(ValidationStatus status)
+            {
+                // Arrange
+                _validatorStateService
+                    .Setup(x => x.GetStatus(It.IsAny<IValidationRequest>()))
+                    .Returns(status);
+
+                // Act & Assert
+                var actual = await _target.GetStatusAsync(_validationRequest.Object);
+
+                Assert.Equal(status, actual);
+            }
+
+            public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
+        }
+
+        public class TheStartValidationAsyncMethod : FactsBase
+        {
+            private static readonly ValidationStatus[] startedValidationStatuses = new ValidationStatus[]
+            {
+                ValidationStatus.Failed,
+                ValidationStatus.Incomplete,
+                ValidationStatus.Succeeded,
+            };
+
+            [Theory]
+            [MemberData(nameof(StartedValidationStatuses))]
+            public async Task ThrowsIfValidationAlreadyStarted(ValidationStatus status)
+            {
+                // Arrange
+                _validatorStateService
+                     .Setup(x => x.GetStatus(It.IsAny<IValidationRequest>()))
+                     .Returns(status);
+
+                // Act & Assert
+                // TODO: More specific exception!
+                await Assert.ThrowsAsync<Exception>(() => _target.StartValidationAsync(_validationRequest.Object));
+            }
+
+            [Fact]
+            public async Task StartsValidationIfNotStarted()
+            {
+                // Arrange
+                // The order of operations is important! The state MUST be persisted AFTER verification has been queued.
+                var statePersisted = false;
+                bool verificationQueuedBeforeStatePersisted = false;
+
+                _validatorStateService
+                     .Setup(x => x.GetStatus(It.IsAny<IValidationRequest>()))
+                     .Returns(ValidationStatus.NotStarted);
+
+                _packageSignatureVerifier
+                    .Setup(x => x.StartVerificationAsync(It.IsAny<IValidationRequest>()))
+                    .Callback(() =>
+                    {
+                        verificationQueuedBeforeStatePersisted = !statePersisted;
+                    })
+                    .Returns(Task.FromResult(0));
+
+                _validatorStateService
+                    .Setup(x => x.AddStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidationStatus>()))
+                    .Callback(() =>
+                    {
+                        statePersisted = true;
+                    })
+                    .Returns(Task.FromResult(0));
+
+                // Act
+                var actualStatus = await _target.StartValidationAsync(_validationRequest.Object);
+
+                // Assert
+                _packageSignatureVerifier
+                    .Verify(x => x.StartVerificationAsync(It.IsAny<IValidationRequest>()), Times.Once);
+
+                _validatorStateService
+                    .Verify(
+                        x => x.AddStatusAsync(
+                                It.IsAny<IValidationRequest>(),
+                                It.Is<ValidationStatus>(s => s == ValidationStatus.Incomplete)),
+                        Times.Once);
+
+                Assert.True(verificationQueuedBeforeStatePersisted);
+                Assert.Equal(ValidationStatus.Incomplete, actualStatus);
+            }
+
+            public static IEnumerable<object[]> StartedValidationStatuses => startedValidationStatuses.Select(s => new object[] { s });
+        }
+
+        public abstract class FactsBase
+        {
+            protected readonly Mock<IValidatorStateService<PackageSigningValidator>> _validatorStateService;
+            protected readonly Mock<IPackageSignatureVerifier> _packageSignatureVerifier;
+            protected readonly Mock<ILogger<PackageSigningValidator>> _logger;
+            protected readonly Mock<IValidationRequest> _validationRequest;
+            protected readonly PackageSigningValidator _target;
+
+            public FactsBase()
+            {
+                _validatorStateService = new Mock<IValidatorStateService<PackageSigningValidator>>();
+                _packageSignatureVerifier = new Mock<IPackageSignatureVerifier>();
+                _logger = new Mock<ILogger<PackageSigningValidator>>();
+
+                _validationRequest = new Mock<IValidationRequest>();
+                _validationRequest.Setup(x => x.NupkgUrl).Returns(NupkgUrl);
+                _validationRequest.Setup(x => x.PackageId).Returns(PackageId);
+                _validationRequest.Setup(x => x.PackageKey).Returns(PackageKey);
+                _validationRequest.Setup(x => x.PackageVersion).Returns(PackageVersion);
+                _validationRequest.Setup(x => x.ValidationId).Returns(ValidationId);
+
+                _target = new PackageSigningValidator(
+                        _validatorStateService.Object,
+                        _packageSignatureVerifier.Object,
+                        _logger.Object);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
@@ -37,7 +37,13 @@ namespace NuGet.Services.Validation.PackageSigning
                 // Arrange
                 _validatorStateService
                     .Setup(x => x.GetStatus(It.IsAny<IValidationRequest>()))
-                    .Returns(status);
+                    .Returns(new ValidatorStatus
+                    {
+                        ValidationId = ValidationId,
+                        PackageKey = PackageKey,
+                        ValidatorName = nameof(PackageSigningValidator),
+                        State = status,
+                    });
 
                 // Act & Assert
                 var actual = await _target.GetStatusAsync(_validationRequest.Object);
@@ -64,7 +70,13 @@ namespace NuGet.Services.Validation.PackageSigning
                 // Arrange
                 _validatorStateService
                      .Setup(x => x.GetStatus(It.IsAny<IValidationRequest>()))
-                     .Returns(status);
+                     .Returns(new ValidatorStatus
+                     {
+                         ValidationId = ValidationId,
+                         PackageKey = PackageKey,
+                         ValidatorName = nameof(PackageSigningValidator),
+                         State = status,
+                     });
 
                 // Act & Assert
                 // TODO: More specific exception!
@@ -81,7 +93,13 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _validatorStateService
                      .Setup(x => x.GetStatus(It.IsAny<IValidationRequest>()))
-                     .Returns(ValidationStatus.NotStarted);
+                     .Returns(new ValidatorStatus
+                     {
+                         ValidationId = ValidationId,
+                         PackageKey = PackageKey,
+                         ValidatorName = nameof(PackageSigningValidator),
+                         State = ValidationStatus.NotStarted,
+                     });
 
                 _packageSignatureVerifier
                     .Setup(x => x.StartVerificationAsync(It.IsAny<IValidationRequest>()))
@@ -92,7 +110,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     .Returns(Task.FromResult(0));
 
                 _validatorStateService
-                    .Setup(x => x.AddStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidationStatus>()))
+                    .Setup(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()))
                     .Callback(() =>
                     {
                         statePersisted = true;
@@ -109,8 +127,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _validatorStateService
                     .Verify(
                         x => x.AddStatusAsync(
-                                It.IsAny<IValidationRequest>(),
-                                It.Is<ValidationStatus>(s => s == ValidationStatus.Incomplete)),
+                                It.Is<ValidatorStatus>(s => s.State == ValidationStatus.Incomplete)),
                         Times.Once);
 
                 Assert.True(verificationQueuedBeforeStatePersisted);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/TestDbAsyncQueryProvider.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/TestDbAsyncQueryProvider.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Validation
+{
+    // Copied from https://msdn.microsoft.com/en-us/library/dn314429.aspx
+    internal class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
+    {
+        private readonly IQueryProvider _inner;
+
+        internal TestDbAsyncQueryProvider(IQueryProvider inner)
+        {
+            _inner = inner;
+        }
+
+        public IQueryable CreateQuery(Expression expression)
+        {
+            return new TestDbAsyncEnumerable<TEntity>(expression);
+        }
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        {
+            return new TestDbAsyncEnumerable<TElement>(expression);
+        }
+
+        public object Execute(Expression expression)
+        {
+            return _inner.Execute(expression);
+        }
+
+        public TResult Execute<TResult>(Expression expression)
+        {
+            return _inner.Execute<TResult>(expression);
+        }
+
+        public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Execute(expression));
+        }
+
+        public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Execute<TResult>(expression));
+        }
+    }
+
+    internal class TestDbAsyncEnumerable<T> : EnumerableQuery<T>, IDbAsyncEnumerable<T>, IQueryable<T>
+    {
+        public TestDbAsyncEnumerable(IEnumerable<T> enumerable)
+            : base(enumerable)
+        { }
+
+        public TestDbAsyncEnumerable(Expression expression)
+            : base(expression)
+        { }
+
+        public IDbAsyncEnumerator<T> GetAsyncEnumerator()
+        {
+            return new TestDbAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+        }
+
+        IDbAsyncEnumerator IDbAsyncEnumerable.GetAsyncEnumerator()
+        {
+            return GetAsyncEnumerator();
+        }
+
+        IQueryProvider IQueryable.Provider
+        {
+            get { return new TestDbAsyncQueryProvider<T>(this); }
+        }
+    }
+
+    internal class TestDbAsyncEnumerator<T> : IDbAsyncEnumerator<T>
+    {
+        private readonly IEnumerator<T> _inner;
+
+        public TestDbAsyncEnumerator(IEnumerator<T> inner)
+        {
+            _inner = inner;
+        }
+
+        public void Dispose()
+        {
+            _inner.Dispose();
+        }
+
+        public Task<bool> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_inner.MoveNext());
+        }
+
+        public T Current
+        {
+            get { return _inner.Current; }
+        }
+
+        object IDbAsyncEnumerator.Current
+        {
+            get { return Current; }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/TestDbAsyncQueryProvider.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/TestDbAsyncQueryProvider.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Linq.Expressions;

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationContextHelpers.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationContextHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Linq.Expressions;
 using Moq;
@@ -44,7 +45,16 @@ namespace NuGet.Services.Validation
 
             var data = dataEnumerable.AsQueryable();
 
-            dbSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(data.Provider);
+            dbSet
+                .As<IDbAsyncEnumerable<T>>()
+                .Setup(m => m.GetAsyncEnumerator())
+                .Returns(new TestDbAsyncEnumerator<T>(data.GetEnumerator()));
+
+            dbSet
+                .As<IQueryable<T>>()
+                .Setup(m => m.Provider)
+                .Returns(new TestDbAsyncQueryProvider<T>(data.Provider));
+
             dbSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
             dbSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
             dbSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationContextHelpers.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationContextHelpers.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Linq.Expressions;
+using Moq;
+
+namespace NuGet.Services.Validation
+{
+    public static class ValidationContextHelpers
+    {
+        public static void Mock(
+            this Mock<IValidationEntitiesContext> validationContext,
+            Mock<IDbSet<ValidatorStatus>> validatorStatusesMock = null,
+            Mock<IDbSet<PackageSigningState>> packageSigningStatesMock = null,
+            Mock<IDbSet<PackageSignature>> packageSignaturesMock = null,
+            Mock<IDbSet<Certificate>> certificatesMock = null,
+            Mock<IDbSet<CertificateValidation>> certificateValidationsMock = null,
+            IEnumerable<ValidatorStatus> validatorStatuses = null,
+            IEnumerable<PackageSigningState> packageSigningStates = null,
+            IEnumerable<PackageSignature> packageSignatures = null,
+            IEnumerable<Certificate> certificates = null,
+            IEnumerable<CertificateValidation> certificateValidations = null)
+        {
+            validationContext.SetupDbSet(c => c.ValidatorStatuses, validatorStatusesMock, validatorStatuses);
+            validationContext.SetupDbSet(c => c.PackageSigningStates, packageSigningStatesMock, packageSigningStates);
+            validationContext.SetupDbSet(c => c.PackageSignatures, packageSignaturesMock, packageSignatures);
+            validationContext.SetupDbSet(c => c.Certificates, certificatesMock, certificates);
+            validationContext.SetupDbSet(c => c.CertificateValidations, certificateValidationsMock, certificateValidations);
+        }
+
+        private static void SetupDbSet<T>(
+            this Mock<IValidationEntitiesContext> validationContext,
+            Expression<Func<IValidationEntitiesContext, IDbSet<T>>> propertyExpression,
+            Mock<IDbSet<T>> dbSet,
+            IEnumerable<T> dataEnumerable)
+          where T : class
+        {
+            dbSet = dbSet ?? new Mock<IDbSet<T>>();
+            dataEnumerable = dataEnumerable ?? new T[0];
+
+            var data = dataEnumerable.AsQueryable();
+
+            dbSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(data.Provider);
+            dbSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
+            dbSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
+            dbSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
+
+            validationContext.Setup(propertyExpression).Returns(dbSet.Object);
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
@@ -1,0 +1,406 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Services.Validation.Orchestrator;
+using Xunit;
+
+namespace NuGet.Services.Validation
+{
+    public class ValidatorStateServiceFacts
+    {
+        private const int PackageKey = 1001;
+        private const string PackageId = "NuGet.Versioning";
+        private const string PackageVersion = "4.3.0.0-ALPHA+git";
+        private static readonly Guid ValidationId = new Guid("fb9c0bac-3d4d-4cc7-ac2d-b3940e15b94d");
+        private static readonly Guid OtherValidationId = new Guid("6593BD33-ABC0-4049-BDCF-915807F1D2B3");
+        private const string NupkgUrl = "https://example/nuget.versioning/4.3.0/package.nupkg";
+
+        private static readonly ValidationStatus[] possibleValidationStatuses = new ValidationStatus[]
+        {
+            ValidationStatus.NotStarted,
+            ValidationStatus.Incomplete,
+            ValidationStatus.Succeeded,
+            ValidationStatus.Failed,
+        };
+
+        class AValidator : IValidator
+        {
+            public Task<ValidationStatus> GetStatusAsync(IValidationRequest request) => throw new NotImplementedException();
+            public Task<ValidationStatus> StartValidationAsync(IValidationRequest request) => throw new NotImplementedException();
+        }
+
+        class BValidator : IValidator
+        {
+            public Task<ValidationStatus> GetStatusAsync(IValidationRequest request) => throw new NotImplementedException();
+            public Task<ValidationStatus> StartValidationAsync(IValidationRequest request) => throw new NotImplementedException();
+        }
+
+        public class TheGetStatusMethod : FactsBase
+        {
+            [Fact]
+            public void GetStatusReturnsNotStartedIfNoPersistedStatus()
+            {
+                // Arrange
+                _validationContext.Mock();
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                var status = stateService.GetStatus(_validationRequest.Object);
+
+                Assert.Equal(ValidationId, status.ValidationId);
+                Assert.Equal(PackageKey, status.PackageKey);
+                Assert.Equal(nameof(AValidator), status.ValidatorName);
+                Assert.Equal(ValidationStatus.NotStarted, status.State);
+            }
+
+            [Fact]
+            public void GetStatusIgnoresStatusOfOtherValidations()
+            {
+                // Arrange
+                _validationContext.Mock(
+                    validatorStatuses: new[]
+                    {
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = ValidationStatus.Succeeded,
+                        }
+                    });
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                var status = stateService.GetStatus(_validationRequest.Object);
+
+                Assert.Equal(ValidationId, status.ValidationId);
+                Assert.Equal(PackageKey, status.PackageKey);
+                Assert.Equal(nameof(AValidator), status.ValidatorName);
+                Assert.Equal(ValidationStatus.NotStarted, status.State);
+            }
+
+            [Theory]
+            [MemberData(nameof(PossibleValidationStatuses))]
+            public void GetStatusReturnsPersistedStatus(ValidationStatus status)
+            {
+                // Arrange
+                _validationContext.Mock(
+                    validatorStatuses: new []
+                    {
+                        new ValidatorStatus
+                        {
+                            ValidationId = ValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = status,
+                        },
+
+                        // This next status is for some "other" validation and should be ignored.
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = ValidationStatus.Failed,
+                        }
+                    });
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                var persistedStatus = stateService.GetStatus(_validationRequest.Object);
+
+                Assert.Equal(ValidationId, persistedStatus.ValidationId);
+                Assert.Equal(PackageKey, persistedStatus.PackageKey);
+                Assert.Equal(nameof(AValidator), persistedStatus.ValidatorName);
+                Assert.Equal(status, persistedStatus.State);
+            }
+
+            public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
+        }
+
+        public class TheIsRevalidationRequestMethod : FactsBase
+        {
+            [Fact]
+            public void ReturnsFalseIfPackageHasNeverBeenValidated()
+            {
+                // Arrange
+                _validationContext.Mock();
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                Assert.False(stateService.IsRevalidationRequest(_validationRequest.Object));
+            }
+
+            [Fact]
+            public void ReturnsTrueIfPackageHasBeenValidatedByValidator()
+            {
+                // Arrange
+                _validationContext.Mock(
+                    validatorStatuses: new[]
+                    {
+                        // The package was validated in another validation request by AValidator.
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = ValidationStatus.Succeeded,
+                        }
+                    });
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                Assert.True(stateService.IsRevalidationRequest(_validationRequest.Object));
+            }
+
+            [Fact]
+            public void ReturnsFalseIfPackageHasBeenValidatedByOtherValidator()
+            {
+                // Arrange
+                _validationContext.Mock(
+                    validatorStatuses: new[]
+                    {
+                        // The package was validated in another validation request by BValidator.
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(BValidator),
+                            State = ValidationStatus.Succeeded,
+                        }
+                    });
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                Assert.False(stateService.IsRevalidationRequest(_validationRequest.Object));
+            }
+
+            [Fact]
+            public void ReturnsTrueIfPackageHasBeenValidatedByMultipleValidators()
+            {
+                // Arrange
+                _validationContext.Mock(
+                    validatorStatuses: new[]
+                    {
+                        // The package was validated in another validation request by AValidator and BValidator.
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = ValidationStatus.Succeeded,
+                        },
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(BValidator),
+                            State = ValidationStatus.Succeeded,
+                        }
+                    });
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                Assert.True(stateService.IsRevalidationRequest(_validationRequest.Object));
+            }
+
+            [Fact]
+            public void ReturnsFalseIfCurrentValidationIsOnlyValidationByValidator()
+            {
+                // Arrange
+                _validationContext.Mock(
+                    validatorStatuses: new[]
+                    {
+                        // The current validation request has been persisted, but, the current validator "AValidator"
+                        // has never validated the current package before.
+                        new ValidatorStatus
+                        {
+                            ValidationId = ValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = ValidationStatus.NotStarted,
+                        },
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(BValidator),
+                            State = ValidationStatus.Succeeded,
+                        }
+                    });
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                Assert.False(stateService.IsRevalidationRequest(_validationRequest.Object));
+            }
+
+            [Fact]
+            public void ReturnsTrueIfPackageHasBeenValidatedByMultipleValidatorsAndCurrentValidationIsPersisted()
+            {
+                // Arrange
+                _validationContext.Mock(
+                    validatorStatuses: new[]
+                    {
+                        // The current validation request has been persisted, and, the package was validated in another
+                        // validation request by AValidator and BValidator.
+                        new ValidatorStatus
+                        {
+                            ValidationId = ValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = ValidationStatus.NotStarted,
+                        },
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(AValidator),
+                            State = ValidationStatus.Failed,
+                        },
+                        new ValidatorStatus
+                        {
+                            ValidationId = OtherValidationId,
+                            PackageKey = PackageKey,
+                            ValidatorName = nameof(BValidator),
+                            State = ValidationStatus.Succeeded,
+                        }
+                    });
+
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                // Act & Assert
+                Assert.True(stateService.IsRevalidationRequest(_validationRequest.Object));
+            }
+        }
+
+        public class TheAddStatusAsyncMethod : FactsBase
+        {
+            [Fact]
+            public async Task AddStatusAsyncThrowsIfValidatorNameIsWrong()
+            {
+                // Arrange
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+                var validationStatus = new ValidatorStatus
+                {
+                    ValidationId = ValidationId,
+                    PackageKey = PackageKey,
+                    ValidatorName = nameof(BValidator),
+                    State = ValidationStatus.Incomplete,
+                };
+
+                // Act & Assert
+                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync(validationStatus));
+            }
+
+            [Theory]
+            [MemberData(nameof(PossibleValidationStatuses))]
+            public async Task AddStatusAsyncMethodPersistsStatus(ValidationStatus status)
+            {
+                // Arrange
+                var validatorName = nameof(AValidator);
+                var validatorStatuses = new Mock<IDbSet<ValidatorStatus>>();
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+
+                _validationContext.Mock(validatorStatusesMock: validatorStatuses);
+
+                // Act & Assert
+                await stateService.AddStatusAsync(new ValidatorStatus
+                {
+                    ValidationId = ValidationId,
+                    PackageKey = PackageKey,
+                    ValidatorName = validatorName,
+                    State = status,
+                });
+
+                _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+
+                validatorStatuses
+                    .Verify(statuses => statuses.Add(
+                        It.Is<ValidatorStatus>(
+                            s => s.ValidationId == ValidationId
+                                && s.PackageKey == PackageKey
+                                && s.ValidatorName == validatorName
+                                && s.State == status)),
+                    Times.Once);
+            }
+
+            public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
+        }
+
+        public class TheSaveStatusAsyncMethod : FactsBase
+        {
+            [Fact]
+            public async Task SaveStatusAsyncThrowsIfValidatorNameIsWrong()
+            {
+                // Arrange
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+                var validatorStatus = new ValidatorStatus
+                {
+                    ValidationId = ValidationId,
+                    PackageKey = PackageKey,
+                    ValidatorName = nameof(BValidator),
+                    State = ValidationStatus.NotStarted,
+                };
+
+                // Act & Assert
+                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync(validatorStatus));
+            }
+
+            [Theory]
+            [MemberData(nameof(PossibleValidationStatuses))]
+            public async Task SaveStatusAsyncMethodPersistsStatus(ValidationStatus status)
+            {
+                // Arrange
+                var stateService = new ValidatorStateService<AValidator>(_validationContext.Object);
+                var validatorStatus = new ValidatorStatus
+                {
+                    ValidationId = ValidationId,
+                    PackageKey = PackageKey,
+                    ValidatorName = nameof(AValidator),
+                    State = ValidationStatus.NotStarted,
+                };
+
+                _validationContext.Mock();
+
+                // Act & Assert
+                await stateService.AddStatusAsync(validatorStatus);
+
+                _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+            }
+
+            public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
+        }
+
+        public abstract class FactsBase
+        {
+            protected readonly Mock<IValidationEntitiesContext> _validationContext;
+            protected readonly Mock<IValidationRequest> _validationRequest;
+
+            public FactsBase()
+            {
+                _validationContext = new Mock<IValidationEntitiesContext>();
+
+                _validationRequest = new Mock<IValidationRequest>();
+                _validationRequest.Setup(x => x.NupkgUrl).Returns(NupkgUrl);
+                _validationRequest.Setup(x => x.PackageId).Returns(PackageId);
+                _validationRequest.Setup(x => x.PackageKey).Returns(PackageKey);
+                _validationRequest.Setup(x => x.PackageVersion).Returns(PackageVersion);
+                _validationRequest.Setup(x => x.ValidationId).Returns(ValidationId);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
@@ -52,7 +52,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                var status = await stateService.GetStatusAsync(nameof(AValidator), _validationRequest.Object);
+                var status = await stateService.GetStatusAsync<AValidator>(_validationRequest.Object);
 
                 Assert.Equal(ValidationId, status.ValidationId);
                 Assert.Equal(PackageKey, status.PackageKey);
@@ -79,7 +79,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                var status = await stateService.GetStatusAsync(nameof(AValidator), _validationRequest.Object);
+                var status = await stateService.GetStatusAsync<AValidator>(_validationRequest.Object);
 
                 Assert.Equal(ValidationId, status.ValidationId);
                 Assert.Equal(PackageKey, status.PackageKey);
@@ -93,7 +93,7 @@ namespace NuGet.Services.Validation
             {
                 // Arrange
                 _validationContext.Mock(
-                    validatorStatuses: new []
+                    validatorStatuses: new[]
                     {
                         new ValidatorStatus
                         {
@@ -116,7 +116,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                var persistedStatus = await stateService.GetStatusAsync(nameof(AValidator), _validationRequest.Object);
+                var persistedStatus = await stateService.GetStatusAsync<AValidator>(_validationRequest.Object);
 
                 Assert.Equal(ValidationId, persistedStatus.ValidationId);
                 Assert.Equal(PackageKey, persistedStatus.PackageKey);
@@ -142,7 +142,7 @@ namespace NuGet.Services.Validation
                 });
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(async() => await stateService.GetStatusAsync(nameof(AValidator), _validationRequest.Object));
+                await Assert.ThrowsAsync<ArgumentException>(async () => await stateService.GetStatusAsync<AValidator>(_validationRequest.Object));
             }
 
             [Fact]
@@ -163,7 +163,7 @@ namespace NuGet.Services.Validation
                 });
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(async () => await stateService.GetStatusAsync(nameof(AValidator), _validationRequest.Object));
+                await Assert.ThrowsAsync<ArgumentException>(async () => await stateService.GetStatusAsync<AValidator>(_validationRequest.Object));
             }
 
             public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
@@ -180,7 +180,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                Assert.False(await stateService.IsRevalidationRequestAsync(nameof(AValidator), _validationRequest.Object));
+                Assert.False(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
             }
 
             [Fact]
@@ -203,7 +203,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                Assert.True(await stateService.IsRevalidationRequestAsync(nameof(AValidator), _validationRequest.Object));
+                Assert.True(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
             }
 
             [Fact]
@@ -226,7 +226,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                Assert.False(await stateService.IsRevalidationRequestAsync(nameof(AValidator), _validationRequest.Object));
+                Assert.False(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
             }
 
             [Fact]
@@ -256,7 +256,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                Assert.True(await stateService.IsRevalidationRequestAsync(nameof(AValidator), _validationRequest.Object));
+                Assert.True(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
             }
 
             [Fact]
@@ -287,7 +287,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                Assert.False(await stateService.IsRevalidationRequestAsync(nameof(AValidator), _validationRequest.Object));
+                Assert.False(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
             }
 
             [Fact]
@@ -325,7 +325,7 @@ namespace NuGet.Services.Validation
                 var stateService = new ValidatorStateService(_validationContext.Object);
 
                 // Act & Assert
-                Assert.True(await stateService.IsRevalidationRequestAsync(nameof(AValidator), _validationRequest.Object));
+                Assert.True(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
             }
         }
 
@@ -345,7 +345,7 @@ namespace NuGet.Services.Validation
                 };
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync(nameof(AValidator), validationStatus));
+                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync<AValidator>(validationStatus));
             }
 
             [Theory]
@@ -360,7 +360,7 @@ namespace NuGet.Services.Validation
                 _validationContext.Mock(validatorStatusesMock: validatorStatuses);
 
                 // Act & Assert
-                await stateService.AddStatusAsync(nameof(AValidator), new ValidatorStatus
+                var result = await stateService.AddStatusAsync<AValidator>(new ValidatorStatus
                 {
                     ValidationId = ValidationId,
                     PackageKey = PackageKey,
@@ -378,6 +378,8 @@ namespace NuGet.Services.Validation
                                 && s.ValidatorName == validatorName
                                 && s.State == status)),
                     Times.Once);
+
+                Assert.Equal(AddStatusResult.Success, result);
             }
 
             public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
@@ -399,7 +401,7 @@ namespace NuGet.Services.Validation
                 };
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync(nameof(AValidator), validatorStatus));
+                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync<AValidator>(validatorStatus));
             }
 
             [Theory]
@@ -419,7 +421,7 @@ namespace NuGet.Services.Validation
                 _validationContext.Mock();
 
                 // Act & Assert
-                await stateService.AddStatusAsync(nameof(AValidator), validatorStatus);
+                await stateService.AddStatusAsync<AValidator>(validatorStatus);
 
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
             }


### PR DESCRIPTION
Adds the basic `PackageSigningValidator`. This PR is "incomplete" in that there are a few missing pieces:

* `PackageSignatureVerifier` doesn't emit messages to Service Bus.
* The [NuGet.Services.Validation.* NuGet packages](https://github.com/NuGet/ServerCommon) haven't been updated yet. I am testing this by overriding the references to local builds. I would recommend you do the same if you would like to build/test this branch.