### PR TITLE
Adding "WebApp" package for the VCS callback service

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -102,7 +102,7 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
             "$PSScriptRoot\src\CopyAzureContainer\Properties\AssemblyInfo.g.cs",
             "$PSScriptRoot\src\NuGetCDNRedirect\Properties\AssemblyInfo.g.cs",
             "$PSScriptRoot\src\NuGet.Services.Validation.Orchestrator\Properties\AssemblyInfo.g.cs",
- 	    "$PSScriptRoot\src\Stats.CollectAzureChinaCDNLogs\Properties\AssemblyInfo.g.cs"
+            "$PSScriptRoot\src\Stats.CollectAzureChinaCDNLogs\Properties\AssemblyInfo.g.cs"
 
             
         $versionMetadata | ForEach-Object {
@@ -143,13 +143,14 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/HandlePackageEdits/HandlePackageEdits.csproj", `
             "src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj", `
             "src/Validation.Callback.Vcs/Validation.Callback.Vcs.csproj", `
+            "src/Validation.Callback.Vcs/Validation.Callback.Vcs.WebApp.nuspec", `
             "src/Validation.Runner/Validation.Runner.csproj", `
             "src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.csproj", `
             "src/Validation.Helper/Validation.Helper.csproj", `
             "src/CopyAzureContainer/CopyAzureContainer.csproj", `
             "src/NuGetCDNRedirect/NuGetCDNRedirect.csproj", `
             "src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj", `
-	    "src/Stats.CollectAzureChinaCDNLogs/Stats.CollectAzureChinaCDNLogs.csproj"
+            "src/Stats.CollectAzureChinaCDNLogs/Stats.CollectAzureChinaCDNLogs.csproj"
 
         Foreach ($Project in $Projects) {
             New-Package (Join-Path $PSScriptRoot "$Project") -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -Branch $Branch -MSBuildVersion "$msBuildVersion"

--- a/src/Validation.Callback.Vcs/Validation.Callback.Vcs.WebApp.nuspec
+++ b/src/Validation.Callback.Vcs/Validation.Callback.Vcs.WebApp.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Validation.Callback.Vcs.WebApp.$branch$</id>
+    <version>$version$</version>
+    <title>Validation.Callback.Vcs.WebApp</title>
+    <authors>.Net Foundation</authors>
+    <owners>.Net Foundation</owners>
+    <licenseUrl>https://github.com/NuGet/NuGet.Jobs/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/NuGet/NuGet.Jobs</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Validation.Callback.Vcs.WebApp</description>
+    <copyright>Copyright 2016 .NET Foundation</copyright>
+    <tags>nuget job</tags>
+  </metadata>
+   <files>
+    <file src="ApplicationInsights.config" />
+    <file src="Web.config" />
+    <file src="bin\**\*.*" exclude="bin\*.pdb;bin\*.xml" target="bin" />
+  </files>
+</package>

--- a/src/Validation.Callback.Vcs/Web.config
+++ b/src/Validation.Callback.Vcs/Web.config
@@ -5,14 +5,14 @@
   -->
 <configuration>
   <appSettings>
-    <add key="ApplicationInsightsInstrumentationKey" value="" />
-    <add key="DataStorageAccount" value="UseDevelopmentStorage=true" />
-    <add key="ContainerName" value="validation" />
-    <add key="KeyVault:VaultName" value="" />
-    <add key="KeyVault:ClientId" value="" />
-    <add key="KeyVault:CertificateThumbprint" value="" />
+    <add key="ApplicationInsightsInstrumentationKey" value="#{Jobs.validation.ApplicationInsightsInstrumentationKey}" />
+    <add key="DataStorageAccount" value="#{Jobs.validation.DataStorageAccount}" />
+    <add key="ContainerName" value="#{Jobs.validation.ContainerName}" />
+    <add key="KeyVault:VaultName" value="#{Deployment.Azure.KeyVault.VaultName}" />
+    <add key="KeyVault:ClientId" value="#{Deployment.Azure.KeyVault.ClientId}" />
+    <add key="KeyVault:CertificateThumbprint" value="#{Deployment.Azure.KeyVault.CertificateThumbprint}" />
     <add key="KeyVault:StoreName" value="My" />
-    <add key="KeyVault:StoreLocation" value="LocalMachine" />
+    <add key="KeyVault:StoreLocation" value="CurrentUser" />
     <add key="KeyVault:ValidateCertificate" value="true" />
   </appSettings>
   <!--


### PR DESCRIPTION
Addresses [eng-389](https://github.com/NuGet/Engineering/issues/389).
Added separate WebApp friendly package for the VCS callback service and updated web.config to use configuration values from Octopus.

Currently in prod, configuration is done by providing replacement values for the configuration through Azure Portal. So this change should not affect it.