### PR TITLE
[Statistics] Add community popularity reports

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Job.cs
@@ -30,6 +30,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
         {
             {ReportNames.NuGetClientVersion, "[dbo].[DownloadReportNuGetClientVersion]" },
             {ReportNames.Last6Weeks, "[dbo].[DownloadReportLast6Weeks]" },
+            {ReportNames.RecentCommunityPopularity, "[dbo].[DownloadReportRecentCommunityPopularity]" },
+            {ReportNames.RecentCommunityPopularityDetail, "[dbo].[DownloadReportRecentCommunityPopularityDetail]" },
             {ReportNames.RecentPopularity, "[dbo].[DownloadReportRecentPopularity]" },
             {ReportNames.RecentPopularityDetail, "[dbo].[DownloadReportRecentPopularityDetail]" },
         };
@@ -81,6 +83,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
                     {
                         { new ReportBuilder(reportBuilderLogger, ReportNames.NuGetClientVersion), new ReportDataCollector(reportCollectorLogger, _storedProcedures[ReportNames.NuGetClientVersion], _statisticsDatabase) },
                         { new ReportBuilder(reportBuilderLogger, ReportNames.Last6Weeks), new ReportDataCollector(reportCollectorLogger, _storedProcedures[ReportNames.Last6Weeks], _statisticsDatabase) },
+                        { new ReportBuilder(reportBuilderLogger, ReportNames.RecentCommunityPopularity), new ReportDataCollector(reportCollectorLogger, _storedProcedures[ReportNames.RecentCommunityPopularity], _statisticsDatabase) },
+                        { new ReportBuilder(reportBuilderLogger, ReportNames.RecentCommunityPopularityDetail), new ReportDataCollector(reportCollectorLogger, _storedProcedures[ReportNames.RecentCommunityPopularityDetail], _statisticsDatabase) },
                         { new ReportBuilder(reportBuilderLogger, ReportNames.RecentPopularity), new ReportDataCollector(reportCollectorLogger, _storedProcedures[ReportNames.RecentPopularity], _statisticsDatabase) },
                         { new ReportBuilder(reportBuilderLogger, ReportNames.RecentPopularityDetail), new ReportDataCollector(reportCollectorLogger, _storedProcedures[ReportNames.RecentPopularityDetail], _statisticsDatabase) }
                     };
