### PR TITLE
Don't validate KeyVault certificate in VCS callback service

### DIFF
--- a/src/Validation.Callback.Vcs/Web.config
+++ b/src/Validation.Callback.Vcs/Web.config
@@ -13,7 +13,7 @@
     <add key="KeyVault:CertificateThumbprint" value="#{Deployment.Azure.KeyVault.CertificateThumbprint}" />
     <add key="KeyVault:StoreName" value="My" />
     <add key="KeyVault:StoreLocation" value="CurrentUser" />
-    <add key="KeyVault:ValidateCertificate" value="true" />
+    <add key="KeyVault:ValidateCertificate" value="false" />
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.


### PR DESCRIPTION
INT certificate is self-signed and cannot be found with current settings.