### PR TITLE
Trim package ID and version and exclude non-200 log entries

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/PackageDefinition.cs
+++ b/src/Stats.AzureCdnLogs.Common/PackageDefinition.cs
@@ -25,7 +25,6 @@ namespace Stats.AzureCdnLogs.Common
 
             requestUrl = HttpUtility.UrlDecode(requestUrl);
 
-
             var urlSegments = requestUrl.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             var fileName = urlSegments.Last();
 
@@ -70,12 +69,17 @@ namespace Stats.AzureCdnLogs.Common
                 }
 
                 var packageDefinition = new PackageDefinition();
-                packageDefinition.PackageId = string.Join(_dotSeparator, packageIdSegments);
-                packageDefinition.PackageVersion = string.Join(_dotSeparator, packageVersionSegments);
+                // Join and trim the package ID and package version. Package IDs and normalized versions never have
+                // spaces in them.
+                packageDefinition.PackageId = string.Join(_dotSeparator, packageIdSegments).Trim();
+                packageDefinition.PackageVersion = string.Join(_dotSeparator, packageVersionSegments).Trim();
 
                 return packageDefinition;
             }
-            else return null;
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/CdnLogEntryParserFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/CdnLogEntryParserFacts.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Stats.AzureCdnLogs.Common;
+using Xunit;
+
+namespace Tests.Stats.ImportAzureCdnStatistics
+{
+    public class CdnLogEntryParserFacts
+    {
+        public class TheParseLogEntryFromLineMethod
+        {
+            private const int LineNumber = 42;
+            private const string StatusLineFormat = "1507030253 0 - - 0.1.2.3 443 {0} 577 GET http://example/path - 0 653  \"UserAgent\" 56086 \"NuGet-Operation: - NuGet-DependentPackage: - NuGet-ProjectGuids: -\"  ";
+            
+            [Theory]
+            [InlineData("TCP_MISS/0")]
+            [InlineData("TCP_MISS/199")]
+            [InlineData("TCP_MISS/300")]
+            [InlineData("TCP_MISS/404")]
+            [InlineData("SOMETHING_ELSE/404")]
+            [InlineData("TCP_MISS/504")]
+            [InlineData("TCP_MISS/604")]
+            public void IgnoresNon200HttpStatusCodes(string status)
+            {
+                // Arrange
+                var line = string.Format(StatusLineFormat, status);
+
+                // Act
+                var logEntry = CdnLogEntryParser.ParseLogEntryFromLine(
+                    LineNumber,
+                    line,
+                    FailOnError);
+
+                // Assert
+                Assert.Null(logEntry);
+            }
+
+            [Theory]
+            [InlineData("TCP_MISS/200")]
+            [InlineData("TCP_MISS/299")]
+            [InlineData("TCP_MISS/")]
+            [InlineData("TCP_MISS")]
+            [InlineData("200")]
+            [InlineData("500")]
+            public void DoesNotIgnore200LevelAndUnrecognizedHttpStatusCodes(string status)
+            {
+                // Arrange
+                var line = string.Format(StatusLineFormat, status);
+
+                // Act
+                var logEntry = CdnLogEntryParser.ParseLogEntryFromLine(
+                    LineNumber,
+                    line,
+                    (e, lineNumber) => Assert.False(true, "The error action should not be called."));
+
+                // Assert
+                Assert.NotNull(logEntry);
+                Assert.Equal(status, logEntry.CacheStatusCode);
+            }
+
+            private static void FailOnError(Exception e, int lineNumber)
+            {
+                Assert.False(true, "The error action should not be called.");
+            }
+        }
+    }
+}

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDefinitionFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDefinitionFacts.cs
@@ -20,6 +20,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
         [InlineData("dnx-mono", "1.0.0-beta7", "http://localhost/packages/dnx-mono.1.0.0-beta7.nupkg")]
         [InlineData("Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus", "6.0.1304", "http://localhost/packages/Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus.6.0.1304.nupkg")]
         [InlineData("新包", "1.0.0", "http://localhost/packages/%E6%96%B0%E5%8C%85.1.0.0.nupkg")]
+        [InlineData("microsoft.applicationinsights.dependencycollector", "2.4.1", "http://localhost/packages/microsoft.applicationinsights.dependencycollector%20.2.4.1.nupkg")]
         //[InlineData("5.0.0.0", "5.0.0", "http://localhost/packages/5.0.0.0.5.0.0.nupkg")] -- can't determine for 100% what the correct id and version is without reaching out to the main gallery db
         public void ExtractsPackageIdAndVersionFromRequestUrl(string expectedPackageId, string expectedPackageVersion, string requestUrl)
         {

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
@@ -121,6 +121,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CdnLogCustomFieldParserFacts.cs" />
+    <Compile Include="CdnLogEntryParserFacts.cs" />
     <Compile Include="LogFileProcessorFacts.cs" />
     <Compile Include="PackageDefinitionFacts.cs" />
     <Compile Include="PackageDimensionFacts.cs" />


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/4802.
Fix https://github.com/NuGet/NuGetGallery/issues/4803.

TIL ANSI SQL does not use trailing spaces for comparison (`=`) of strings. Try this in your SSMS:
```sql
DECLARE @packages TABLE (
	PackageId NVARCHAR(255) NOT NULL,
	PackageVersion NVARCHAR(128) NOT NULL,
	UNIQUE NONCLUSTERED (PackageId, PackageVersion)
);

INSERT INTO @packages (PackageId, PackageVersion) VALUES ('microsoft.applicationinsights.dependencycollector', '2.4.1')
INSERT INTO @packages (PackageId, PackageVersion) VALUES ('microsoft.applicationinsights.dependencycollector ', '2.4.1')
```

I will block on @xavierdecoster's sign off since this is his area of expertise.

This PR will allow a CDN log file to be processed. It is in the dead-letter right now.