### PR TITLE
[Package Signing] Add missing configuration

### DIFF
--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Settings/int.json
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Settings/int.json
@@ -7,6 +7,9 @@
     "TopicPath": "validate-signature",
     "SubscriptionName": "extract-and-validate-signature"
   },
+
+  "PackageDownloadTimeout": "10:00",
+
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
   "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Settings/prod.json
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Settings/prod.json
@@ -7,6 +7,9 @@
     "TopicPath": "validate-signature",
     "SubscriptionName": "extract-and-validate-signature"
   },
+
+  "PackageDownloadTimeout": "10:00",
+
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
   "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",


### PR DESCRIPTION
The validate package signature job fails to start without the `PackageDownloadTimeout` configuration present.

This is the RI from dev -> master.