### PR TITLE
[Package Signing] Fixed concurrency issue

### DIFF
--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27005.2
+VisualStudioVersion = 15.0.27121.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Jobs.Common", "src\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj", "{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}"
 EndProject
@@ -100,6 +100,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.PackageSigning.Core", "src\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj", "{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.PackageSigning.ExtractAndValidateSignature", "src\Validation.PackageSigning.ExtractAndValidateSignature\Validation.PackageSigning.ExtractAndValidateSignature.csproj", "{DD043977-6BCD-475A-BEE2-8C34309EC622}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.PackageSigning.ExtractAndValidateSignature.Tests", "tests\Validation.PackageSigning.ExtractAndValidateSignature.Tests\Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj", "{26435822-8938-48C9-96FD-0DCCF8F7CE00}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -253,6 +255,10 @@ Global
 		{DD043977-6BCD-475A-BEE2-8C34309EC622}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DD043977-6BCD-475A-BEE2-8C34309EC622}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DD043977-6BCD-475A-BEE2-8C34309EC622}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26435822-8938-48C9-96FD-0DCCF8F7CE00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26435822-8938-48C9-96FD-0DCCF8F7CE00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26435822-8938-48C9-96FD-0DCCF8F7CE00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26435822-8938-48C9-96FD-0DCCF8F7CE00}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -293,6 +299,7 @@ Global
 		{F9690B52-3C92-42A0-B41F-1A6040C2D2EE} = {6A776396-02B1-475D-A104-26940ADB04AB}
 		{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10} = {678D7B14-F8BC-4193-99AF-2EE8AA390A02}
 		{DD043977-6BCD-475A-BEE2-8C34309EC622} = {678D7B14-F8BC-4193-99AF-2EE8AA390A02}
+		{26435822-8938-48C9-96FD-0DCCF8F7CE00} = {6A776396-02B1-475D-A104-26940ADB04AB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {284A7AC3-FB43-4F1F-9C9C-2AF0E1F46C2B}

--- a/src/Validation.PackageSigning.Core/Storage/ValidatorStateService.cs
+++ b/src/Validation.PackageSigning.Core/Storage/ValidatorStateService.cs
@@ -14,8 +14,6 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
 {
     public class ValidatorStateService : IValidatorStateService
     {
-        private const int UniqueConstraintViolationErrorCode = 2627;
-
         private readonly IValidationEntitiesContext _validationContext;
         private readonly ILogger<ValidatorStateService> _logger;
         private readonly string _validatorName;
@@ -114,7 +112,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
 
                 return AddStatusResult.Success;
             }
-            catch (DbUpdateException e) when (IsUniqueConstraintViolationException(e))
+            catch (DbUpdateException e) when (e.IsUniqueConstraintViolationException())
             {
                 return AddStatusResult.StatusAlreadyExists;
             }
@@ -193,18 +191,6 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
             }
 
             return desiredState;
-        }
-
-        private static bool IsUniqueConstraintViolationException(DbUpdateException e)
-        {
-            var sqlException = e.GetBaseException() as SqlException;
-
-            if (sqlException != null)
-            {
-                return sqlException.Errors.Cast<SqlError>().Any(error => error.Number == UniqueConstraintViolationErrorCode);
-            }
-
-            return false;
         }
     }
 }

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -111,7 +111,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 
             // Update the package's state.
             // TODO: Determine whether this is a revalidation request.
