### PR TITLE
Only clear the package download URL in the legacy orchestrator (not the new validation pipeline)

### DIFF
--- a/src/Validation.Common/PackageValidationQueue.cs
+++ b/src/Validation.Common/PackageValidationQueue.cs
@@ -84,14 +84,6 @@ namespace NuGet.Jobs.Validation.Common
                 deserializedMessage.PopReceipt = message.PopReceipt;
                 deserializedMessage.DequeueCount = message.DequeueCount;
 
-                if (deserializedMessage.Package?.DownloadUrl != null)
-                {
-                    // Don't read the package URL from OData. Instead, allow the validators to build the package URL
-                    // themselves. This is important because the URL in the OData feed is not pointing directly to
-                    // Azure Blob Storage, which is required by the VCS validator.
-                    deserializedMessage.Package.DownloadUrl = null;
-                }
-
                 results.Add(deserializedMessage);
             }
 

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -287,6 +287,11 @@ namespace NuGet.Jobs.Validation.Runner
                 // Start the validation process for each package
                 foreach (var package in packages)
                 {
+                    // Don't read the package URL from OData. Instead, allow the validators to build the package URL
+                    // themselves. This is important because the URL in the OData feed is not pointing directly to
+                    // Azure Blob Storage, which is required by the VCS validator.
+                    package.DownloadUrl = null;
+
                     await packageValidationService.StartValidationProcessAsync(package, _requestValidationTasks);
                 }
 


### PR DESCRIPTION
Previously, the code was always building the URL to the package inside the legacy `VcsValidator`. This works fine when packages are always in the `packages` container. But this breaks when we starting using the `validation` container (meaning asynchronous validation is required before a package is available).

Now, we only construct the package URL in the legacy orchestrator case.