### PR TITLE
Using AbsoluteUri instead of ToString() to get string representation of Uri

### DIFF
--- a/src/Validation.Common/Validators/ValidatorBase.cs
+++ b/src/Validation.Common/Validators/ValidatorBase.cs
@@ -45,7 +45,7 @@ namespace NuGet.Jobs.Validation.Common.Validators
             string packageUrl;
             if (message.Package.DownloadUrl != null)
             {
-                packageUrl = message.Package.DownloadUrl.ToString();
+                packageUrl = message.Package.DownloadUrl.AbsoluteUri;
             }
             else
             {

--- a/tests/Validation.Common.Tests/Validators/Vcs/VcsValidatorFacts.cs
+++ b/tests/Validation.Common.Tests/Validators/Vcs/VcsValidatorFacts.cs
@@ -40,7 +40,7 @@ namespace Validation.Common.Tests
                 Assert.Equal(ValidationResult.Asynchronous, actual);
                 _scanningService.Verify(
                     x => x.CreateVirusScanJobAsync(
-                        _message.Package.DownloadUrl.ToString(),
+                        _message.Package.DownloadUrl.AbsoluteUri,
                         _callbackUrl,
                         $"NuGet - f470b9fb-0243-4f65-8aef-90d93dfe1a03 - NuGet.Versioning 3.4.0-ALPHA",
                         _message.ValidationId),


### PR DESCRIPTION
According to [internet](http://faithlife.codes/blog/2010/08/uritostring_must_die/) [folklore](https://stackoverflow.com/questions/7624987/whats-the-difference-between-uri-tostring-and-uri-absoluteuri) there were times, when `Uri.AbsolutUri` and `Uri.ToString()` produced different results and `Uri.AbsoluteUri` was the right thing to use. It does not seem to be the case now, but I want to stay on the safe side since it is unclear what exactly `Uri.ToString()` produces.