### PR TITLE
[Package Signing] Integrate Package Signing Validators with Orchestrator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -40,7 +40,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -58,9 +57,11 @@
     <Compile Include="OrchestrationRunnerConfiguration.cs" />
     <Compile Include="PackageCertificates\CertificateVerificationEnqueuer.cs" />
     <Compile Include="PackageCertificates\ICertificateVerificationEnqueuer.cs" />
+    <Compile Include="PackageCertificates\PackageCertificatesConfiguration.cs" />
     <Compile Include="PackageCertificates\PackageCertificatesValidator.cs" />
     <Compile Include="PackageSigning\IPackageSignatureVerificationEnqueuer.cs" />
     <Compile Include="PackageSigning\PackageSignatureVerificationEnqueuer.cs" />
+    <Compile Include="PackageSigning\PackageSigningConfiguration.cs" />
     <Compile Include="PackageSigning\PackageSigningValidator.cs" />
     <Compile Include="PackageValidationMessageDataSerializer.cs" />
     <Compile Include="Program.cs" />
@@ -145,6 +146,9 @@
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.3</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>

--- a/src/NuGet.Services.Validation.Orchestrator/PackageCertificates/PackageCertificatesConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageCertificates/PackageCertificatesConfiguration.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Jobs.Configuration;
+
+namespace NuGet.Services.Validation.PackageCertificates
+{
+    public class PackageCertificatesConfiguration
+    {
+        /// <summary>
+        /// How stale certificates' statuses can be before revalidating.
+        /// </summary>
+        public TimeSpan? CertificateRevalidationThreshold { get; set; }
+
+        /// <summary>
+        /// The Service Bus configuration used to enqueue package certificate validations.
+        /// </summary>
+        public ServiceBusConfiguration ServiceBus { get; set; }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningConfiguration.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Jobs.Configuration;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    /// <summary>
+    /// Configuration for initializing the <see cref="PackageSigningValidator"/>.
+    /// </summary>
+    public class PackageSigningConfiguration
+    {
+        /// <summary>
+        /// The Service Bus configuration used to enqueue package signing validations.
+        /// </summary>
+        public ServiceBusConfiguration ServiceBus { get; set; }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -8,11 +8,26 @@
       }
     ],
     "ValidationStorageConnectionString": "",
-    "ValidationMessageRecheckPeriod":  "00:01:00"
+    "ValidationMessageRecheckPeriod": "00:01:00"
   },
   "Vcs": {
     "ContainerName": "validation",
     "DataStorageAccount": "UseDevelopmentStorage=true"
+  },
+  "PackageSigning": {
+    "ServiceBus": {
+      "ConnectionString": "",
+      "TopicPath": "",
+      "SubscriptionName": ""
+    }
+  },
+  "PackageCertificates": {
+    "CertificateRevalidationThreshold": "1:00:00:00",
+    "ServiceBus": {
+      "ConnectionString": "",
+      "TopicPath": "",
+      "SubscriptionName": ""
+    }
   },
   "RunnerConfiguration": {
     "ProcessRecycleInterval": "1:00:00:00",


### PR DESCRIPTION
This change connects the Package Signing `IValidator`s to the Orchestrator so that the Orchestrator can kick off `ExtractAndValidateSignature` and `ValidateCertificate` validation jobs. I did manual integration testing with DEV and my own Service Bus/SQL resources.

Shout out to @agr for the help on this! The Orchestrator worked like a dream after a few minor hiccups :)