### PR TITLE
Consider VCS requests with no request ID, job ID, and region code as failures (and later retry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ Results.*.xml
 
 AssemblyInfo.*.cs
 /tests/Validation.Helper.Tests/Validation.Helper.Tests.nuget.props
+/tests/Validation.Common.Tests/Validation.Common.Tests.nuget.props

--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26915.1
+VisualStudioVersion = 15.0.26923.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Jobs.Common", "src\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj", "{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}"
 EndProject
@@ -94,6 +94,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.Orchestrator", "src\NuGet.Services.Validation.Orchestrator\NuGet.Services.Validation.Orchestrator.csproj", "{E6D094FB-9068-4578-B176-116F97E7506B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.Orchestrator.Tests", "tests\NuGet.Services.Validation.Orchestrator.Tests\NuGet.Services.Validation.Orchestrator.Tests.csproj", "{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Common.Tests", "tests\Validation.Common.Tests\Validation.Common.Tests.csproj", "{F9690B52-3C92-42A0-B41F-1A6040C2D2EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -235,6 +237,10 @@ Global
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9690B52-3C92-42A0-B41F-1A6040C2D2EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9690B52-3C92-42A0-B41F-1A6040C2D2EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9690B52-3C92-42A0-B41F-1A6040C2D2EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9690B52-3C92-42A0-B41F-1A6040C2D2EE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -272,6 +278,7 @@ Global
 		{FC0CEF12-D501-46D1-B1BF-D4134BD8D478} = {B9D03824-A9CA-43AC-86D6-8BB399B9A228}
 		{0C887292-C5AB-4107-946C-A53B18A38D22} = {6A776396-02B1-475D-A104-26940ADB04AB}
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632} = {6A776396-02B1-475D-A104-26940ADB04AB}
+		{F9690B52-3C92-42A0-B41F-1A6040C2D2EE} = {6A776396-02B1-475D-A104-26940ADB04AB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {284A7AC3-FB43-4F1F-9C9C-2AF0E1F46C2B}

--- a/src/Validation.Common/Validators/ValidationException.cs
+++ b/src/Validation.Common/Validators/ValidationException.cs
@@ -7,7 +7,7 @@ using System.Runtime.Serialization;
 namespace NuGet.Jobs.Validation.Common.Validators.Vcs
 {
     [Serializable]
-    internal class ValidationException : Exception
+    public class ValidationException : Exception
     {
         public ValidationException(string message) : base(message)
         {

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -13,6 +13,7 @@ using NuGet.Jobs.Validation.Common.OData;
 using NuGet.Jobs.Validation.Common.Validators;
 using NuGet.Jobs.Validation.Common.Validators.Unzip;
 using NuGet.Jobs.Validation.Common.Validators.Vcs;
+using NuGet.Services.VirusScanning.Vcs;
 
 namespace NuGet.Jobs.Validation.Runner
 {
@@ -48,18 +49,27 @@ namespace NuGet.Jobs.Validation.Runner
             }
             if (_runValidationTasks.Contains(VcsValidator.ValidatorName))
             {
-                // if contact alias set, use it, if not, use submitter alias.
-                string submitterAlias = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorSubmitterAlias);
-                string contactAlias = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.VcsContactAlias)
-                    ?? submitterAlias;
+                var serviceUrl = new Uri(JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorServiceUrl));
+                var consumerCode = "DIRECT";
+                var callbackUrl = new Uri(JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorCallbackUrl));
+                var packageUrlTemplate = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageUrlTemplate);
+                var submitterAlias = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorSubmitterAlias);
 
-                _validators.Add(new VcsValidator(
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorServiceUrl),
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.VcsValidatorCallbackUrl),
+                // if contact alias set, use it, if not, use submitter alias.
+                var contactAlias = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.VcsContactAlias) ?? submitterAlias;
+                
+                var scanningService = new VcsVirusScanningService(
+                    serviceUrl,
+                    consumerCode,
                     contactAlias,
                     submitterAlias,
-                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageUrlTemplate),
-                    LoggerFactory));
+                    LoggerFactory);
+
+                _validators.Add(new VcsValidator(
+                    callbackUrl,
+                    packageUrlTemplate,
+                    scanningService,
+                    LoggerFactory.CreateLogger<VcsValidator>()));
             }
         }
 

--- a/src/Validation.Runner/Validation.Runner.csproj
+++ b/src/Validation.Runner/Validation.Runner.csproj
@@ -68,6 +68,12 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Services.VirusScanning.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.VirusScanning.Vcs.3.2.0\lib\net452\NuGet.Services.VirusScanning.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Services.VirusScanning.Vcs, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.VirusScanning.Vcs.3.2.0\lib\net452\NuGet.Services.VirusScanning.Vcs.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />

