### PR TITLE
 Add support for excluding some packages from VCS scans

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -135,7 +135,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 new NuGetGallery.EntitiesContext(
                     serviceProvider.GetRequiredService<IOptionsSnapshot<GalleryDbConfiguration>>().Value.ConnectionString,
                     readOnly: false));
-            services.AddScoped<ValidationEntitiesContext>(serviceProvider =>
+            services.AddScoped(serviceProvider =>
                 new ValidationEntitiesContext(
                     serviceProvider.GetRequiredService<IOptionsSnapshot<ValidationDbConfiguration>>().Value.ConnectionString));
             services.AddScoped<IValidationStorageService, ValidationStorageService>();
@@ -157,6 +157,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IMessageHandler<PackageValidationMessageData>, ValidationMessageHandler>();
             services.AddTransient<IServiceBusMessageSerializer, ServiceBusMessageSerializer>();
             services.AddTransient<IBrokeredMessageSerializer<PackageValidationMessageData>, PackageValidationMessageDataSerializationAdapter>();
+            services.AddTransient<IPackageCriteriaEvaluator, PackageCriteriaEvaluator>();
             services.AddTransient<VcsValidator>();
         }
 

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -62,6 +62,10 @@
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="ValidationConfiguration.cs" />
     <Compile Include="ValidationConfigurationItem.cs" />
+    <Compile Include="Vcs\IPackageCriteria.cs" />
+    <Compile Include="Vcs\IPackageCriteriaEvaluator.cs" />
+    <Compile Include="Vcs\PackageCriteriaEvaluator.cs" />
+    <Compile Include="Vcs\PackageCriteria.cs" />
     <Compile Include="Vcs\VcsConfiguration.cs" />
     <Compile Include="Vcs\VcsValidator.cs" />
     <Compile Include="ValidationDbConfiguration.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/Vcs/IPackageCriteria.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Vcs/IPackageCriteria.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.Validation.Vcs
