### PR TITLE
[PackageSigning] Change the interface of ValidatorStateService

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningValidator.cs
@@ -27,7 +27,7 @@ namespace NuGet.Services.Validation.PackageSigning
 
         public async Task<ValidationStatus> GetStatusAsync(IValidationRequest request)
         {
-            var validatorStatus = await _validatorStateService.GetStatusAsync<PackageSigningValidator>(request);
+            var validatorStatus = await _validatorStateService.GetStatusAsync(request);
 
             return validatorStatus.State;
         }
@@ -35,7 +35,7 @@ namespace NuGet.Services.Validation.PackageSigning
         public async Task<ValidationStatus> StartValidationAsync(IValidationRequest request)
         {
             // Check that this is the first validation for this specific request.
-            var validatorStatus = await _validatorStateService.GetStatusAsync<PackageSigningValidator>(request);
+            var validatorStatus = await _validatorStateService.GetStatusAsync(request);
 
             if (validatorStatus.State != ValidationStatus.NotStarted)
             {
@@ -53,7 +53,7 @@ namespace NuGet.Services.Validation.PackageSigning
             validatorStatus.State = ValidationStatus.Incomplete;
 
             await _packageSignatureVerifier.StartVerificationAsync(request);
-            var result = await _validatorStateService.AddStatusAsync<PackageSigningValidator>(validatorStatus);
+            var result = await _validatorStateService.AddStatusAsync(validatorStatus);
 
             if (result == AddStatusResult.StatusAlreadyExists)
             {

--- a/src/Validation.PackageSigning.Core/Storage/IValidatorStateService.cs
+++ b/src/Validation.PackageSigning.Core/Storage/IValidatorStateService.cs
@@ -14,34 +14,30 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
         /// <summary>
         /// Get the persisted <see cref="ValidatorStatus"/> for the given <see cref="IValidationRequest"/>.
         /// </summary>
-        /// <typeparam name="T">The <see cref="IValidator"/> whose status should be fetched.</typeparam>
         /// <param name="request">The request whose status should be fetched.</param>
         /// <returns>The persisted status of the validation request, or, a new ValidatorStatus if no status has been persisted.</returns>
-        Task<ValidatorStatus> GetStatusAsync<T>(IValidationRequest request) where T : IValidator;
+        Task<ValidatorStatus> GetStatusAsync(IValidationRequest request);
 
         /// <summary>
         /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/> by
         /// a different validation request.
         /// </summary>
-        /// <typeparam name="T">The <see cref="IValidator"/> whose statuses should be evaluated.</typeparam>
         /// <param name="request">The package validation request.</param>
         /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package in a different validation request.</returns>
-        Task<bool> IsRevalidationRequestAsync<T>(IValidationRequest request) where T : IValidator;
+        Task<bool> IsRevalidationRequestAsync(IValidationRequest request);
 
         /// <summary>
         /// Persist the status of a new validation request.
         /// </summary>
-        /// <typeparam name="T">The <see cref="IValidator"/> whose status should be added.</typeparam>
         /// <param name="status">The status of the given validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        Task<AddStatusResult> AddStatusAsync<T>(ValidatorStatus status) where T : IValidator;
+        Task<AddStatusResult> AddStatusAsync(ValidatorStatus status);
 
         /// <summary>
         /// Persist the status of an already existing validation request.
         /// </summary>
-        /// <typeparam name="T">The <see cref="IValidator"/> whose status should be saved.</typeparam>
         /// <param name="status">The updated status for the validation request.</param>
         /// <returns>A task that completes when the status has been persisted.</returns>
-        Task<SaveStatusResult> SaveStatusAsync<T>(ValidatorStatus status) where T : IValidator;
+        Task<SaveStatusResult> SaveStatusAsync(ValidatorStatus status);
     }
 }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
@@ -37,7 +37,7 @@ namespace NuGet.Services.Validation.PackageSigning
             {
                 // Arrange
                 _validatorStateService
-                    .Setup(x => x.GetStatusAsync<PackageSigningValidator>(It.IsAny<IValidationRequest>()))
+                    .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
                     .ReturnsAsync(new ValidatorStatus
                     {
                         ValidationId = ValidationId,
@@ -70,7 +70,7 @@ namespace NuGet.Services.Validation.PackageSigning
             {
                 // Arrange
                 _validatorStateService
-                     .Setup(x => x.GetStatusAsync<PackageSigningValidator>(It.IsAny<IValidationRequest>()))
+                     .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
                      .ReturnsAsync(new ValidatorStatus
                      {
                          ValidationId = ValidationId,
@@ -86,7 +86,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     .Verify(x => x.StartVerificationAsync(It.IsAny<IValidationRequest>()), Times.Never);
 
                 _validatorStateService
-                    .Verify(x => x.AddStatusAsync<PackageSigningValidator>(It.IsAny<ValidatorStatus>()), Times.Never);
+                    .Verify(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
             }
 
             [Fact]
@@ -98,7 +98,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 bool verificationQueuedBeforeStatePersisted = false;
 
                 _validatorStateService
-                     .Setup(x => x.GetStatusAsync<PackageSigningValidator>(It.IsAny<IValidationRequest>()))
+                     .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
                      .ReturnsAsync(new ValidatorStatus
                      {
                          ValidationId = ValidationId,
@@ -116,7 +116,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     .Returns(Task.FromResult(0));
 
                 _validatorStateService
-                    .Setup(x => x.AddStatusAsync<PackageSigningValidator>(It.IsAny<ValidatorStatus>()))
+                    .Setup(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()))
                     .Callback(() =>
                     {
                         statePersisted = true;
@@ -132,7 +132,7 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _validatorStateService
                     .Verify(
-                        x => x.AddStatusAsync<PackageSigningValidator>(
+                        x => x.AddStatusAsync(
                                 It.Is<ValidatorStatus>(s => s.State == ValidationStatus.Incomplete)),
                         Times.Once);
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
@@ -49,10 +49,10 @@ namespace NuGet.Services.Validation
                 // Arrange
                 _validationContext.Mock();
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                var status = await stateService.GetStatusAsync<AValidator>(_validationRequest.Object);
+                var status = await stateService.GetStatusAsync(_validationRequest.Object);
 
                 Assert.Equal(ValidationId, status.ValidationId);
                 Assert.Equal(PackageKey, status.PackageKey);
@@ -76,10 +76,10 @@ namespace NuGet.Services.Validation
                         }
                     });
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                var status = await stateService.GetStatusAsync<AValidator>(_validationRequest.Object);
+                var status = await stateService.GetStatusAsync(_validationRequest.Object);
 
                 Assert.Equal(ValidationId, status.ValidationId);
                 Assert.Equal(PackageKey, status.PackageKey);
@@ -113,10 +113,10 @@ namespace NuGet.Services.Validation
                         }
                     });
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                var persistedStatus = await stateService.GetStatusAsync<AValidator>(_validationRequest.Object);
+                var persistedStatus = await stateService.GetStatusAsync(_validationRequest.Object);
 
                 Assert.Equal(ValidationId, persistedStatus.ValidationId);
                 Assert.Equal(PackageKey, persistedStatus.PackageKey);
@@ -128,7 +128,7 @@ namespace NuGet.Services.Validation
             public async Task GetStatusThrowsOnInvalidPackageKey()
             {
                 // Arrange
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 _validationContext.Mock(validatorStatuses: new[]
                 {
@@ -142,14 +142,14 @@ namespace NuGet.Services.Validation
                 });
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(async () => await stateService.GetStatusAsync<AValidator>(_validationRequest.Object));
+                await Assert.ThrowsAsync<ArgumentException>(async () => await stateService.GetStatusAsync(_validationRequest.Object));
             }
 
             [Fact]
             public async Task GetStatusThrowsOnInvalidValidatorName()
             {
                 // Arrange
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 _validationContext.Mock(validatorStatuses: new[]
                 {
@@ -163,7 +163,7 @@ namespace NuGet.Services.Validation
                 });
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(async () => await stateService.GetStatusAsync<AValidator>(_validationRequest.Object));
+                await Assert.ThrowsAsync<ArgumentException>(async () => await stateService.GetStatusAsync(_validationRequest.Object));
             }
 
             public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
@@ -177,10 +177,10 @@ namespace NuGet.Services.Validation
                 // Arrange
                 _validationContext.Mock();
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                Assert.False(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
+                Assert.False(await stateService.IsRevalidationRequestAsync(_validationRequest.Object));
             }
 
             [Fact]
@@ -200,10 +200,10 @@ namespace NuGet.Services.Validation
                         }
                     });
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                Assert.True(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
+                Assert.True(await stateService.IsRevalidationRequestAsync(_validationRequest.Object));
             }
 
             [Fact]
@@ -223,10 +223,10 @@ namespace NuGet.Services.Validation
                         }
                     });
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                Assert.False(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
+                Assert.False(await stateService.IsRevalidationRequestAsync(_validationRequest.Object));
             }
 
             [Fact]
