### PR TITLE
Add missing `sign.targets` import.

### DIFF
--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -56,4 +56,10 @@
     <Compile Include="Storage\ValidatorStateService.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <SignPath>..\..\build</SignPath>
+    <SignPath Condition="'$(BUILD_SOURCESDIRECTORY)' != ''">$(BUILD_SOURCESDIRECTORY)\build</SignPath>
+    <SignPath Condition="'$(NuGetBuildPath)' != ''">$(NuGetBuildPath)</SignPath>
+  </PropertyGroup>
+  <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
 </Project>


### PR DESCRIPTION
This fixes CI build for the `dev-package-signing` branch. Kudos to @xavierdecoster for catching and debugging this :)