@@ -293,6 +297,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
         {
             public const string NuGetClientVersion = "nugetclientversion";
             public const string Last6Weeks = "last6weeks";
+            public const string RecentCommunityPopularity = "recentcommunitypopularity";
+            public const string RecentCommunityPopularityDetail = "recentcommunitypopularitydetail";
             public const string RecentPopularity = "recentpopularity";
             public const string RecentPopularityDetail = "recentpopularitydetail";
             public const string RecentPopularityDetailByPackageId = "recentpopularitydetailbypackageid";

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
@@ -1,0 +1,49 @@
+﻿CREATE PROCEDURE [dbo].[DownloadReportRecentCommunityPopularity]
+	@ReportGenerationTime DATETIME
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	-- Find all non-community package ids that should be filtered out from the report
+	Declare @NonCommunityPackages TABLE (LowercasedPackageId nvarchar(128))
+
+	INSERT INTO @NonCommunityPackages
+		SELECT P.[LowercasedPackageId]
+		FROM [dbo].[Fact_Package_PackageSet] P
+		WHERE P.[Dimension_PackageSet_Id] IN
+		(
+			SELECT PS.[Id]
+			FROM [dbo].[Dimension_PackageSet] PS
+			WHERE
+				PS.[Name] = 'Microsoft' OR
+				PS.[Name] = 'ASP.NET MVC' OR
+				PS.[Name] = 'ASP.NET Web API'
+		)
+
+	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')
+
+	-- Find all packages that have had download facts added in the last 42 days, today inclusive
+	SELECT		TOP 100 P.[PackageId]
+				,SUM(ISNULL(F.[DownloadCount], 0)) AS 'Downloads'
+	FROM		[dbo].[Fact_Download] AS F (NOLOCK)
+
+	INNER JOIN	[dbo].[Dimension_Date] AS D (NOLOCK)
+	ON			F.[Dimension_Date_Id] = D.[Id]
+
+	INNER JOIN	[dbo].[Dimension_Package] AS P (NOLOCK)
+	ON			F.[Dimension_Package_Id] = P.[Id]
+
+	INNER JOIN	Dimension_Client AS C (NOLOCK)
+	ON			C.[Id] = F.[Dimension_Client_Id]
+
+	WHERE		D.[Date] IS NOT NULL
+			AND ISNULL(D.[Date], CONVERT(DATE, '1900-01-01')) >= CONVERT(DATE, DATEADD(day, -42, @ReportGenerationTime))
+			AND ISNULL(D.[Date], CONVERT(DATE, DATEADD(day, 1, @ReportGenerationTime))) <= CONVERT(DATE, @ReportGenerationTime)
+			AND F.[Timestamp] <= @Cursor
+			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
+			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
+			AND P.LowercasedPackageId NOT IN (SELECT [LowercasedPackageId] FROM @NonCommunityPackages)
+
+	GROUP BY	P.[PackageId]
+	ORDER BY	[Downloads] DESC
+END

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
@@ -28,7 +28,9 @@ BEGIN
 			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
 			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
 			AND P.[LowercasedPackageId] NOT IN (
-				SELECT [LowercasedPackageId] FROM [dbo].[Fact_Package_PackageSet] WHERE [Dimension_PackageSet_Id] = @NonCommunityPackagesId
+				SELECT [LowercasedPackageId]
+				FROM [dbo].[Fact_Package_PackageSet]
+				WHERE [Dimension_PackageSet_Id] = @NonCommunityPackagesId
 			)
 
 	GROUP BY	P.[PackageId]

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
@@ -18,9 +18,6 @@ BEGIN
 	INNER JOIN	[dbo].[Dimension_Package] AS P (NOLOCK)
 	ON			F.[Dimension_Package_Id] = P.[Id]
 
-	LEFT JOIN   [dbo].[Fact_Package_PackageSet] AS PS (NOLOCK)
-	ON          P.[LowercasedPackageId] = PS.[LowercasedPackageId]
-
 	INNER JOIN	Dimension_Client AS C (NOLOCK)
 	ON			C.[Id] = F.[Dimension_Client_Id]
 
@@ -30,7 +27,9 @@ BEGIN
 			AND F.[Timestamp] <= @Cursor
 			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
 			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
-			AND (PS.[Id] IS NULL OR PS.[Id] != @NonCommunityPackagesId)
+			AND P.[LowercasedPackageId] NOT IN (
+				SELECT [LowercasedPackageId] FROM [dbo].[Fact_Package_PackageSet] WHERE [Dimension_PackageSet_Id] = @NonCommunityPackagesId
+			)
 
 	GROUP BY	P.[PackageId]
 	ORDER BY	[Downloads] DESC

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
@@ -14,10 +14,12 @@ BEGIN
 		(
 			SELECT PS.[Id]
 			FROM [dbo].[Dimension_PackageSet] PS
-			WHERE
-				PS.[Name] = 'Microsoft' OR
-				PS.[Name] = 'ASP.NET MVC' OR
-				PS.[Name] = 'ASP.NET Web API'
+			WHERE PS.[Name] IN
+			(
+				'Microsoft',
+				'ASP.NET MVC',
+				'ASP.NET Web API'
+			)
 		)
 
 	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
@@ -4,17 +4,8 @@ AS
 BEGIN
 	SET NOCOUNT ON;
 
-	-- Find all non-community package ids that should be filtered out from the report
-	Declare @NonCommunityPackages TABLE (LowercasedPackageId nvarchar(128))
-
-	INSERT INTO @NonCommunityPackages
-		SELECT P.[LowercasedPackageId]
-		FROM [dbo].[Fact_Package_PackageSet] P
-		INNER JOIN [dbo].[Dimension_PackageSet] PS
-		ON P.[Dimension_PackageSet_Id] = PS.[Id]
-		WHERE PS.[Name] = 'NonCommunityPackages'
-
 	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')
+	DECLARE @NonCommunityPackagesId int = (SELECT [Id] FROM [dbo].[Dimension_PackageSet] WHERE [Name] = 'NonCommunityPackages');
 
 	-- Find all packages that have had download facts added in the last 42 days, today inclusive
 	SELECT		TOP 100 P.[PackageId]
@@ -27,6 +18,9 @@ BEGIN
 	INNER JOIN	[dbo].[Dimension_Package] AS P (NOLOCK)
 	ON			F.[Dimension_Package_Id] = P.[Id]
 
+	LEFT JOIN   [dbo].[Fact_Package_PackageSet] AS PS (NOLOCK)
+	ON          P.[LowercasedPackageId] = PS.[LowercasedPackageId]
+
 	INNER JOIN	Dimension_Client AS C (NOLOCK)
 	ON			C.[Id] = F.[Dimension_Client_Id]
 
@@ -36,7 +30,7 @@ BEGIN
 			AND F.[Timestamp] <= @Cursor
 			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
 			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
-			AND P.LowercasedPackageId NOT IN (SELECT [LowercasedPackageId] FROM @NonCommunityPackages)
+			AND (PS.[Id] IS NULL OR PS.[Id] != @NonCommunityPackagesId)
 
 	GROUP BY	P.[PackageId]
 	ORDER BY	[Downloads] DESC

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularity.sql
@@ -10,17 +10,9 @@ BEGIN
 	INSERT INTO @NonCommunityPackages
 		SELECT P.[LowercasedPackageId]
 		FROM [dbo].[Fact_Package_PackageSet] P
-		WHERE P.[Dimension_PackageSet_Id] IN
-		(
-			SELECT PS.[Id]
-			FROM [dbo].[Dimension_PackageSet] PS
-			WHERE PS.[Name] IN
-			(
-				'Microsoft',
-				'ASP.NET MVC',
-				'ASP.NET Web API'
-			)
-		)
+		INNER JOIN [dbo].[Dimension_PackageSet] PS
+		ON P.[Dimension_PackageSet_Id] = PS.[Id]
+		WHERE PS.[Name] = 'NonCommunityPackages'
 
 	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')
 

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
@@ -21,9 +21,6 @@ BEGIN
 	INNER JOIN	[dbo].[Dimension_Package] AS P (NOLOCK)
 	ON			F.[Dimension_Package_Id] = P.[Id]
 
-	LEFT JOIN   [dbo].[Fact_Package_PackageSet] AS PS (NOLOCK)
-	ON          P.[LowercasedPackageId] = PS.[LowercasedPackageId]
-
 	INNER JOIN	Dimension_Client AS C (NOLOCK)
 	ON			C.[Id] = F.[Dimension_Client_Id]
 
@@ -33,7 +30,9 @@ BEGIN
 			AND F.[Timestamp] <= @Cursor
 			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
 			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
-			AND (PS.[Id] IS NULL OR PS.[Id] != @NonCommunityPackagesId)
+			AND P.[LowercasedPackageId] NOT IN (
+				SELECT [LowercasedPackageId] FROM [dbo].[Fact_Package_PackageSet] WHERE [Dimension_PackageSet_Id] = @NonCommunityPackagesId
+			)
 
 	GROUP BY	P.[PackageId],
 				P.[PackageVersion]

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
@@ -14,10 +14,12 @@ BEGIN
 		(
 			SELECT PS.[Id]
 			FROM [dbo].[Dimension_PackageSet] PS
-			WHERE
-				PS.[Name] = 'Microsoft' OR
-				PS.[Name] = 'ASP.NET MVC' OR
-				PS.[Name] = 'ASP.NET Web API'
+			WHERE PS.[Name] IN
+			(
+				'Microsoft',
+				'ASP.NET MVC',
+				'ASP.NET Web API'
+			)
 		)
 
 	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
@@ -1,0 +1,52 @@
+﻿CREATE PROCEDURE [dbo].[DownloadReportRecentCommunityPopularityDetail]
+	@ReportGenerationTime DATETIME
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	-- Find all non-community package ids that should be filtered out from the report
+	Declare @NonCommunityPackages TABLE (LowercasedPackageId nvarchar(128))
+
+	INSERT INTO @NonCommunityPackages
+		SELECT P.[LowercasedPackageId]
+		FROM [dbo].[Fact_Package_PackageSet] P
+		WHERE P.[Dimension_PackageSet_Id] IN
+		(
+			SELECT PS.[Id]
+			FROM [dbo].[Dimension_PackageSet] PS
+			WHERE
+				PS.[Name] = 'Microsoft' OR
+				PS.[Name] = 'ASP.NET MVC' OR
+				PS.[Name] = 'ASP.NET Web API'
+		)
+
+	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')
+
+	-- Find all packages that have had download facts added in the last 42 days, today inclusive
+	SELECT		TOP 500
+				P.[PackageId]
+				,P.[PackageVersion]
+				,SUM(ISNULL(F.[DownloadCount], 0)) AS 'Downloads'
+	FROM		[dbo].[Fact_Download] AS F (NOLOCK)
+
+	INNER JOIN	[dbo].[Dimension_Date] AS D (NOLOCK)
+	ON			F.[Dimension_Date_Id] = D.[Id]
+
+	INNER JOIN	[dbo].[Dimension_Package] AS P (NOLOCK)
+	ON			F.[Dimension_Package_Id] = P.[Id]
+
+	INNER JOIN	Dimension_Client AS C (NOLOCK)
+	ON			C.[Id] = F.[Dimension_Client_Id]
+
+	WHERE		D.[Date] IS NOT NULL
+			AND ISNULL(D.[Date], CONVERT(DATE, '1900-01-01')) >= CONVERT(DATE, DATEADD(day, -42, @ReportGenerationTime))
+			AND ISNULL(D.[Date], CONVERT(DATE, DATEADD(day, 1, @ReportGenerationTime))) <= CONVERT(DATE, @ReportGenerationTime)
+			AND F.[Timestamp] <= @Cursor
+			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
+			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
+			AND P.LowercasedPackageId NOT IN (SELECT [LowercasedPackageId] FROM @NonCommunityPackages)
+
+	GROUP BY	P.[PackageId],
+				P.[PackageVersion]
+	ORDER BY	[Downloads] DESC
+END

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
@@ -10,17 +10,9 @@ BEGIN
 	INSERT INTO @NonCommunityPackages
 		SELECT P.[LowercasedPackageId]
 		FROM [dbo].[Fact_Package_PackageSet] P
-		WHERE P.[Dimension_PackageSet_Id] IN
-		(
-			SELECT PS.[Id]
-			FROM [dbo].[Dimension_PackageSet] PS
-			WHERE PS.[Name] IN
-			(
-				'Microsoft',
-				'ASP.NET MVC',
-				'ASP.NET Web API'
-			)
-		)
+		INNER JOIN [dbo].[Dimension_PackageSet] PS
+		ON P.[Dimension_PackageSet_Id] = PS.[Id]
+		WHERE PS.[Name] = 'NonCommunityPackages'
 
 	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')
 

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportRecentCommunityPopularityDetail.sql
@@ -31,7 +31,9 @@ BEGIN
 			AND C.ClientCategory NOT IN ('Crawler', 'Unknown')
 			AND NOT (C.ClientCategory = 'NuGet' AND CAST(ISNULL(C.[Major], '0') AS INT) > 10)
 			AND P.[LowercasedPackageId] NOT IN (
-				SELECT [LowercasedPackageId] FROM [dbo].[Fact_Package_PackageSet] WHERE [Dimension_PackageSet_Id] = @NonCommunityPackagesId
+				SELECT [LowercasedPackageId]
+				FROM [dbo].[Fact_Package_PackageSet]
+				WHERE [Dimension_PackageSet_Id] = @NonCommunityPackagesId
 			)
 
 	GROUP BY	P.[PackageId],

--- a/src/Stats.Warehouse/Stats.Warehouse.sqlproj
+++ b/src/Stats.Warehouse/Stats.Warehouse.sqlproj
@@ -136,6 +136,8 @@
     <Build Include="Programmability\Stored Procedures\dbo.GetTotalPackageDownloadsByDate.sql" />
     <Build Include="Programmability\Stored Procedures\dbo.CheckLogFileHasPackageStatistics.sql" />
     <Build Include="Programmability\Stored Procedures\dbo.CheckLogFileHasToolStatistics.sql" />
+    <Build Include="Programmability\Stored Procedures\dbo.DownloadReportRecentCommunityPopularity.sql" />
+    <Build Include="Programmability\Stored Procedures\dbo.DownloadReportRecentCommunityPopularityDetail.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="StaticCodeAnalysis.SuppressMessages.xml" />


### PR DESCRIPTION
Adds reports that finds the most popular packages that aren't labelled as "Microsoft", "ASP.NET MVC", or "ASP.NET Web API" packages. The queries were tested against the statistics database.

These reports will be used to fix https://github.com/NuGet/NuGetGallery/issues/3417.

Useful links:
* [This list](https://gist.githubusercontent.com/loic-sharma/36d9a9cf742df9c85645dd275d6a9d2d/raw/df1d80e33ac6b9ce9cfb2a010f4c5d97fe8c25ea/gistfile1.txt) contains all the packages that will be considered "non-community".
* [This powershell script](https://gist.github.com/loic-sharma/39c65e3b4d02bac1f52242ef24cf3832) will be used to import non-community packages into the statistics database.
* [This SQL query](https://gist.github.com/loic-sharma/76090850a76d38c1611ec7b0183bc3ea) is the result of running the powershell script.