@@ -253,10 +253,10 @@ namespace NuGet.Services.Validation
                         }
                     });
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                Assert.True(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
+                Assert.True(await stateService.IsRevalidationRequestAsync(_validationRequest.Object));
             }
 
             [Fact]
@@ -284,10 +284,10 @@ namespace NuGet.Services.Validation
                         }
                     });
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                Assert.False(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
+                Assert.False(await stateService.IsRevalidationRequestAsync(_validationRequest.Object));
             }
 
             [Fact]
@@ -322,10 +322,10 @@ namespace NuGet.Services.Validation
                         }
                     });
 
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 // Act & Assert
-                Assert.True(await stateService.IsRevalidationRequestAsync<AValidator>(_validationRequest.Object));
+                Assert.True(await stateService.IsRevalidationRequestAsync(_validationRequest.Object));
             }
         }
 
@@ -335,7 +335,7 @@ namespace NuGet.Services.Validation
             public async Task AddStatusAsyncThrowsIfValidatorNameIsWrong()
             {
                 // Arrange
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
                 var validationStatus = new ValidatorStatus
                 {
                     ValidationId = ValidationId,
@@ -345,7 +345,7 @@ namespace NuGet.Services.Validation
                 };
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync<AValidator>(validationStatus));
+                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync(validationStatus));
             }
 
             [Theory]
