### PR TITLE
Excluding microsoft.*, system.* and runtime.native.* package id's from top downloaded packages list in past 6 weeks

### DIFF
--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentPopularity.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentPopularity.sql
@@ -26,6 +26,9 @@ BEGIN
 			AND F.[Timestamp] <= @Cursor
 			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
 			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
+			AND (P.[LowercasedPackageId] NOT LIKE 'microsoft.%'
+				AND P.[LowercasedPackageId] NOT LIKE 'system.%'
+				AND P.[LowercasedPackageId] NOT LIKE 'runtime.native.%')
 
 	GROUP BY	P.[PackageId]
 	ORDER BY	[Downloads] DESC

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentPopularityDetail.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentPopularityDetail.sql
@@ -27,7 +27,10 @@ BEGIN
 			AND ISNULL(D.[Date], CONVERT(DATE, DATEADD(day, 1, @ReportGenerationTime))) <= CONVERT(DATE, @ReportGenerationTime)
 			AND F.[Timestamp] <= @Cursor
 			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
-			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
+			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)			
+			AND (P.[LowercasedPackageId] NOT LIKE 'microsoft.%'
+				AND P.[LowercasedPackageId] NOT LIKE 'system.%'
+				AND P.[LowercasedPackageId] NOT LIKE 'runtime.native.%')
 
 	GROUP BY	P.[PackageId],
 				P.[PackageVersion]


### PR DESCRIPTION
A quick win would be to simply filter them out on the two queries used to generate the JSON blobs for these UI reports.

https://github.com/NuGet/NuGetGallery/issues/3417