### PR TITLE
Fix two issues with Validation.Helper

### DIFF
--- a/src/Validation.Common/PackageValidationQueue.cs
+++ b/src/Validation.Common/PackageValidationQueue.cs
@@ -84,6 +84,14 @@ namespace NuGet.Jobs.Validation.Common
                 deserializedMessage.PopReceipt = message.PopReceipt;
                 deserializedMessage.DequeueCount = message.DequeueCount;
 
+                if (deserializedMessage.Package?.DownloadUrl != null)
+                {
+                    // Don't read the package URL from OData. Instead, allow the validators to build the package URL
+                    // themselves. This is important because the URL in the OData feed is not pointing directly to
+                    // Azure Blob Storage, which is required by the VCS validator.
+                    deserializedMessage.Package.DownloadUrl = null;
+                }
+
                 results.Add(deserializedMessage);
             }
 

--- a/src/Validation.Helper/project.json
+++ b/src/Validation.Helper/project.json
@@ -1,5 +1,9 @@
 ﻿{
   "dependencies": {
+    "Microsoft.Data.OData": {
+      "version": "5.7.0",
+      "comment": "Not a direct dependency, workaround to have correct version of json.dll to be put in the output directory. Probably could be removed once all dependent projects are upgraded to use project.json"
+    },
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
     "Newtonsoft.Json": {
       "version": "9.0.1",

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -287,11 +287,6 @@ namespace NuGet.Jobs.Validation.Runner
                 // Start the validation process for each package
                 foreach (var package in packages)
                 {
-                    // Don't read the package URL from OData. Instead, allow the validators to build the package URL
-                    // themselves. This is important because the URL in the OData feed is not pointing directly to
-                    // Azure Blob Storage, which is required by the VCS validator.
-                    package.DownloadUrl = null;
-
                     await packageValidationService.StartValidationProcessAsync(package, _requestValidationTasks);
                 }
 


### PR DESCRIPTION
Issues:

1. Runtime exception where Microsoft.Data.OData could not be found at runtime.
1. Validation.Helper was enqueueing messages with gallery download URL. VCS does not accept this. Therefore, make the dequeueing code clear the download URL so it never arrives at the VCS validator.