@@ -355,12 +355,12 @@ namespace NuGet.Services.Validation
                 // Arrange
                 var validatorName = nameof(AValidator);
                 var validatorStatuses = new Mock<IDbSet<ValidatorStatus>>();
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
 
                 _validationContext.Mock(validatorStatusesMock: validatorStatuses);
 
                 // Act & Assert
-                var result = await stateService.AddStatusAsync<AValidator>(new ValidatorStatus
+                var result = await stateService.AddStatusAsync(new ValidatorStatus
                 {
                     ValidationId = ValidationId,
                     PackageKey = PackageKey,
@@ -391,7 +391,7 @@ namespace NuGet.Services.Validation
             public async Task SaveStatusAsyncThrowsIfValidatorNameIsWrong()
             {
                 // Arrange
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
                 var validatorStatus = new ValidatorStatus
                 {
                     ValidationId = ValidationId,
@@ -401,7 +401,7 @@ namespace NuGet.Services.Validation
                 };
 
                 // Act & Assert
-                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync<AValidator>(validatorStatus));
+                await Assert.ThrowsAsync<ArgumentException>(() => stateService.AddStatusAsync(validatorStatus));
             }
 
             [Theory]
@@ -409,7 +409,7 @@ namespace NuGet.Services.Validation
             public async Task SaveStatusAsyncMethodPersistsStatus(ValidationStatus status)
             {
                 // Arrange
-                var stateService = new ValidatorStateService(_validationContext.Object);
+                var stateService = new ValidatorStateService(_validationContext.Object, typeof(AValidator));
                 var validatorStatus = new ValidatorStatus
                 {
                     ValidationId = ValidationId,
@@ -421,7 +421,7 @@ namespace NuGet.Services.Validation
                 _validationContext.Mock();
 
                 // Act & Assert
-                await stateService.AddStatusAsync<AValidator>(validatorStatus);
+                await stateService.AddStatusAsync(validatorStatus);
 
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
             }


### PR DESCRIPTION
Move the `IValidator` type on all `IValidatorStateService` method calls to the constructor of  `ValidatorStateService`. This restricts an instance of an `ValidatorStateService` to a single `IValidator`, however, this simplifies this:

```
_validatorStateService.GetStatusAsync<PackageSigningValidator>(request);
```

to this:

```
_validatorStateService.GetStatusAsync(request);
```