-            var result = await _packageSigningStateService.SetPackageSigningState(
+            var result = await _packageSigningStateService.TrySetPackageSigningState(
                             validation.PackageKey,
                             message.PackageId,
                             message.PackageVersion,

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data.Entity.Infrastructure;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -103,30 +104,66 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
         private async Task<bool> HandleUnsignedPackageAsync(ValidatorStatus validation, SignatureValidationMessage message)
         {
             _logger.LogInformation(
-                        "Package {PackageId} {PackageVersion} is unsigned, no additional validations necessary.",
+                        "Package {PackageId} {PackageVersion} is unsigned, no additional validations necessary for {ValidationId}.",
                         message.PackageId,
-                        message.PackageVersion);
+                        message.PackageVersion,
+                        message.ValidationId);
 
-            var savePackageSigningStateResult = await _packageSigningStateService.TrySetPackageSigningState(
-                validation.PackageKey,
-                message.PackageId,
-                message.PackageVersion,
-                isRevalidationRequest: false,
-                status: PackageSigningStatus.Unsigned);
+            // Update the package's state.
+            // TODO: Determine whether this is a revalidation request.
+            var result = await _packageSigningStateService.SetPackageSigningState(
+                            validation.PackageKey,
+                            message.PackageId,
+                            message.PackageVersion,
+                            isRevalidationRequest: false,
+                            status: PackageSigningStatus.Unsigned);
+
+            if (result == SavePackageSigningStateResult.StatusAlreadyExists)
+            {
+                _logger.LogWarning(
+                    "Updates to package signature's state are only allowed on explicit revalidations for package {PackageId} {PackageVersion} for {ValidationId}",
+                    message.PackageId,
+                    message.PackageVersion,
+                    message.ValidationId);
+
+                // The message's request is invalid and no amount of retrying will fix it.
+                // Consume the message.
+                return true;
+            }
 
             validation.State = ValidationStatus.Succeeded;
-            var saveStateResult = await _validatorStateService.SaveStatusAsync(validation);
 
-            // Consume the message if successfully saved state.
-            return saveStateResult == SaveStatusResult.Success;
+            try
+            {
+                var saveStatus = await _validatorStateService.SaveStatusAsync(validation);
+
+                if (saveStatus == SaveStatusResult.Success)
+                {
+                    // Consume the message.
+                    return true;
+                }
+            }
+            catch (DbUpdateException e) when (e.IsUniqueConstraintViolationException())
+            {
+            }
+
+            _logger.LogWarning(
+                "Unable to save to save, requeueing package {PackageId} {PackageVersion} for validation id: {ValidationId}.",
+                message.PackageId,
+                message.PackageVersion,
+                message.ValidationId);
+
+            // Message may be retried.
+            return false;
         }
 
         private async Task<bool> BlockSignedPackageAsync(ValidatorStatus validation, SignatureValidationMessage message)
         {
             _logger.LogInformation(
-                        "Signed package {PackageId} {PackageVersion} is blocked.",
+                        "Signed package {PackageId} {PackageVersion} is blocked for validation {ValidationId}.",
                         message.PackageId,
-                        message.PackageVersion);
+                        message.PackageVersion,
+                        message.ValidationId);
 
             validation.State = ValidationStatus.Failed;
             var saveStateResult = await _validatorStateService.SaveStatusAsync(validation);

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/IPackageSigningStateService.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/IPackageSigningStateService.cs
@@ -8,7 +8,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
 {
     public interface IPackageSigningStateService
     {
-        Task<SavePackageSigningStateResult> TrySetPackageSigningState(
+        Task<SavePackageSigningStateResult> SetPackageSigningState(
             int packageKey,
             string packageId,
             string packageVersion,

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/IPackageSigningStateService.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/IPackageSigningStateService.cs
@@ -8,7 +8,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
 {
     public interface IPackageSigningStateService
     {
-        Task<SavePackageSigningStateResult> SetPackageSigningState(
+        Task<SavePackageSigningStateResult> TrySetPackageSigningState(
             int packageKey,
             string packageId,
             string packageVersion,

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/PackageSigningStateService.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/PackageSigningStateService.cs
@@ -24,7 +24,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<SavePackageSigningStateResult> SetPackageSigningState(
+        public async Task<SavePackageSigningStateResult> TrySetPackageSigningState(
             int packageKey,
             string packageId,
             string packageVersion,

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/PackageSigningStateService.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/PackageSigningStateService.cs
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.Entity.Infrastructure;
-using System.Linq;
+using System.Data.Entity;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Validation;
@@ -25,7 +24,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<SavePackageSigningStateResult> TrySetPackageSigningState(
+        public async Task<SavePackageSigningStateResult> SetPackageSigningState(
             int packageKey,
             string packageId,
             string packageVersion,
@@ -41,49 +40,33 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
                 throw new ArgumentException(nameof(packageVersion));
             }
 
-            // Check for revalidation
-            var currentState = _validationContext.PackageSigningStates.FirstOrDefault(s => s.PackageKey == packageKey);
-            if (isRevalidationRequest && currentState != null)
+            // It is possible this package has already been validated. If so, the package's state will already exist
+            // in the database. Updates to this state should only be requested on explicit revalidation gestures. However,
+            // this invariant may be broken due to message duplication.
+            var signatureState = await _validationContext.PackageSigningStates.FirstOrDefaultAsync(s => s.PackageKey == packageKey);
+
+            if (signatureState != null && !isRevalidationRequest)
             {
-                // Update existing record
-                currentState.SigningStatus = status;
+                return SavePackageSigningStateResult.StatusAlreadyExists;
+            }
+
+            if (signatureState != null)
+            {
+                signatureState.SigningStatus = status;
             }
             else
             {
-                // Insert new record
-                currentState = new PackageSigningState
+                // This package does not have a persisted record for its state. Create a new one.
+                _validationContext.PackageSigningStates.Add(new PackageSigningState
                 {
                     PackageId = packageId,
                     PackageKey = packageKey,
                     PackageNormalizedVersion = NuGetVersion.Parse(packageVersion).ToNormalizedString(),
                     SigningStatus = status
-                };
-
-                _validationContext.PackageSigningStates.Add(currentState);
+                });
             }
 
-            try
-            {
-                await _validationContext.SaveChangesAsync();
-
-                return SavePackageSigningStateResult.Success;
-            }
-            catch (DbUpdateException e) when (e.IsUniqueConstraintViolationException())
-            {
-                return SavePackageSigningStateResult.StatusAlreadyExists;
-            }
-            catch (DbUpdateConcurrencyException e)
-            {
-                _logger.LogWarning(
-                    0,
-                    e,
-                    "Failed to update package signing state for package id {PackageId} version {PackageVersion} to status {NewStatus} due to concurrency exception.",
-                    packageId,
-                    packageVersion,
-                    status);
-
-                return SavePackageSigningStateResult.Stale;
-            }
+            return SavePackageSigningStateResult.Success;
         }
     }
 }

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/SavePackageSigningStateResult.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Storage/SavePackageSigningStateResult.cs
@@ -15,10 +15,5 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
         /// exists with the same validation id.
         /// </summary>
         StatusAlreadyExists,
-
-        /// <summary>
-        /// Failed to persist the <see cref="PackageSigningStatus"/> due to a concurrency exception.
-        /// </summary>
-        Stale
     }
 }

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbAsyncQueryProviderMock.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbAsyncQueryProviderMock.cs
@@ -1,0 +1,49 @@
+﻿using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    internal class DbAsyncQueryProviderMock
+        : IDbAsyncQueryProvider
+    {
+        private readonly IQueryable _queryable;
+
+        public DbAsyncQueryProviderMock(IQueryable queryable)
+        {
+            _queryable = queryable;
+        }
+
+        public IQueryable CreateQuery(Expression expression)
+        {
+            return _queryable.Provider.CreateQuery(expression);
+        }
+
+        public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
+        {
+            return _queryable.Provider.CreateQuery<TElement>(expression);
+        }
+
+        public object Execute(Expression expression)
+        {
+            return _queryable.Provider.Execute(expression);
+        }
+
+        public TResult Execute<TResult>(Expression expression)
+        {
+            return _queryable.Provider.Execute<TResult>(expression);
+        }
+
+        public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Execute(expression));
+        }
+
+        public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Execute<TResult>(expression));
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbAsyncQueryProviderMock.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbAsyncQueryProviderMock.cs
@@ -1,4 +1,7 @@
-﻿using System.Data.Entity.Infrastructure;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbSetMockFactory.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbSetMockFactory.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Linq;
 using Moq;

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbSetMockFactory.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/DbSetMockFactory.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using Moq;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    internal static class DbSetMockFactory
+    {
+        internal static IDbSet<T> Create<T>(params T[] sourceList) where T : class
+        {
+            var list = new List<T>(sourceList);
+            var queryable = list.AsQueryable();
+
+            var dbSet = new Mock<IDbSet<T>>();
+            dbSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(new DbAsyncQueryProviderMock(queryable));
+            dbSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
+            dbSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
+            dbSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(list.GetEnumerator());
+            dbSet.Setup(m => m.Add(It.IsAny<T>())).Callback<T>(e => list.Add(e));
+
+            return dbSet.Object;
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
@@ -1,0 +1,133 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Services.Validation;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    public class PackageSigningStateServiceFacts
+    {
+        public class TheTrySetPackageSigningStateMethod
+        {
+            private readonly ILoggerFactory _loggerFactory;
+
+            public TheTrySetPackageSigningStateMethod(ITestOutputHelper testOutput)
+            {
+                _loggerFactory = new LoggerFactory();
+                _loggerFactory.AddXunit(testOutput);
+            }
+
+            [Fact]
+            public async Task ReturnsStatusAlreadyExistsWhenSignatureStateNotNullAndNotRevalidating()
+            {
+                // Arrange
+                const int packageKey = 1;
+                const string packageId = "packageId";
+                const string packageVersion = "1.0.0";
+                var packageSigningState = new PackageSigningState
+                {
+                    PackageId = packageId,
+                    PackageKey = packageKey,
+                    SigningStatus = PackageSigningStatus.Valid,
+                    PackageNormalizedVersion = packageVersion
+                };
+
+                var logger = _loggerFactory.CreateLogger<PackageSigningStateService>();
+                var packageSigningStatesDbSetMock = DbSetMockFactory.Create(packageSigningState);
+                var validationContextMock = new Mock<IValidationEntitiesContext>(MockBehavior.Strict);
+                validationContextMock.Setup(m => m.PackageSigningStates).Returns(packageSigningStatesDbSetMock);
+
+                // Act
+                var packageSigningStateService = new PackageSigningStateService(validationContextMock.Object, logger);
+
+                // Assert
+                var result = await packageSigningStateService.TrySetPackageSigningState(
+                    packageKey,
+                    packageId,
+                    packageVersion,
+                    isRevalidationRequest: false,
+                    status: PackageSigningStatus.Valid);
+
+                // Assert
+                Assert.Equal(SavePackageSigningStateResult.StatusAlreadyExists, result);
+            }
+
+            [Fact]
+            public async Task ReturnsStatusSuccessAndUpdatedExistingStateWhenSignatureStateNotNullAndRevalidating()
+            {
+                // Arrange
+                const int packageKey = 1;
+                const string packageId = "packageId";
+                const string packageVersion = "1.0.0";
+                const PackageSigningStatus newStatus = PackageSigningStatus.Invalid;
+                var packageSigningState = new PackageSigningState
+                {
+                    PackageId = packageId,
+                    PackageKey = packageKey,
+                    SigningStatus = PackageSigningStatus.Unsigned,
+                    PackageNormalizedVersion = packageVersion
+                };
+
+                var logger = _loggerFactory.CreateLogger<PackageSigningStateService>();
+                var packageSigningStatesDbSetMock = DbSetMockFactory.Create(packageSigningState);
+                var validationContextMock = new Mock<IValidationEntitiesContext>(MockBehavior.Strict);
+                validationContextMock.Setup(m => m.PackageSigningStates).Returns(packageSigningStatesDbSetMock);
+
+                // Act
+                var packageSigningStateService = new PackageSigningStateService(validationContextMock.Object, logger);
+
+                // Assert
+                var result = await packageSigningStateService.TrySetPackageSigningState(
+                    packageKey,
+                    packageId,
+                    packageVersion,
+                    isRevalidationRequest: true,
+                    status: newStatus);
+
+                // Assert
+                Assert.Equal(SavePackageSigningStateResult.Success, result);
+                Assert.Equal(newStatus, packageSigningState.SigningStatus);
+            }
+
+            [Fact]
+            public async Task ReturnsStatusSuccessAndAddedNewStateWhenSignatureStateIsNull()
+            {
+                // Arrange
+                const int packageKey = 1;
+                const string packageId = "packageId";
+                const string packageVersion = "1.0.0";
+                const PackageSigningStatus newStatus = PackageSigningStatus.Invalid;
+
+                var logger = _loggerFactory.CreateLogger<PackageSigningStateService>();
+                var packageSigningStatesDbSetMock = DbSetMockFactory.Create<PackageSigningState>();
+                var validationContextMock = new Mock<IValidationEntitiesContext>(MockBehavior.Strict);
+                validationContextMock.Setup(m => m.PackageSigningStates).Returns(packageSigningStatesDbSetMock);
+
+                // Act
+                var packageSigningStateService = new PackageSigningStateService(validationContextMock.Object, logger);
+
+                // Assert
+                var result = await packageSigningStateService.TrySetPackageSigningState(
+                    packageKey,
+                    packageId,
+                    packageVersion,
+                    isRevalidationRequest: true,
+                    status: newStatus);
+
+                // Assert
+                Assert.Equal(SavePackageSigningStateResult.Success, result);
+
+                var newState = validationContextMock.Object.PackageSigningStates.FirstOrDefault();
+                Assert.NotNull(newState);
+                Assert.Equal(packageKey, newState.PackageKey);
+                Assert.Equal(packageId, newState.PackageId);
+                Assert.Equal(packageVersion, newState.PackageNormalizedVersion);
+                Assert.Equal(newStatus, newState.SigningStatus);
+            }
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
@@ -54,6 +54,10 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 
                 // Assert
                 Assert.Equal(SavePackageSigningStateResult.StatusAlreadyExists, result);
+                validationContextMock.Verify(
+                    m => m.SaveChangesAsync(),
+                    Times.Never,
+                    "Saving the context here is unnecessary.");
             }
 
             [Fact]
@@ -91,6 +95,10 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
                 // Assert
                 Assert.Equal(SavePackageSigningStateResult.Success, result);
                 Assert.Equal(newStatus, packageSigningState.SigningStatus);
+                validationContextMock.Verify(
+                    m => m.SaveChangesAsync(),
+                    Times.Never,
+                    "Saving the context here is incorrect as updating the validator's status also saves the context. Doing so would cause both queries not to be executed in the same transaction.");
             }
 
             [Fact]
@@ -127,6 +135,10 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
                 Assert.Equal(packageId, newState.PackageId);
                 Assert.Equal(packageVersion, newState.PackageNormalizedVersion);
                 Assert.Equal(newStatus, newState.SigningStatus);
+                validationContextMock.Verify(
+                    m => m.SaveChangesAsync(),
+                    Times.Never,
+                    "Saving the context here is incorrect as updating the validator's status also saves the context. Doing so would cause both queries not to be executed in the same transaction.");
             }
         }
     }

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Properties/AssemblyInfo.cs
@@ -1,36 +1,12 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Validation.PackageSigning.ExtractAndValidateSignature.Tests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyDescription("Unit tests for ExtractAndValidateSignature job.")]
+[assembly: AssemblyCompany(".NET Foundation")]
 [assembly: AssemblyProduct("Validation.PackageSigning.ExtractAndValidateSignature.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
+[assembly: AssemblyCopyright("Copyright © .NET Foundation 2017")]
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("26435822-8938-48c9-96fd-0dccf8f7ce00")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Validation.PackageSigning.ExtractAndValidateSignature.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Validation.PackageSigning.ExtractAndValidateSignature.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("26435822-8938-48c9-96fd-0dccf8f7ce00")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{26435822-8938-48C9-96FD-0DCCF8F7CE00}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Validation.PackageSigning.ExtractAndValidateSignature.Tests</RootNamespace>
+    <AssemblyName>Validation.PackageSigning.ExtractAndValidateSignature.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DbAsyncQueryProviderMock.cs" />
+    <Compile Include="DbSetMockFactory.cs" />
+    <Compile Include="PackageSigningStateServiceFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XunitLoggerFactoryExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>1.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="Moq">
+      <Version>4.7.145</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.3.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Validation.PackageSigning.ExtractAndValidateSignature\Validation.PackageSigning.ExtractAndValidateSignature.csproj">
+      <Project>{DD043977-6BCD-475A-BEE2-8C34309EC622}</Project>
+      <Name>Validation.PackageSigning.ExtractAndValidateSignature</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/XunitLoggerFactoryExtensions.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/XunitLoggerFactoryExtensions.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging
+{
+    public static class XunitLoggerFactoryExtensions
+    {
+        public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output)
+        {
+            loggerFactory.AddProvider(new XunitLoggerProvider(output));
+            return loggerFactory;
+        }
+
+        public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output, LogLevel minLevel)
+        {
+            loggerFactory.AddProvider(new XunitLoggerProvider(output, minLevel));
+            return loggerFactory;
+        }
+    }
+
+    public class XunitLoggerProvider : ILoggerProvider
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly LogLevel _minLevel;
+
+        public XunitLoggerProvider(ITestOutputHelper output)
+            : this(output, LogLevel.Trace)
+        {
+        }
+
+        public XunitLoggerProvider(ITestOutputHelper output, LogLevel minLevel)
+        {
+            _output = output;
+            _minLevel = minLevel;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new XunitLogger(_output, categoryName, _minLevel);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    public class XunitLogger : ILogger
+    {
+        private static readonly char[] NewLineChars = new[] { '\r', '\n' };
+        private readonly string _category;
+        private readonly LogLevel _minLogLevel;
+        private readonly ITestOutputHelper _output;
+
+        public XunitLogger(ITestOutputHelper output, string category, LogLevel minLogLevel)
+        {
+            _minLogLevel = minLogLevel;
+            _category = category;
+            _output = output;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+            var firstLinePrefix = $"| {_category} {logLevel}: ";
+            var lines = formatter(state, exception).Split('\n');
+            _output.WriteLine(firstLinePrefix + lines.First().TrimEnd(NewLineChars));
+
+            var additionalLinePrefix = "|" + new string(' ', firstLinePrefix.Length - 1);
+            foreach (var line in lines.Skip(1))
+            {
+                _output.WriteLine(additionalLinePrefix + line.TrimEnd(NewLineChars));
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+            => logLevel >= _minLogLevel;
+
+        public IDisposable BeginScope<TState>(TState state)
+            => new NullScope();
+
+        private class NullScope : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/XunitLoggerFactoryExtensions.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/XunitLoggerFactoryExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
Fixes a few issues:

1. The `ExtractAndValidatePackageSignature` job saved the context twice for unsigned packages.
2. `PackageSigningStateService`'s `SetPackageSigningState` logic around revalidations was invalid. This fix should be covered by a unit test, could you add this @xavierdecoster? I have to head out early today and won't be able to address this until next week. Thanks! :)
3. Minor improvements / clean ups.