### PR TITLE
Hardening the orchestrator shutdown process.

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/IShutdownNotificationProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IShutdownNotificationProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    /// <summary>
+    /// Provides the ability to send shutdown notification
+    /// </summary>
+    public interface IShutdownNotificationProvider
+    {
+        /// <summary>
+        /// Sends a message that shutdown was initiated
+        /// </summary>
+        void NotifyShutdownInitiated();
+
+        /// <summary>
+        /// Cancellation token the gets signaled about initiated shutdown
+        /// </summary>
+        CancellationToken Token { get; }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/IShutdownNotificationTokenProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IShutdownNotificationTokenProvider.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    /// <summary>
+    /// DI helper that wraps <see cref="CancellationToken"/>
+    /// </summary>
+    public interface IShutdownNotificationTokenProvider
+    {
+
+        /// <summary>
+        /// Cancellation token the gets signaled about initiated shutdown
+        /// </summary>
+        CancellationToken Token { get; }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -149,6 +149,10 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<ConfigurationValidator>();
             services.AddTransient<OrchestrationRunner>();
 
+            services.AddSingleton<IShutdownNotificationProvider, ShutdownNotificationProvider>();
+            services.AddSingleton<IShutdownNotificationTokenProvider>(serviceProvider => 
+                new ShutdownNotificationTokenProvider(serviceProvider.GetRequiredService<IShutdownNotificationProvider>().Token));
+
             services.AddScoped<NuGetGallery.IEntitiesContext>(serviceProvider =>
                 new NuGetGallery.EntitiesContext(
                     serviceProvider.GetRequiredService<IOptionsSnapshot<GalleryDbConfiguration>>().Value.ConnectionString,

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -50,6 +50,8 @@
     <Compile Include="EmailConfiguration.cs" />
     <Compile Include="Error.cs" />
     <Compile Include="IMessageService.cs" />
+    <Compile Include="IShutdownNotificationProvider.cs" />
+    <Compile Include="IShutdownNotificationTokenProvider.cs" />
     <Compile Include="IValidationOutcomeProcessor.cs" />
     <Compile Include="IValidationSetProcessor.cs" />
     <Compile Include="IValidationSetProvider.cs" />
@@ -71,6 +73,8 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="ShutdownNotificationProvider.cs" />
+    <Compile Include="ShutdownNotificationTokenProvider.cs" />
     <Compile Include="SmtpConfiguration.cs" />
     <Compile Include="ValidationConfiguration.cs" />
     <Compile Include="ValidationConfigurationItem.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/ShutdownNotificationProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ShutdownNotificationProvider.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    public class ShutdownNotificationProvider : IShutdownNotificationProvider
+    {
+        private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+
+        public CancellationToken Token => _cancellationTokenSource.Token;
+
+        public void NotifyShutdownInitiated()
+        {
+            _cancellationTokenSource.Cancel();
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/ShutdownNotificationTokenProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ShutdownNotificationTokenProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    public class ShutdownNotificationTokenProvider : IShutdownNotificationTokenProvider
+    {
+        public ShutdownNotificationTokenProvider(CancellationToken cancellationToken)
+        {
+            Token = cancellationToken;
+        }
+
+        public CancellationToken Token { get; }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationMessageHandler.cs
@@ -15,6 +15,7 @@ namespace NuGet.Services.Validation.Orchestrator
         private readonly IValidationSetProvider _validationSetProvider;
         private readonly IValidationSetProcessor _validationSetProcessor;
         private readonly IValidationOutcomeProcessor _validationOutcomeProcessor;
+        private readonly IShutdownNotificationTokenProvider _shutdownNotificationTokenProvider;
         private readonly ILogger<ValidationMessageHandler> _logger;
 
         public ValidationMessageHandler(
@@ -22,17 +23,29 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidationSetProvider validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
             IValidationOutcomeProcessor validationOutcomeProcessor,
+            IShutdownNotificationTokenProvider shutdownNotificationTokenProvider,
             ILogger<ValidationMessageHandler> logger)
         {
             _galleryPackageService = galleryPackageService ?? throw new ArgumentNullException(nameof(galleryPackageService));
             _validationSetProvider = validationSetProvider ?? throw new ArgumentNullException(nameof(validationSetProvider));
             _validationSetProcessor = validationSetProcessor ?? throw new ArgumentNullException(nameof(validationSetProcessor));
             _validationOutcomeProcessor = validationOutcomeProcessor ?? throw new ArgumentNullException(nameof(validationOutcomeProcessor));
+            _shutdownNotificationTokenProvider = shutdownNotificationTokenProvider ?? throw new ArgumentNullException(nameof(shutdownNotificationTokenProvider));
+            if (shutdownNotificationTokenProvider.Token == null)
+            {
+                throw new ArgumentException($"{nameof(shutdownNotificationTokenProvider.Token)} property cannot be null", nameof(shutdownNotificationTokenProvider));
+            }
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task<bool> HandleAsync(PackageValidationMessageData message)
         {
+            if (_shutdownNotificationTokenProvider.Token.IsCancellationRequested)
+            {
+                _logger.LogInformation("Service shutdown was requested, will not process new message");
+                return false;
+            }
+
             var package = _galleryPackageService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageVersion);
 
             if (package == null)

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/OrchestrationRunnerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/OrchestrationRunnerFacts.cs
@@ -16,69 +16,116 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         [Fact]
         public async Task StartsMessageProcessing()
         {
-            var subscriptionProcessor = new Mock<ISubscriptionProcessor<PackageValidationMessageData>>();
-            var loggerMock = new Mock<ILogger<OrchestrationRunner>>();
-            var optionsAccessorMock = CreateOptionsAccessorMock(TimeSpan.Zero, TimeSpan.Zero);
-
-            var runner = new OrchestrationRunner(subscriptionProcessor.Object, optionsAccessorMock.Object, loggerMock.Object);
+            var runner = CreateRunner();
             await runner.RunOrchestrationAsync();
 
-            subscriptionProcessor.Verify(o => o.Start(), Times.Once());
+            SubscriptionProcessorMock.Verify(o => o.Start(), Times.Once());
         }
 
         [Fact]
         public async Task ShutsDownMessageProcessing()
         {
-            var orchestratorMock = new Mock<ISubscriptionProcessor<PackageValidationMessageData>>();
-            var loggerMock = new Mock<ILogger<OrchestrationRunner>>();
-            var optionsAccessorMock = CreateOptionsAccessorMock(TimeSpan.Zero, TimeSpan.Zero);
-
             var startCalled = false;
-            orchestratorMock
+            SubscriptionProcessorMock
                 .Setup(o => o.Start())
                 .Callback(() => startCalled = true);
 
-            orchestratorMock
+            SubscriptionProcessorMock
                 .Setup(o => o.StartShutdownAsync())
                 .Callback(() => Assert.True(startCalled))
                 .Returns(Task.FromResult(0));
-            var runner = new OrchestrationRunner(orchestratorMock.Object, optionsAccessorMock.Object, loggerMock.Object);
+            var runner = CreateRunner();
             await runner.RunOrchestrationAsync();
 
-            orchestratorMock.Verify(o => o.StartShutdownAsync(), Times.Once());
+            SubscriptionProcessorMock.Verify(o => o.StartShutdownAsync(), Times.Once());
         }
 
         [Fact(Skip = "Flaky test. Won't run it as part of CI.")]
         public async Task WaitsOrchestratorToShutDown()
         {
-            var orchestratorMock = new Mock<ISubscriptionProcessor<PackageValidationMessageData>>();
-            var loggerMock = new Mock<ILogger<OrchestrationRunner>>();
-            var optionsAccessorMock = CreateOptionsAccessorMock(TimeSpan.Zero, TimeSpan.FromSeconds(3));
+            SetupOptionsAccessorMock(TimeSpan.Zero, TimeSpan.FromSeconds(3));
 
             int numberOfRequestsInProgress = 2;
-            orchestratorMock
+            SubscriptionProcessorMock
                 .SetupGet(o => o.NumberOfMessagesInProgress)
                 .Returns(() => numberOfRequestsInProgress--);
 
-            var runner = new OrchestrationRunner(orchestratorMock.Object, optionsAccessorMock.Object, loggerMock.Object);
+            var runner = CreateRunner();
             await runner.RunOrchestrationAsync();
 
-            orchestratorMock.Verify(o => o.NumberOfMessagesInProgress, Times.Exactly(3));
+            SubscriptionProcessorMock.Verify(o => o.NumberOfMessagesInProgress, Times.AtLeast(3));
         }
 
-        private static Mock<IOptionsSnapshot<OrchestrationRunnerConfiguration>> CreateOptionsAccessorMock(
+        [Fact]
+        public async Task SendsShutdownNotificationAfterRunningValidations()
+        {
+            bool startedProcessing = false;
+            SubscriptionProcessorMock
+                .Setup(sp => sp.Start())
+                .Callback(() => startedProcessing = true);
+
+            ShutdownNotificationProviderMock
+                .Setup(snp => snp.NotifyShutdownInitiated())
+                .Callback(() => Assert.True(startedProcessing));
+
+            var runner = CreateRunner();
+            await runner.RunOrchestrationAsync();
+
+            ShutdownNotificationProviderMock
+                .Verify(snp => snp.NotifyShutdownInitiated());
+        }
+
+        [Fact(Skip = "Time based test, will not run in CI")]
+        public async Task DoesNotBlockOnWaitingForSubscriptionProcessorToInitiateShutdown()
+        {
+            SubscriptionProcessorMock
+                .Setup(sp => sp.StartShutdownAsync())
+                .Returns(Task.Delay(TimeSpan.FromDays(1))); // veeeery long shutdown
+
+            var runner = CreateRunner();
+            var orchestrationTask = runner.RunOrchestrationAsync();
+            var delayTask = Task.Delay(TimeSpan.FromSeconds(5));
+
+            var didNotWait = await Task.WhenAny(orchestrationTask, delayTask) == orchestrationTask;
+
+            Assert.True(didNotWait);
+            SubscriptionProcessorMock
+                .Verify(sp => sp.StartShutdownAsync(), Times.AtLeastOnce());
+        }
+
+        private Mock<IOptionsSnapshot<OrchestrationRunnerConfiguration>> SetupOptionsAccessorMock(
             TimeSpan processRecycleInterval,
             TimeSpan shutdownWaitInterval)
         {
-            var optionsAccessorMock = new Mock<IOptionsSnapshot<OrchestrationRunnerConfiguration>>();
-            optionsAccessorMock
+            OrchestrationRunnerConfigurationAccessorMock = new Mock<IOptionsSnapshot<OrchestrationRunnerConfiguration>>();
+            OrchestrationRunnerConfigurationAccessorMock
                 .SetupGet(o => o.Value)
                 .Returns(new OrchestrationRunnerConfiguration
                 {
                     ProcessRecycleInterval = processRecycleInterval,
                     ShutdownWaitInterval = shutdownWaitInterval
                 });
-            return optionsAccessorMock;
+            return OrchestrationRunnerConfigurationAccessorMock;
         }
+
+        private OrchestrationRunner CreateRunner()
+            => new OrchestrationRunner(
+                SubscriptionProcessorMock.Object,
+                OrchestrationRunnerConfigurationAccessorMock.Object,
+                ShutdownNotificationProviderMock.Object,
+                LoggerMock.Object);
+
+        public OrchestrationRunnerFacts()
+        {
+            SubscriptionProcessorMock = new Mock<ISubscriptionProcessor<PackageValidationMessageData>>();
+            LoggerMock = new Mock<ILogger<OrchestrationRunner>>();
+            ShutdownNotificationProviderMock = new Mock<IShutdownNotificationProvider>();
+            SetupOptionsAccessorMock(TimeSpan.Zero, TimeSpan.Zero);
+        }
+
+        private Mock<ISubscriptionProcessor<PackageValidationMessageData>> SubscriptionProcessorMock { get; }
+        private Mock<ILogger<OrchestrationRunner>> LoggerMock { get; }
+        private Mock<IShutdownNotificationProvider> ShutdownNotificationProviderMock { get; }
+        private Mock<IOptionsSnapshot<OrchestrationRunnerConfiguration>> OrchestrationRunnerConfigurationAccessorMock { get; set;  }
     }
 }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -87,6 +88,29 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationOutcomeProcessorMock
                 .Verify(vop => vop.ProcessValidationOutcomeAsync(ValidationSet, Package));
         }
+
+        [Fact]
+        public async Task AbandonsMessageProcessingIfShutdownIsInProgress()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            ShutdownNotificationTokenProviderMock
+                .SetupGet(x => x.Token)
+                .Returns(cancellationTokenSource.Token);
+            cancellationTokenSource.Cancel();
+
+            var handler = CreateHandler();
+            var result = await handler.HandleAsync(MessageData);
+
+            Assert.False(result);
+            CorePackageServiceMock
+                .Verify(cps => cps.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            ValidationSetProviderMock
+                .Verify(vsp => vsp.GetOrCreateValidationSetAsync(It.IsAny<Guid>(), It.IsAny<Package>()), Times.Never());
+            ValidationSetProcessorMock
+                .Verify(vsp => vsp.ProcessValidationsAsync(It.IsAny<PackageValidationSet>(), It.IsAny<Package>()), Times.Never());
+            ValidationOutcomeProcessorMock
+                .Verify(vop => vop.ProcessValidationOutcomeAsync(It.IsAny<PackageValidationSet>(), It.IsAny<Package>()), Times.Never());
+        }
     }
 
     public class ValidationMessageHandlerFactsBase
@@ -95,6 +119,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         protected Mock<IValidationSetProvider> ValidationSetProviderMock { get; }
         protected Mock<IValidationSetProcessor> ValidationSetProcessorMock { get; }
         protected Mock<IValidationOutcomeProcessor> ValidationOutcomeProcessorMock { get; }
+        protected Mock<IShutdownNotificationTokenProvider> ShutdownNotificationTokenProviderMock { get; }
         protected Mock<ILogger<ValidationMessageHandler>> LoggerMock { get; }
 
         public ValidationMessageHandlerFactsBase(MockBehavior mockBehavior)
@@ -103,6 +128,10 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationSetProviderMock = new Mock<IValidationSetProvider>(mockBehavior);
             ValidationSetProcessorMock = new Mock<IValidationSetProcessor>(mockBehavior);
             ValidationOutcomeProcessorMock = new Mock<IValidationOutcomeProcessor>(mockBehavior);
+            ShutdownNotificationTokenProviderMock = new Mock<IShutdownNotificationTokenProvider>(mockBehavior);
+            ShutdownNotificationTokenProviderMock
+                .SetupGet(x => x.Token)
+                .Returns(CancellationToken.None);
             LoggerMock = new Mock<ILogger<ValidationMessageHandler>>(); // we generally don't care about how logger is called, so it's loose all the time
         }
 
@@ -113,6 +142,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSetProviderMock.Object,
                 ValidationSetProcessorMock.Object,
                 ValidationOutcomeProcessorMock.Object,
+                ShutdownNotificationTokenProviderMock.Object,
                 LoggerMock.Object);
         }
     }


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/1063

* Will not wait infinitely for `await _subscriptionProcessor.StartShutdownAsync()` to return anymore, instead will ignore it after configured timeout;
* Added `CancellationToken` to inform `ValidationMessageHandler` about shutdown in progress, so it would abandon incoming message at entry without attempting to process it.