### PR TITLE
Clear the download URL before submitting to VCS in Validation.Helper

### DIFF
--- a/src/Validation.Helper/Rescan.cs
+++ b/src/Validation.Helper/Rescan.cs
@@ -1,17 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs.Validation.Common;
 using NuGet.Jobs.Validation.Common.OData;
 using NuGet.Jobs.Validation.Common.Validators.Vcs;
-using System.Web;
 
 namespace NuGet.Jobs.Validation.Helper
 {
@@ -24,10 +21,10 @@ namespace NuGet.Jobs.Validation.Helper
         private readonly PackageValidationService _packageValidationService;
         private readonly string _galleryBaseAddress;
 
-        public string PackageId { get; private set; }
-        public string PackageVersion { get; private set; }
+        public Action Action => Action.Rescan;
 
-        public Action Action => Helper.Action.Rescan;
+        public string PackageId { get; }
+        public string PackageVersion { get; }
 
         public Rescan(
             IDictionary<string, string> jobArgsDictionary, 
@@ -36,8 +33,7 @@ namespace NuGet.Jobs.Validation.Helper
             string containerName,
             NuGetV2Feed feed, 
             PackageValidationService packageValidationService,
-            string galleryBaseAddress
-            )
+            string galleryBaseAddress)
         {
             _logger = logger;
             _feed = feed;
@@ -60,7 +56,12 @@ namespace NuGet.Jobs.Validation.Helper
                 PackageId,
                 PackageVersion);
 
-            NuGetPackage package = await Util.GetPackage(_galleryBaseAddress, _feed, PackageId, PackageVersion);
+            var package = await Util.GetPackage(
+                _galleryBaseAddress,
+                _feed,
+                PackageId,
+                PackageVersion,
+                includeDownloadUrl: false);
             if (package == null)
             {
                 _logger.LogError($"Unable to find {{{TraceConstant.PackageId}}} " +

--- a/src/Validation.Runner/Job.cs
+++ b/src/Validation.Runner/Job.cs
@@ -260,7 +260,11 @@ namespace NuGet.Jobs.Validation.Runner
 
                 var createdPackagesUrl = MakePackageQueryUrl(_galleryBaseAddress, "Created", referenceLastCreated);
                 Logger.LogInformation("Querying packages created since {StartTime}, URL: {QueryUrl}", referenceLastCreated, createdPackagesUrl);
-                var createdPackages = await feed.GetPackagesAsync(createdPackagesUrl, continuationsToFollow: 0);
+                var createdPackages = await feed.GetPackagesAsync(
+                    createdPackagesUrl,
+                    includeDownloadUrl: false,
+                    continuationsToFollow: 0);
+
                 foreach (var package in createdPackages)
                 {
                     packages.Add(package);
@@ -287,11 +291,6 @@ namespace NuGet.Jobs.Validation.Runner
                 // Start the validation process for each package
                 foreach (var package in packages)
                 {
-                    // Don't read the package URL from OData. Instead, allow the validators to build the package URL
-                    // themselves. This is important because the URL in the OData feed is not pointing directly to
-                    // Azure Blob Storage, which is required by the VCS validator.
-                    package.DownloadUrl = null;
-
                     await packageValidationService.StartValidationProcessAsync(package, _requestValidationTasks);
                 }
 


### PR DESCRIPTION
Fix https://github.com/NuGet/NuGetGallery/issues/5030

The alternative to this is to clear it in `NuGetV2Feed.GetPackagesAsync`. I leaned away from this because this looked like a generalize bit of code. Clearing the download URL is VCS-specific.

https://github.com/NuGet/NuGet.Jobs/blob/1ab205abb28e2c230b6eac17dbe11ec4714c279e/src/Validation.Common/OData/NuGetV2Feed.cs#L51