### PR TITLE
When running the legacy validators, always build the package URL instead of using URL from OData

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -100,13 +100,13 @@ namespace NuGet.Jobs
         // Arguments specific to validation tasks
         public const string RunValidationTasks = "RunValidationTasks";
         public const string RequestValidationTasks = "RequestValidationTasks";
+        public const string PackageUrlTemplate = "PackageUrlTemplate";
 
         // Arguments specific to VCS validation task
         public const string VcsValidatorServiceUrl = "VcsValidatorServiceUrl";
         public const string VcsValidatorCallbackUrl = "VcsValidatorCallbackUrl";
         public const string VcsContactAlias = "VcsContactAlias";
         public const string VcsValidatorSubmitterAlias = "VcsValidatorAlias";
-        public const string VcsPackageUrlTemplate = "VcsPackageUrlTemplate";
 
         // Key Vault
         public const string VaultName = "VaultName";

--- a/src/Validation.Common/Validators/Unzip/UnzipValidator.cs
+++ b/src/Validation.Common/Validators/Unzip/UnzipValidator.cs
@@ -19,7 +19,7 @@ namespace NuGet.Jobs.Validation.Common.Validators.Unzip
 
         private readonly ILogger<UnzipValidator> _logger;
 
-        public UnzipValidator(ILoggerFactory loggerFactory)
+        public UnzipValidator(string packageUrlTemplate, ILoggerFactory loggerFactory) : base(packageUrlTemplate)
         {
             _logger = loggerFactory.CreateLogger<UnzipValidator>();
         }
@@ -40,14 +40,16 @@ namespace NuGet.Jobs.Validation.Common.Validators.Unzip
             {
                 try
                 {
-                    using (var packageStream = await httpClient.GetStreamAsync(message.Package.DownloadUrl))
+                    var packageUrl = GetPackageUrl(message);
+
+                    using (var packageStream = await httpClient.GetStreamAsync(packageUrl))
                     {
                         using (var packageFileStream = File.Open(temporaryFile, FileMode.OpenOrCreate))
                         {
                             await packageStream.CopyToAsync(packageFileStream);
 
-                            _logger.LogInformation($"Downloaded package from {{{TraceConstant.Url}}}", message.Package.DownloadUrl);
-                            WriteAuditEntry(auditEntries, $"Downloaded package from {message.Package.DownloadUrl}",
+                            _logger.LogInformation($"Downloaded package from {{{TraceConstant.Url}}}", packageUrl);
+                            WriteAuditEntry(auditEntries, $"Downloaded package from {packageUrl}",
                                 ValidationEvent.PackageDownloaded);
 
                             packageFileStream.Position = 0;

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -42,7 +42,9 @@ namespace NuGet.Jobs.Validation.Runner
             // Add validators
             if (_runValidationTasks.Contains(UnzipValidator.ValidatorName))
             {
-                _validators.Add(new UnzipValidator(LoggerFactory));
+                _validators.Add(new UnzipValidator(
+                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageUrlTemplate),
+                    LoggerFactory));
             }
             if (_runValidationTasks.Contains(VcsValidator.ValidatorName))
             {
@@ -56,7 +58,7 @@ namespace NuGet.Jobs.Validation.Runner
                     JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorCallbackUrl),
                     contactAlias,
                     submitterAlias,
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsPackageUrlTemplate),
+                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageUrlTemplate),
                     LoggerFactory));
             }
         }
@@ -282,6 +284,11 @@ namespace NuGet.Jobs.Validation.Runner
                 // Start the validation process for each package
                 foreach (var package in packages)
                 {
+                    // Don't read the package URL from OData. Instead, allow the validators to build the package URL
+                    // themselves. This is important because the URL in the OData feed is not pointing directly to
+                    // Azure Blob Storage, which is required by the VCS validator.
+                    package.DownloadUrl = null;
+
                     await packageValidationService.StartValidationProcessAsync(package, _requestValidationTasks);
                 }
 

--- a/src/Validation.Runner/Scripts/Validation.Runner.cmd
+++ b/src/Validation.Runner/Scripts/Validation.Runner.cmd
@@ -3,12 +3,28 @@
 cd bin
 
 :Top
-    echo "Starting job - #{Jobs.validation.Title}"
+echo "Starting job - #{Jobs.validation.Title}"
     
-    title #{Jobs.validation.Title}
+title #{Jobs.validation.Title}
 
-    start /w Validation.Runner.exe -VaultName "#{Deployment.Azure.KeyVault.VaultName}" -ClientId "#{Deployment.Azure.KeyVault.ClientId}" -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" -RunValidationTasks "#{Jobs.validation.RunValidationTasks}" -RequestValidationTasks "#{Jobs.validation.RequestValidationTasks}" -GalleryBaseAddress "#{Jobs.validation.GalleryBaseAddress}" -DataStorageAccount "#{Jobs.validation.DataStorageAccount}" -ContainerName "#{Jobs.validation.ContainerName}" -VcsValidatorServiceUrl "#{Jobs.validation.VcsValidatorServiceUrl}" -VcsValidatorCallbackUrl "#{Jobs.validation.VcsValidatorCallbackUrl}" -VcsValidatorAlias "#{Jobs.validation.VcsValidatorAlias}" -VcsPackageUrlTemplate "#{Jobs.validation.VcsPackageUrlTemplate}" -verbose true -Interval #{Jobs.validation.Interval} -InstrumentationKey "#{Jobs.validation.ApplicationInsightsInstrumentationKey}" -VcsContactAlias "#{Jobs.validation.NugetVcsContactAlias}"
+start /w Validation.Runner.exe ^
+    -VaultName "#{Deployment.Azure.KeyVault.VaultName}" ^
+    -ClientId "#{Deployment.Azure.KeyVault.ClientId}" ^
+    -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" ^
+    -RunValidationTasks "#{Jobs.validation.RunValidationTasks}" ^
+    -RequestValidationTasks "#{Jobs.validation.RequestValidationTasks}" ^
+    -GalleryBaseAddress "#{Jobs.validation.GalleryBaseAddress}" ^
+    -DataStorageAccount "#{Jobs.validation.DataStorageAccount}" ^
+    -ContainerName "#{Jobs.validation.ContainerName}" ^
+    -PackageUrlTemplate "#{Jobs.validation.PackageUrlTemplate}" ^
+    -VcsValidatorServiceUrl "#{Jobs.validation.VcsValidatorServiceUrl}" ^
+    -VcsValidatorCallbackUrl "#{Jobs.validation.VcsValidatorCallbackUrl}" ^
+    -VcsValidatorAlias "#{Jobs.validation.VcsValidatorAlias}" ^
+    -verbose true ^
+    -Interval #{Jobs.validation.Interval} ^
+    -InstrumentationKey "#{Jobs.validation.ApplicationInsightsInstrumentationKey}" ^
+    -VcsContactAlias "#{Jobs.validation.NugetVcsContactAlias}"
 
-    echo "Finished #{Jobs.validation.Title}"
+echo "Finished #{Jobs.validation.Title}"
 
-    goto Top
+goto Top


### PR DESCRIPTION
In a previous `dev` commit (https://github.com/NuGet/NuGet.Jobs/commit/fdc1b1f888c3ff16f7839e963d7ac1fe3bd24104), I changed VCS validator to favor the `DownloadUrl` on the `Package`. This does not work for the legacy orchestrator since this value does not point directly to blob storage.