### PR TITLE
Fix Gallery.Maintenance crashes

### DIFF
--- a/src/Gallery.Maintenance/Job.cs
+++ b/src/Gallery.Maintenance/Job.cs
@@ -59,7 +59,7 @@ namespace Gallery.Maintenance
             var taskBaseType = typeof(MaintenanceTask);
 
             return taskBaseType.Assembly.GetTypes()
-                .Where(type => type.IsClass && taskBaseType.IsAssignableFrom(type))
+                .Where(type => type.IsClass && !type.IsAbstract && taskBaseType.IsAssignableFrom(type))
                 .Select(type => 
                     (MaintenanceTask) type.GetConstructor(
                         new Type[] { typeof(ILogger<>).MakeGenericType(type) })

--- a/src/Gallery.Maintenance/project.json
+++ b/src/Gallery.Maintenance/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+    "NuGet.Services.Logging": "2.2.3"
   },
   "frameworks": {
     "net452": {}


### PR DESCRIPTION
There were two issues here.
1 - The project needed to have `NuGet.Services.Logging` (I think this is related to the fact that it's `project.json` and the rest of the projects are `packages.config`.)
2 - `IMaintenanceTask` was changed to the abstract `MaintenanceTask` in a previous commit, which caused the reflection to fail because it didn't filter out `MaintenanceTask` itself