+{
+    /// <summary>
+    /// Generic criteria used to include or exclude packages from a process.
+    /// </summary>
+    public interface IPackageCriteria
+    {
+        /// <summary>
+        /// A list of package owner usernames to exclude. This configuration takes precedence over
+        /// <see cref="ByDefaultExclude"/>.
+        /// </summary>
+        IList<string> ExcludeOwners { get; }
+
+        /// <summary>
+        /// A list of package ID patterns used to include packages. These patterns accept wildcards. This configuration
+        /// takes precedence over <see cref="ExcludeOwners"/>. For example, if a package is excluded by
+        /// <see cref="ExcludeOwners"/> but has an ID matching one of the patterns, the criteria still matches that
+        /// package.
+        /// </summary>
+        IList<string> IncludeIdPatterns { get; }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/Vcs/IPackageCriteriaEvaluator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Vcs/IPackageCriteriaEvaluator.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Vcs
+{
+    /// <summary>
+    /// Evaluates whether a given package matches some criteria.
+    /// </summary>
+    public interface IPackageCriteriaEvaluator
+    {
+        bool IsMatch(IPackageCriteria criteria, Package package);
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/Vcs/PackageCriteria.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Vcs/PackageCriteria.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.Validation.Vcs
+{
+    public class PackageCriteria : IPackageCriteria
+    {
+        public IList<string> ExcludeOwners { get; set; } = new List<string>();
+
+        public IList<string> IncludeIdPatterns { get; set; } = new List<string>();
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/Vcs/PackageCriteriaEvaluator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Vcs/PackageCriteriaEvaluator.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Vcs
+{
+    public class PackageCriteriaEvaluator : IPackageCriteriaEvaluator
+    {
+        public bool IsMatch(IPackageCriteria criteria, Package package)
+        {
+            // By default, match the package.
+            var isMatch = true;
+
+            // Apply the owners rules.
+            if (criteria.ExcludeOwners != null)
+            {
+                var ownerUsernames = package
+                    .PackageRegistration
+                    .Owners
+                    .Select(x => x.Username);
+
+                if (criteria.ExcludeOwners.Intersect(ownerUsernames).Any())
+                {
+                    isMatch = false;
+                }
+            }
+
+            // Apply the package ID pattern rules.
+            if (criteria.IncludeIdPatterns != null)
+            {
+                foreach (var includeIdPattern in criteria.IncludeIdPatterns)
+                {
+                    var includeIdRegex = new Regex(
+                        WildcardToRegex(includeIdPattern),
+                        RegexOptions.IgnoreCase,
+                        TimeSpan.FromSeconds(5));
+
+                    if (includeIdRegex.IsMatch(package.PackageRegistration.Id))
+                    {
+                        isMatch = true;
+                    }
+                }
+            }
+
+            return isMatch;
+        }
+
+        /// <summary>
+        /// Source: <see cref="https://stackoverflow.com/a/6907849"/>
+        /// </summary>
+        public static string WildcardToRegex(string pattern)
+        {
+            return "^" + Regex
+                .Escape(pattern)
+                .Replace(@"\*", ".*")
+                .Replace(@"\?", ".") + "$";
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/Vcs/VcsConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Vcs/VcsConfiguration.cs
@@ -17,5 +17,10 @@ namespace NuGet.Services.Validation.Vcs
         /// The connection string to use to connect to an Azure Storage account.
         /// </summary>
         public string DataStorageAccount { get; set; }
+
+        /// <summary>
+        /// The criteria used to determine if a package should be scanned by VCS.
+        /// </summary>
+        public PackageCriteria PackageCriteria { get; set; } = new PackageCriteria();
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -8,11 +8,19 @@
       }
     ],
     "ValidationStorageConnectionString": "",
-    "ValidationMessageRecheckPeriod":  "00:01:00"
+    "ValidationMessageRecheckPeriod": "00:01:00"
   },
   "Vcs": {
     "ContainerName": "validation",
-    "DataStorageAccount": "UseDevelopmentStorage=true"
+    "DataStorageAccount": "UseDevelopmentStorage=true",
+    "PackageCriteria": {
+      "ExcludeOwners": [
+        "NugetTestAccount"
+      ],
+      "IncludeIdPatterns": [
+        "E2E.SemVer1Stable.*"
+      ]
+    }
   },
   "RunnerConfiguration": {
     "ProcessRecycleInterval": "1:00:00:00",

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="ValidationProviderFacts.cs" />
     <Compile Include="ValidationSetProcessorFacts.cs" />
     <Compile Include="ValidationSetProviderFacts.cs" />
+    <Compile Include="Vcs\PackageCriteriaEvaluatorFacts.cs" />
     <Compile Include="Vcs\VcsValidatorFacts.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Vcs/PackageCriteriaEvaluatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Vcs/PackageCriteriaEvaluatorFacts.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGetGallery;
+using Xunit;
+
+namespace NuGet.Services.Validation.Vcs
+{
+    public class PackageCriteriaEvaluatorFacts
+    {
+        public class TheIsMatchMethod
+        {
+            private readonly PackageCriteriaEvaluator _target;
+            private readonly PackageCriteria _criteria;
+            private readonly string _matchingOwner;
+            private readonly string _matchingPattern;
+            private readonly Package _package;
+
+            public TheIsMatchMethod()
+            {
+                _target = new PackageCriteriaEvaluator();
+                _matchingOwner = "NugetTestAccount";
+                _matchingPattern = "E2E.SemVer1Stable.*";
+                _criteria = new PackageCriteria
+                {
+                    ExcludeOwners = new[] { _matchingOwner },
+                    IncludeIdPatterns = new[] { _matchingPattern },
+                };
+                _package = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "E2E.SemVer1Stable.170503.225847.7481282",
+                        Owners = new List<User>
+                        {
+                            new User { Username = _matchingOwner },
+                        },
+                    },
+                };
+            }
+
+            [Fact]
+            public void MatchesByDefault()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new string[0];
+                _criteria.IncludeIdPatterns = new string[0];
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.True(actual, "By default, match the package.");
+            }
+
+            [Fact]
+            public void ExcludesMatchingSingleOwner()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new[] { _matchingOwner };
+                _criteria.IncludeIdPatterns = new string[0];
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.False(actual, "The package should have been excluded due to matching owner username.");
+            }
+            
+            [Fact]
+            public void ExcludesMatchingSomeOwners()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new[] { _matchingOwner, "PersonA", "PersonB" };
+                _criteria.IncludeIdPatterns = new string[0];
+                _package.PackageRegistration.Owners.Add(new User { Username = "PersonA" });
+                _package.PackageRegistration.Owners.Add(new User { Username = "PersonC" });
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.False(actual, "The package should have been excluded due to matching owner username.");
+            }
+
+            [Fact]
+            public void MatchingPackageIdOverridesMatchingOwner()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new[] { _matchingOwner };
+                _criteria.IncludeIdPatterns = new[] { _matchingPattern };
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.True(actual, "The package should have been included due to matching ID pattern.");
+            }
+
+            [Fact]
+            public void NonMatchingPackageIdPatternDoesNotOverrideMatchingOwner()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new[] { _matchingOwner };
+                _criteria.IncludeIdPatterns = new[] { "DoesNotMatch.*" };
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.False(actual, "The package should have been excluded due to matching owner username.");
+            }
+
+            [Fact]
+            public void MatchingPackageIdOverridesDefault()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new string[0];
+                _criteria.IncludeIdPatterns = new[] { _matchingPattern };
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.True(actual, "The package should have been included due to matching ID pattern.");
+            }
+
+            [Fact]
+            public void NonMatchingPackageIdWithMatchingOwnerIsNotMatched()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new[] { _matchingOwner };
+                _criteria.IncludeIdPatterns = new[] { "DoesNotMatch.*" };
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.False(actual, "The package should have been excluded due to matching owner username.");
+            }
+
+            [Fact]
+            public void MatchingPackageIdWithNonMatchingOwnerIsMatched()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new[] { "DoesNotMatch" };
+                _criteria.IncludeIdPatterns = new[] { _matchingPattern };
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.True(actual, "The package should have been included due to matching owner username.");
+            }
+
+            [Fact]
+            public void NonMatchingPackageIdWithNonMatchingOwnerMatches()
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new[] { "DoesNotMatch" };
+                _criteria.IncludeIdPatterns = new[] { "DoesNotMatch.*" };
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.True(actual, "The package should be matched when none of the rules apply.");
+            }
+
+            [Theory]
+            [InlineData("NuGet.Versioning", "NuGet.Versioning")]
+            [InlineData("NuGet.*", "NuGet.Versioning")]
+            [InlineData("NuGet.?ersi?ning", "NuGet.Versioning")]
+            [InlineData("NuGet.*ning", "NuGet.Versioning")]
+            [InlineData("*.Versioning", "NuGet.Versioning")]
+            [InlineData("*", "NuGet.Versioning")]
+            [InlineData("N*.?ersi?ning", "NuGet.Versioning")]
+            public void PackageIdMatchingSupportsSyntax(string idPattern, string id)
+            {
+                // Arrange
+                _criteria.ExcludeOwners = new string[0];
+                _criteria.IncludeIdPatterns = new[] { idPattern };
+                _package.PackageRegistration.Id = id;
+
+                // Act
+                var actual = _target.IsMatch(_criteria, _package);
+
+                // Assert
+                Assert.True(actual, "The package should have been included due to matching ID pattern.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/945.

If the criteria is matched, we "fake" a successful validation result, but we don't persist anything. All we do is write a log and allow orchestrator to write its validation record.

This is a minimal set of rules to address the issue. I chose not to make something more generic since it was unnecessary complexity.

I chose the name `ByDefaultExclude` so that missing configuration would result in everything being scanned by VCS. I also baked in our expected configuration since it serves as a great example (and supports the misconfiguration case as well).

I will make a separate PR to add this configuration explicitly to the real config files.