--- a/src/Validation.Runner/packages.config
+++ b/src/Validation.Runner/packages.config
@@ -11,6 +11,7 @@
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="NuGet.Services.VirusScanning.Vcs" version="3.2.0" targetFramework="net452" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
   <package id="System.ComponentModel" version="4.0.1" targetFramework="net452" />

--- a/test.ps1
+++ b/test.ps1
@@ -29,9 +29,9 @@ Function Run-Tests {
         "tests\Tests.Stats.CollectAzureCdnLogs\bin\$Configuration\Tests.Stats.CollectAzureCdnLogs.dll", `
         "tests\Tests.Stats.ImportAzureCdnStatistics\bin\$Configuration\Tests.Stats.ImportAzureCdnStatistics.dll", `
         "tests\Validation.Helper.Tests\bin\$Configuration\Validation.Helper.Tests.dll",`
-	"tests\Tests.Stats.CollectAzureChinaCDNLogs\bin\$Configuration\Tests.Stats.CollectAzureChinaCDNLogs.dll", `
-        "tests\NuGet.Services.Validation.Orchestrator.Tests\bin\$Configuration\NuGet.Services.Validation.Orchestrator.Tests.dll"
-
+        "tests\Tests.Stats.CollectAzureChinaCDNLogs\bin\$Configuration\Tests.Stats.CollectAzureChinaCDNLogs.dll", `
+        "tests\NuGet.Services.Validation.Orchestrator.Tests\bin\$Configuration\NuGet.Services.Validation.Orchestrator.Tests.dll", `
+        "tests\Validation.Common.Tests\bin\$Configuration\Validation.Common.Tests.dll"
     
     $TestCount = 0
     

--- a/tests/Validation.Common.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Validation.Common.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Validation.Common.Tests")]
+[assembly: AssemblyProduct("Validation.Common.Tests")]
+[assembly: ComVisible(false)]
+[assembly: Guid("f9690b52-3c92-42a0-b41f-1a6040c2d2ee")]

--- a/tests/Validation.Common.Tests/Validation.Common.Tests.csproj
+++ b/tests/Validation.Common.Tests/Validation.Common.Tests.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F9690B52-3C92-42A0-B41F-1A6040C2D2EE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Validation.Common.Tests</RootNamespace>
+    <AssemblyName>Validation.Common.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Validators\Vcs\VcsValidatorFacts.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Validation.Common\Validation.Common.csproj">
+      <Project>{2539ddf3-0cc5-4a03-b5f9-39b47744a7bd}</Project>
+      <Name>Validation.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/Validation.Common.Tests/Validators/Vcs/VcsValidatorFacts.cs
+++ b/tests/Validation.Common.Tests/Validators/Vcs/VcsValidatorFacts.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Jobs.Validation.Common;
+using NuGet.Jobs.Validation.Common.Validators;
+using NuGet.Jobs.Validation.Common.Validators.Vcs;
+using NuGet.Services.VirusScanning.Core;
+using Xunit;
+
+namespace Validation.Common.Tests
+{
+    public class VcsValidatorFacts
+    {
+        public class TheNameProperty : FactsBase
+        {
+            [Fact]
+            public void NeverChanges()
+            {
+                Assert.Equal("validator-vcs", _target.Name);
+            }
+        }
+
+        public class TheValidateMethod : FactsBase
+        {
+            [Fact]
+            public async Task PrefersTheDownloadUrlOverBuildingTheUrl()
+            {
+                // Arrange
+                _message.Package.DownloadUrl = new Uri("http://example/some-custom-url");
+
+                // Act
+                var actual = await _target.ValidateAsync(_message, _auditEntries);
+
+                // Assert
+                Assert.Equal(ValidationResult.Asynchronous, actual);
+                _scanningService.Verify(
+                    x => x.CreateVirusScanJobAsync(
+                        _message.Package.DownloadUrl.ToString(),
+                        _callbackUrl,
+                        $"NuGet - f470b9fb-0243-4f65-8aef-90d93dfe1a03 - NuGet.Versioning 3.4.0-ALPHA",
+                        _message.ValidationId),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task ReturnsAsynchronousOnSuccess()
+            {
+                // Arrange & Act
+                var actual = await _target.ValidateAsync(_message, _auditEntries);
+
+                // Assert
+                Assert.Equal(ValidationResult.Asynchronous, actual);
+                _scanningService.Verify(
+                    x => x.CreateVirusScanJobAsync(
+                        "http://example/packages/nuget.versioning/3.4.0-alpha/nuget.versioning.3.4.0-alpha.nupkg",
+                        _callbackUrl,
+                        $"NuGet - f470b9fb-0243-4f65-8aef-90d93dfe1a03 - NuGet.Versioning 3.4.0-ALPHA",
+                        _message.ValidationId),
+                    Times.Once);
+                _scanningService.Verify(
+                    x => x.CreateVirusScanJobAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<Guid>()),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task FailsWhenThereIsAnErrorMessage()
+            {
+                // Arrange
+                var errorMessage = "Error!";
+                _virusScanJob.ErrorMessage = errorMessage;
+
+                // Act & Assert
+                var exception = await Assert.ThrowsAsync<ValidationException>(
+                    () => _target.ValidateAsync(_message, _auditEntries));
+                Assert.Equal(errorMessage, exception.Message);
+            }
+
+            [Fact]
+            public async Task FailsIfAllResponseValuesAreNull()
+            {
+                // Arrange
+                _virusScanJob.RequestId = null;
+                _virusScanJob.JobId = null;
+                _virusScanJob.RegionCode = null;
+
+                // Act & Assert
+                var exception = await Assert.ThrowsAsync<ValidationException>(
+                    () => _target.ValidateAsync(_message, _auditEntries));
+                Assert.Equal("The request had no request ID, job ID, and region code.", exception.Message);
+            }
+
+            [Fact]
+            public async Task SucceedsIfOnlyRequestIdIsNull()
+            {
+                // Arrange
+                _virusScanJob.RequestId = null;
+
+                // Act
+                var actual = await _target.ValidateAsync(_message, _auditEntries);
+
+                // Assert
+                Assert.Equal(ValidationResult.Asynchronous, actual);
+            }
+
+            [Fact]
+            public async Task SucceedsIfOnlyJobIdIsNull()
+            {
+                // Arrange
+                _virusScanJob.JobId = null;
+
+                // Act
+                var actual = await _target.ValidateAsync(_message, _auditEntries);
+
+                // Assert
+                Assert.Equal(ValidationResult.Asynchronous, actual);
+            }
+
+            [Fact]
+            public async Task SucceedsIfOnlyRegionCodeIsNull()
+            {
+                // Arrange
+                _virusScanJob.RegionCode = null;
+
+                // Act
+                var actual = await _target.ValidateAsync(_message, _auditEntries);
+
+                // Assert
+                Assert.Equal(ValidationResult.Asynchronous, actual);
+            }
+        }
+
+        public abstract class FactsBase
+        {
+            protected readonly Uri _callbackUrl;
+            protected readonly string _packageUrlTemplate;
+            protected readonly Mock<IVirusScanningService> _scanningService;
+            protected readonly Mock<ILogger<VcsValidator>> _logger;
+            protected PackageValidationMessage _message;
+            protected List<PackageValidationAuditEntry> _auditEntries;
+            protected VirusScanJob _virusScanJob;
+            protected readonly VcsValidator _target;
+
+            public FactsBase()
+            {
+                _callbackUrl = new Uri("http://example/callback");
+                _packageUrlTemplate = "http://example/packages/{id}/{version}/{id}.{version}.nupkg";
+                _scanningService = new Mock<IVirusScanningService>();
+                _logger = new Mock<ILogger<VcsValidator>>();
+
+                _message = new PackageValidationMessage
+                {
+                    PackageId = "NuGet.Versioning",
+                    PackageVersion = "3.4.0-ALPHA",
+                    ValidationId = new Guid("f470b9fb-0243-4f65-8aef-90d93dfe1a03"),
+                    Package = new NuGetPackage
+                    {
+                        Id = "NuGet.Versioning",
+                        NormalizedVersion = "3.4.0-ALPHA"
+                    }
+                };
+                _auditEntries = new List<PackageValidationAuditEntry>();
+                _virusScanJob = new VirusScanJob
+                {
+                    JobId = "123",
+                    RequestId = "456",
+                    RegionCode = "USW",
+                };
+
+                _scanningService
+                    .Setup(x => x.CreateVirusScanJobAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<Guid>()))
+                    .Returns(() => Task.FromResult(_virusScanJob));
+
+                _target = new VcsValidator(
+                    _callbackUrl,
+                    _packageUrlTemplate,
+                    _scanningService.Object,
+                    _logger.Object);
+            }
+        }
+    }
+}

--- a/tests/Validation.Common.Tests/project.json
+++ b/tests/Validation.Common.Tests/project.json
@@ -1,0 +1,15 @@
+﻿{
+  "dependencies": {
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+    "NuGet.Services.VirusScanning.Vcs": "3.2.0",
+    "moq": "4.5.23",
+    "xunit": "2.1.0",
+    "xunit.runner.visualstudio": "2.1.0"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Jobs/pull/223. Fix https://github.com/NuGet/Engineering/issues/844.

100% of the past instances where request ID, job ID, and region code are null resulting in no VCS callback. This is 135 instances.