### PR TITLE
[Package Signing] Add client APIs to Package Signature Validation Job

### DIFF
--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -7,7 +7,6 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Logging;
@@ -163,7 +162,7 @@ namespace NuGet.Jobs
                 // Wait for <sleepDuration> milliSeconds and run the job again
                 _logger.LogInformation("Will sleep for {SleepDuration} before the next Job run", PrettyPrintTime(sleepDuration));
                 
-                Thread.Sleep(sleepDuration);
+                await Task.Delay(sleepDuration);
             }
         }
     }

--- a/src/Validation.PackageSigning.Core/Error.cs
+++ b/src/Validation.PackageSigning.Core/Error.cs
@@ -9,5 +9,7 @@ namespace NuGet.Jobs.Validation.PackageSigning
     {
         public static EventId ValidatorStateServiceFailedToAddStatus = new EventId(1000, "Failed to add validator's status");
         public static EventId ValidatorStateServiceFailedToUpdateStatus = new EventId(1001, "Failed to update validator's status");
+
+        public static EventId ValidateSignatureFailedToDownloadPackageStatus = new EventId(1100, "Failed to download package");
     }
 }

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Job.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Job.cs
@@ -157,16 +157,18 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 
             services.AddSingleton(p =>
             {
-                var handler = new WebRequestHandler
+                var assemblyName = typeof(SignatureValidationMessage).Assembly.GetName();
+
+                var client = new HttpClient(new WebRequestHandler
                 {
                     AllowPipelining = true,
                     AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate),
-                };
+                });
 
-                return new HttpClient(handler)
-                {
-                    Timeout = configurationRoot.GetValue<TimeSpan>(PackageDownloadTimeoutName)
-                };
+                client.Timeout = configurationRoot.GetValue<TimeSpan>(PackageDownloadTimeoutName);
+                client.DefaultRequestHeaders.Add("user-agent", $"{assemblyName.Name}/{assemblyName.Version}");
+
+                return client;
             });
         }
 

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Settings/dev.json
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Settings/dev.json
@@ -7,6 +7,9 @@
     "TopicPath": "validate-signature",
     "SubscriptionName": "extract-and-validate-signature"
   },
+
+  "PackageDownloadTimeout": "10:00",
+
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
   "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -195,17 +195,17 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
                 // Download the package from the network to a temporary file.
                 using (var response = await _httpClient.GetAsync(packageUri, HttpCompletionOption.ResponseHeadersRead))
                 {
-                    if (response.StatusCode != HttpStatusCode.OK)
-                    {
-                        throw new InvalidOperationException($"Package download expected status code: {HttpStatusCode.OK}, actual: {response.StatusCode}");
-                    }
-
                     _logger.LogInformation(
                         "Received response {StatusCode}: {ReasonPhrase} of type {ContentType} for request {PackageUri}",
                         response.StatusCode,
                         response.ReasonPhrase,
                         response.Content.Headers.ContentType,
                         packageUri);
+
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        throw new InvalidOperationException($"Expected status code {HttpStatusCode.OK} for package download, actual: {response.StatusCode}");
+                    }
 
                     using (var networkStream = await response.Content.ReadAsStreamAsync())
                     {

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -99,11 +99,10 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 
         private async Task<bool> IsSigned(Uri packageUri)
         {
-            using (var cancellationTokenSource = new CancellationTokenSource())
             using (var packageStream = await DownloadPackageAsync(packageUri))
             using (var package = new PackageArchiveReader(packageStream))
             {
-                return await package.IsSignedAsync(cancellationTokenSource.Token);
+                return await package.IsSignedAsync(CancellationToken.None);
             }
         }
 

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -106,7 +106,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
             var cancellationToken = CancellationToken.None;
 
             using (var packageStream = await DownloadPackageAsync(packageUri, cancellationToken))
-            using (var package = new PackageArchiveReader(packageStream))
+            using (var package = new PackageArchiveReader(packageStream, leaveStreamOpen: false))
             {
                 return await package.IsSignedAsync(cancellationToken);
             }

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -99,12 +99,11 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 
         private async Task<bool> IsSigned(Uri packageUri)
         {
+            using (var cancellationTokenSource = new CancellationTokenSource())
             using (var packageStream = await DownloadPackageAsync(packageUri))
             using (var package = new PackageArchiveReader(packageStream))
             {
-                var cancellationToken = new CancellationTokenSource().Token;
-
-                return await package.IsSignedAsync(cancellationToken);
+                return await package.IsSignedAsync(cancellationTokenSource.Token);
             }
         }
 

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -96,6 +96,9 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
       <Version>1.1.2</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Packaging">
+      <Version>4.6.0-xprivate-8478</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.4.3</Version>
     </PackageReference>

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -97,7 +97,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.6.0-xprivate-8478</Version>
+      <Version>4.6.0-preview1-4690</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.4.3</Version>
@@ -116,9 +116,6 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
       <Version>2.4.3</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Versioning">
-      <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>


### PR DESCRIPTION
Calls `NuGet.Client`'s APIs to determine whether a package is signed. **NOTE**: This doesn't have any integration tests yet as that would require a signed package to be checked-in to source control.

@mishra14 (I can't seem to add you as a "Reviewer" for whatever reason)