### PR TITLE
Tweaking target .NET Framework versions

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/App.config
+++ b/src/NuGet.Services.Validation.Orchestrator/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
     </startup>
 </configuration>

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NuGet.Services.Validation.Orchestrator</RootNamespace>
     <AssemblyName>NuGet.Services.Validation.Orchestrator</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGet.Jobs.Validation.PackageSigning</RootNamespace>
     <AssemblyName>NuGet.Jobs.Validation.PackageSigning</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
`Validation.PackageSigning.Core` will need to be consumed by the Gallery's Admin panel. This pull request lowers the target framework for the core signing package to match the Gallery's target framework.

@agr: I also bumped up Orchestrator's target from 4.5 to 4.6 to be consistent. Note that this change targets the `dev-package-signing` branch, so feel free to mirror this change in your own branch - I'll fix the merge conflict later.