### PR TITLE
[Package Signing] Added shared Package Signing project

### DIFF
--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26915.1
+VisualStudioVersion = 15.0.27005.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Jobs.Common", "src\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj", "{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}"
 EndProject
@@ -95,7 +95,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.O
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.Orchestrator.Tests", "tests\NuGet.Services.Validation.Orchestrator.Tests\NuGet.Services.Validation.Orchestrator.Tests.csproj", "{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageSigningValidationTest", "PackageSigningValidationTest\PackageSigningValidationTest.csproj", "{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.PackageSigning.Core", "src\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj", "{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -237,10 +237,10 @@ Global
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -278,6 +278,7 @@ Global
 		{FC0CEF12-D501-46D1-B1BF-D4134BD8D478} = {B9D03824-A9CA-43AC-86D6-8BB399B9A228}
 		{0C887292-C5AB-4107-946C-A53B18A38D22} = {6A776396-02B1-475D-A104-26940ADB04AB}
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632} = {6A776396-02B1-475D-A104-26940ADB04AB}
+		{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10} = {678D7B14-F8BC-4193-99AF-2EE8AA390A02}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {284A7AC3-FB43-4F1F-9C9C-2AF0E1F46C2B}

--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -95,6 +95,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.O
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Services.Validation.Orchestrator.Tests", "tests\NuGet.Services.Validation.Orchestrator.Tests\NuGet.Services.Validation.Orchestrator.Tests.csproj", "{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageSigningValidationTest", "PackageSigningValidationTest\PackageSigningValidationTest.csproj", "{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -235,6 +237,10 @@ Global
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A3B0B15D-22D9-4F1F-94C4-B24B28ECF632}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3786F98C-3DA1-4A00-8010-8AC53ECBA6E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -99,7 +99,7 @@
       <Version>2.2.5</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.3.0</Version>
+      <Version>2.3.2-master-15927</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>4.3.0</Version>

--- a/src/Validation.PackageSigning.Core/ICertificateStore.cs
+++ b/src/Validation.PackageSigning.Core/ICertificateStore.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs.Validation.PackageSigning
+{
+    /// <summary>
+    /// The class used to <see cref="X509Certificate2"/> store and retrieve certificates.
+    /// </summary>
+    public interface ICertificateStore
+    {
+        /// <summary>
+        /// Check if the store contains the certificate.
+        /// </summary>
+        /// <param name="thumbprint">The certificate's thumbprint.</param>
+        /// <returns>Whether the store contains a certificate that has the given thumbprint.</returns>
+        Task<bool> Exists(string thumbprint);
+
+        /// <summary>
+        /// Load the certificate into memory.
+        /// </summary>
+        /// <param name="thumbprint">The certificate's thumbprint.</param>
+        /// <returns>A certificate whose thumbprint is the given thumbprint.</returns>
+        Task<X509Certificate2> Load(string thumbprint);
+
+        /// <summary>
+        /// Save the certificate to the store.
+        /// </summary>
+        /// <param name="certificate">The certificate to save to the store.</param>
+        /// <returns>A task that completes when the certificate has been saved.</returns>
+        Task Save(X509Certificate2 certificate);
+    }
+}

--- a/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessage.cs
+++ b/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessage.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Jobs.Validation.PackageSigning.Messages
+{
+    /// <summary>
+    /// The message used to kick off a Certificate Validation.
+    /// </summary>
+    public class CertificateValidationMessage
+    {
+        /// <summary>
+        /// The key to the certificate that should be validated.
+        /// </summary>
+        public long CertificateKey { get; set; }
+
+        /// <summary>
+        /// This validation's identifier. Certificate validations may share the same validation
+        /// id (used to validate multiple certificates in one validation).
+        /// </summary>
+        public Guid ValidationId { get; set; }
+
+        /// <summary>
+        /// Whether a revoked certificate should be revalidated. By default, Certificate Authorities
+        /// are not required to keep a certificate's revocation information forever, therefore, revoked
+        /// certificates should only be revalidated in special cases such as a manual revalidation gesture
+        /// by a NuGet Admin.
+        /// </summary>
+        public bool RevalidateRevokedCertificate { get; set; }
+    }
+}

--- a/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessageSerializer.cs
+++ b/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessageSerializer.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Services.ServiceBus;
+
+namespace NuGet.Jobs.Validation.PackageSigning.Messages
+{
+    public class CertificateValidationMessageSerializer : IBrokeredMessageSerializer<CertificateValidationMessage>
+    {
+        private const string CertificateValidationSchemaName = "CertificateValidationMessageData";
+
+        private BrokeredMessageSerializer<CertificateValidationMessageData1> _serializer;
+
+        public IBrokeredMessage Serialize(CertificateValidationMessage message)
+        {
+            return _serializer.Serialize(new CertificateValidationMessageData1
+            {
+                CertificateKey = message.CertificateKey,
+                ValidationId = message.ValidationId,
+                RevalidateRevokedCertificate = message.RevalidateRevokedCertificate
+            });
+        }
+
+        public CertificateValidationMessage Deserialize(IBrokeredMessage message)
+        {
+            var deserializedMessage = _serializer.Deserialize(message);
+
+            return new CertificateValidationMessage
+            {
+                CertificateKey = deserializedMessage.CertificateKey,
+                ValidationId = deserializedMessage.ValidationId,
+                RevalidateRevokedCertificate = deserializedMessage.RevalidateRevokedCertificate
+            };
+        }
+
+        [Schema(Name = CertificateValidationSchemaName, Version = 1)]
+        private struct CertificateValidationMessageData1
+        {
+            public long CertificateKey { get; set; }
+            public Guid ValidationId { get; set; }
+            public bool RevalidateRevokedCertificate { get; set; }
+        }
+    }
+}

--- a/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessageSerializer.cs
+++ b/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessageSerializer.cs
@@ -10,7 +10,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
     {
         private const string CertificateValidationSchemaName = "CertificateValidationMessageData";
 
-        private BrokeredMessageSerializer<CertificateValidationMessageData1> _serializer;
+        private IBrokeredMessageSerializer<CertificateValidationMessageData1> _serializer =
+            new BrokeredMessageSerializer<CertificateValidationMessageData1>();
 
         public IBrokeredMessage Serialize(CertificateValidationMessage message)
         {

--- a/src/Validation.PackageSigning.Core/Properties/AssemblyInfo.cs
+++ b/src/Validation.PackageSigning.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Validation.PackageSigning.Core")]
+[assembly: AssemblyDescription("Shared libraries for package signing validation")]
+[assembly: AssemblyCompany(".NET Foundation")]
+[assembly: AssemblyProduct("Validation.PackageSigning.Core")]
+[assembly: AssemblyCopyright("Copyright © .NET Foundation 2017")]
+[assembly: ComVisible(false)]
+[assembly: Guid("91c060da-736f-4da9-a57f-cb3ac0e6cb10")]

--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -30,16 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <!-- TODO: Don't do this, consume packages! -->
-    <Reference Include="NuGet.Services.Contracts">
-      <HintPath>..\..\..\ServerCommon\src\NuGet.Services.Validation\bin\Debug\NuGet.Services.Contracts.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Services.ServiceBus">
-      <HintPath>..\..\..\ServerCommon\src\NuGet.Services.Validation\bin\Debug\NuGet.Services.ServiceBus.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Services.Validation">
-      <HintPath>..\..\..\ServerCommon\src\NuGet.Services.Validation\bin\Debug\NuGet.Services.Validation.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -48,6 +38,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGet.Services.ServiceBus" Version="2.3.2-master-15927" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ICertificateStore.cs" />

--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Jobs.Validation.PackageSigning</RootNamespace>
+    <AssemblyName>NuGet.Jobs.Validation.PackageSigning</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- TODO: Don't do this, consume packages! -->
+    <Reference Include="NuGet.Services.Contracts">
+      <HintPath>..\..\..\ServerCommon\src\NuGet.Services.Validation\bin\Debug\NuGet.Services.Contracts.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Services.ServiceBus">
+      <HintPath>..\..\..\ServerCommon\src\NuGet.Services.Validation\bin\Debug\NuGet.Services.ServiceBus.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Services.Validation">
+      <HintPath>..\..\..\ServerCommon\src\NuGet.Services.Validation\bin\Debug\NuGet.Services.Validation.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ICertificateStore.cs" />
+    <Compile Include="Messages\CertificateValidationMessage.cs" />
+    <Compile Include="Messages\CertificateValidationMessageSerializer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ConfigurationFacts.cs" />
     <Compile Include="PackageSigning\PackageSigningValidatorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestDbAsyncQueryProvider.cs" />
     <Compile Include="ValidationContextHelpers.cs" />
     <Compile Include="ValidatorStateServiceFacts.cs" />
     <Compile Include="Vcs\VcsValidatorFacts.cs" />


### PR DESCRIPTION
Adds a shared project that will be used across different package signing projects. Contains:

* `ICertificateStore` - @xavierdecoster will need to implement this as part of the Extract Package Signature job. The certificates will later be consumed by the certificates validator.
* `CertificateValidationMessage`/`CertificateValidationMessageSerializer` - the messaged use by the `CertificatesValidator` to kick off `VerifyCertificate` jobs.

@xavierdecoster The message and serializer used for the Extract and Validate Package Signatures job should be added here.