### PR TITLE
Persist parent and end certificates in the database

### DIFF
--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/ExtractedCertificates.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/ExtractedCertificates.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
+{
+    /// <summary>
+    /// All of the certificates extracted from a signature.
+    /// </summary>
+    public class ExtractedCertificates
+    {
+        public ExtractedCertificates(
+            HashedCertificate signatureEndCertificate,
+            IReadOnlyList<HashedCertificate> signatureParentCertificates,
+            HashedCertificate timestampEndCertificate,
+            IReadOnlyList<HashedCertificate> timestampParentCertificates)
+        {
+            SignatureEndCertificate = signatureEndCertificate ?? throw new ArgumentNullException(nameof(signatureEndCertificate));
+            SignatureParentCertificates = signatureParentCertificates ?? throw new ArgumentNullException(nameof(signatureParentCertificates));
+            TimestampEndCertificate = timestampEndCertificate ?? throw new ArgumentNullException(nameof(timestampEndCertificate));
+            TimestampParentCertificates = timestampParentCertificates ?? throw new ArgumentNullException(nameof(timestampParentCertificates));
+        }
+
+        public HashedCertificate SignatureEndCertificate { get; }
+        public IReadOnlyList<HashedCertificate> SignatureParentCertificates { get; }
+        public HashedCertificate TimestampEndCertificate { get; }
+        public IReadOnlyList<HashedCertificate> TimestampParentCertificates { get; }
+    }
+}

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/HashedCertificate.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/HashedCertificate.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
+{
+    /// <summary>
+    /// A certificate and its corresponding SHA-256 thumbprint, represented as a lowercase hexadecimal string. This
+    /// type is meant to be a convenient way to avoid rehashing the certificate over and over.
+    /// </summary>
+    public class HashedCertificate
+    {
+        public HashedCertificate(X509Certificate2 certificate)
+        {
+            Certificate = certificate ?? throw new ArgumentNullException(nameof(certificate));
+            Thumbprint = certificate.ComputeSHA256Thumbprint();
+        }
+
+        public X509Certificate2 Certificate { get; }
+        public string Thumbprint { get; }
+    }
+}

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignaturePartsExtractor.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignaturePartsExtractor.cs
@@ -3,25 +3,30 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Packaging.Signing;
+using NuGet.Services.Validation;
 
 namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 {
     public class SignaturePartsExtractor : ISignaturePartsExtractor
     {
         private readonly ICertificateStore _certificateStore;
+        private readonly IValidationEntitiesContext _entitiesContext;
 
-        public SignaturePartsExtractor(ICertificateStore certificateStore)
+        public SignaturePartsExtractor(
+            ICertificateStore certificateStore,
+            IValidationEntitiesContext entitiesContext)
         {
             _certificateStore = certificateStore ?? throw new ArgumentNullException(nameof(certificateStore));
+            _entitiesContext = entitiesContext ?? throw new ArgumentNullException(nameof(entitiesContext));
         }
 
         public async Task ExtractAsync(ISignedPackageReader signedPackageReader, CancellationToken token)
@@ -31,28 +36,58 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
                 throw new ArgumentException("The provided package reader must refer to a signed package.", nameof(signedPackageReader));
             }
 
+            // Read the signatures from the package.
             var signatures = await signedPackageReader.GetSignaturesAsync(token);
 
-            foreach (var signature in signatures)
-            {
-                foreach (var certificate in GetCertificates(signature.SignedCms))
-                {
-                    await SaveCertificateAsync(certificate, token);
-                }
+            // Extract the certificates found in the package signatures.
+            var extractedCertificates = ExtractCertificates(signatures);
 
-                foreach (var timestamp in signature.Timestamps)
-                {
-                    // TODO: use the signing-certificate-v2 attribute to prune.
-                    foreach (var certificate in timestamp.SignedCms.Certificates)
-                    {
-                        await SaveCertificateAsync(certificate, token);
-                    }
-                }
-            }
+            // Save the certificates to blob storage.
+            await SaveCertificatesToStoreAsync(extractedCertificates, token);
+
+            // Save the certificates to the database.
+            await SaveCertificatesToDatabaseAsync(extractedCertificates);
         }
 
-        private IEnumerable<X509Certificate2> GetCertificates(SignedCms signedCms)
+        private ExtractedCertificates ExtractCertificates(IReadOnlyList<Signature> signatures)
         {
+            if (signatures.Count != 1)
+            {
+                throw new ArgumentException("There should be exactly one signature.", nameof(signatures));
+            }
+
+            if (signatures[0].Timestamps.Count != 1)
+            {
+                throw new ArgumentException("There should be exactly one timestamp.", nameof(signatures));
+            }
+
+            var signatureCertificates = GetCertificates(signatures[0].SignedCms, filter: true).ToList();
+            var signatureEndCertificate = signatureCertificates.Last();
+            var signatureParentCertificates = signatureCertificates.Take(signatureCertificates.Count - 1).ToList();
+
+            var timestampCertificates = GetCertificates(signatures[0].Timestamps[0].SignedCms, filter: false).ToList();
+            var timestampEndCertificate = timestampCertificates.Last();
+            var timestampParentCertificates = timestampCertificates.Take(timestampCertificates.Count - 1).ToList();
+
+            return new ExtractedCertificates(
+                signatureEndCertificate,
+                signatureParentCertificates,
+                timestampEndCertificate,
+                timestampParentCertificates);
+        }
+
+        private IEnumerable<HashedCertificate> GetCertificates(SignedCms signedCms, bool filter)
+        {
+            if (!filter)
+            {
+                foreach (var certificate in signedCms.Certificates)
+                {
+                    yield return new HashedCertificate(certificate);
+                }
+
+                yield break;
+            }
+
             // Use the signing-certificate-v2 attribute to prune the list of certificates.
             var signingCertificateV2Attribute = signedCms
                 .SignerInfos[0]
@@ -83,22 +118,178 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 
                     if (signingCertificateHashes.Contains(hash))
                     {
-                        yield return certificate;
+                        // Emit the certificate, hashed with a uniform hashing algorithm.
+                        yield return new HashedCertificate(certificate);
                     }
                 }
             }
         }
 
-        private async Task SaveCertificateAsync(X509Certificate2 certificate, CancellationToken token)
+        private async Task SaveCertificatesToDatabaseAsync(ExtractedCertificates extractedCertificates)
         {
-            var thumbprint = certificate.ComputeSHA256Thumbprint();
+            // Initialize the end and parent certificates.
+            var thumbprintToEndCertificate = await InitializeEndCertificatesAsync(
+                new[]
+                {
+                    extractedCertificates.SignatureEndCertificate,
+                    extractedCertificates.TimestampEndCertificate
+                });
 
-            if (await _certificateStore.ExistsAsync(thumbprint, token))
+            var thumbprintToParentCertificate = await InitializeParentCertificatesAsync(
+                extractedCertificates
+                    .SignatureParentCertificates
+                    .Concat(extractedCertificates.TimestampParentCertificates));
+
+            // Connect the end and parent certificates.
+            ConnectCertificates(
+                extractedCertificates.SignatureEndCertificate,
+                extractedCertificates.SignatureParentCertificates,
+                thumbprintToEndCertificate,
+                thumbprintToParentCertificate);
+
+            ConnectCertificates(
+                extractedCertificates.TimestampEndCertificate,
+                extractedCertificates.TimestampParentCertificates,
+                thumbprintToEndCertificate,
+                thumbprintToParentCertificate);
+
+            // Commit
+            await _entitiesContext.SaveChangesAsync();
+        }
+
+        private void ConnectCertificates(
+            HashedCertificate endCertificate,
+            IReadOnlyList<HashedCertificate> parentCertificates,
+            IReadOnlyDictionary<string, EndCertificate> thumbprintToEndCertificate,
+            IReadOnlyDictionary<string, ParentCertificate> thumbprintToParentCertificates)
+        {
+            var endCertificateEntity = thumbprintToEndCertificate[endCertificate.Thumbprint];
+            var parentCertificateKeys = new HashSet<long>(endCertificateEntity
+                .CertificateChainLinks
+                .Select(x => x.ParentCertificateKey));
+
+            foreach (var parentCertificate in parentCertificates)
+            {
+                var parentCertificateEntity = thumbprintToParentCertificates[parentCertificate.Thumbprint];
+
+                // If either end of the link is new, the link must be new.
+                if (endCertificateEntity.Key == default(long)
+                    || parentCertificateEntity.Key == default(long)
+                    || !parentCertificateKeys.Contains(parentCertificateEntity.Key))
+                {
+                    var link = new CertificateChainLink
+                    {
+                        EndCertificate = endCertificateEntity,
+                        ParentCertificate = parentCertificateEntity,
+                    };
+                    _entitiesContext.CertificateChainLinks.Add(link);
+                    endCertificateEntity.CertificateChainLinks.Add(link);
+                    parentCertificateEntity.CertificateChainLinks.Add(link);
+
+                    if (parentCertificateEntity.Key != default(long))
+                    {
+                        parentCertificateKeys.Add(parentCertificateEntity.Key);
+                    }
+                }
+            }
+        }
+
+        private async Task<IReadOnlyDictionary<string, EndCertificate>> InitializeEndCertificatesAsync(
+            IEnumerable<HashedCertificate> certificates)
+        {
+            var thumbprints = certificates
+                .Select(x => x.Thumbprint)
+                .Distinct()
+                .ToList();
+
+            // Find all of the end certificate entities that intersect with the set of certificates found in the
+            // package that is currently being processed.
+            var existingEntities = await _entitiesContext
+                .EndCertificates
+                .Include(x => x.CertificateChainLinks)
+                .Where(x => thumbprints.Contains(x.Thumbprint))
+                .ToListAsync();
+            
+            var thumbprintToEntity = existingEntities.ToDictionary(x => x.Thumbprint);
+
+            foreach (var certificate in certificates)
+            {
+                if (!thumbprintToEntity.TryGetValue(certificate.Thumbprint, out var entity))
+                {
+                    entity = new EndCertificate
+                    {
+                        Status = EndCertificateStatus.Unknown,
+                        Thumbprint = certificate.Thumbprint,
+                        CertificateChainLinks = new List<CertificateChainLink>(),
+                    };
+                    _entitiesContext.EndCertificates.Add(entity);
+
+                    thumbprintToEntity[certificate.Thumbprint] = entity;
+                }
+            }
+
+            return thumbprintToEntity;
+        }
+
+        private async Task<IReadOnlyDictionary<string, ParentCertificate>> InitializeParentCertificatesAsync(
+            IEnumerable<HashedCertificate> certificates)
+        {
+            var thumbprints = certificates
+                .Select(x => x.Thumbprint)
+                .Distinct()
+                .ToList();
+
+            // Find all of the parent certificate entities that intersect with the set of certificates found in the
+            // package that is currently being processed.
+            var existingEntities = await _entitiesContext
+                .ParentCertificates
+                .Include(x => x.CertificateChainLinks)
+                .Where(x => thumbprints.Contains(x.Thumbprint))
+                .ToListAsync();
+            
+            var thumbprintToEntity = existingEntities.ToDictionary(x => x.Thumbprint);
+
+            foreach (var certificate in certificates)
+            {
+                if (!thumbprintToEntity.TryGetValue(certificate.Thumbprint, out var entity))
+                {
+                    entity = new ParentCertificate
+                    {
+                        Thumbprint = certificate.Thumbprint,
+                        CertificateChainLinks = new List<CertificateChainLink>(),
+                    };
+                    _entitiesContext.ParentCertificates.Add(entity);
+
+                    thumbprintToEntity[certificate.Thumbprint] = entity;
+                }
+            }
+
+            return thumbprintToEntity;
+        }
+
+        private async Task SaveCertificatesToStoreAsync(ExtractedCertificates extractedCertificates, CancellationToken token)
+        {
+            var allCertificates = Enumerable
+                .Empty<HashedCertificate>()
+                .Concat(extractedCertificates.SignatureParentCertificates)
+                .Concat(new[] { extractedCertificates.SignatureEndCertificate })
+                .Concat(extractedCertificates.TimestampParentCertificates)
+                .Concat(new[] { extractedCertificates.TimestampEndCertificate });
+
+            foreach (var certificate in allCertificates)
+            {
+                await SaveCertificateToStoreAsync(certificate, token);
+            }
+        }
+
+        private async Task SaveCertificateToStoreAsync(HashedCertificate certificate, CancellationToken token)
+        {
+            if (await _certificateStore.ExistsAsync(certificate.Thumbprint, token))
             {
                 return;
             }
 
-            await _certificateStore.SaveAsync(certificate, token);
+            await _certificateStore.SaveAsync(certificate.Certificate, token);
         }
     }
 }

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -40,7 +40,9 @@
     <Reference Include="System.Security" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExtractedCertificates.cs" />
     <Compile Include="Hash.cs" />
+    <Compile Include="HashedCertificate.cs" />
     <Compile Include="ISignaturePartsExtractor.cs" />
     <Compile Include="ISignatureValidator.cs" />
     <Compile Include="SignaturePartsExtractor.cs" />

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignaturePartsExtractorFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignaturePartsExtractorFacts.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.Pkcs;
@@ -13,6 +14,7 @@ using Moq;
 using NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Packaging.Signing;
+using NuGet.Services.Validation;
 using Org.BouncyCastle.Cms;
 using Org.BouncyCastle.X509.Store;
 using Xunit;
@@ -27,21 +29,27 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
         /// This contains the SHA-256 thumbprints of the test certificate chain as well as the time stamping
         /// authoring (TSA) chain. In this case, Symantec's TSA is used.
         /// </summary>
-        private static readonly IReadOnlyList<SubjectAndThumbprint> Leaf1Certificates = new[]
+        private static readonly ExtractedCertificatesThumbprints Leaf1Certificates = new ExtractedCertificatesThumbprints
         {
-            new SubjectAndThumbprint(
-                "CN=NUGET_DO_NOT_TRUST.root.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
-                "0e829fa17cfd9be513a41d9f205320f7d035f48d6c4cc7acbaa95f1744c1d6bb"),
-            new SubjectAndThumbprint(
-                "CN=NUGET_DO_NOT_TRUST.intermediate.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
-                "d5949445cde4d80bc0c857dddb8520114a146d73de081a77404b0c17dda6a4b4"),
-            new SubjectAndThumbprint(
+            SignatureParentCertificates = new[]
+            {
+                new SubjectAndThumbprint(
+                    "CN=NUGET_DO_NOT_TRUST.root.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
+                    TestResources.RootThumbprint),
+                new SubjectAndThumbprint(
+                    "CN=NUGET_DO_NOT_TRUST.intermediate.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
+                    "d5949445cde4d80bc0c857dddb8520114a146d73de081a77404b0c17dda6a4b4"),
+            },
+            SignatureEndCertificate = new SubjectAndThumbprint(
                 "CN=NUGET_DO_NOT_TRUST.leaf-1.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
                 TestResources.Leaf1Thumbprint),
-            new SubjectAndThumbprint(
-                "CN=Symantec SHA256 TimeStamping CA, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
-                "f3516ddcc8afc808788bd8b0e840bda2b5e23c6244252ca3000bb6c87170402a"),
-            new SubjectAndThumbprint(
+            TimestampParentCertificates = new[]
+            {
+                new SubjectAndThumbprint(
+                    "CN=Symantec SHA256 TimeStamping CA, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
+                    "f3516ddcc8afc808788bd8b0e840bda2b5e23c6244252ca3000bb6c87170402a")
+            },
+            TimestampEndCertificate = new SubjectAndThumbprint(
                 "CN=Symantec SHA256 TimeStamping Signer - G2, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
                 "cf7ac17ad047ecd5fdc36822031b12d4ef078b6f2b4c5e6ba41f8ff2cf4bad67"),
         };
@@ -52,6 +60,7 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
             private readonly CancellationToken _token;
             private readonly Mock<ICertificateStore> _certificateStore;
             private readonly List<X509Certificate2> _savedCertificates;
+            private readonly Mock<IValidationEntitiesContext> _entitiesContext;
             private readonly SignaturePartsExtractor _target;
 
             public ExtractAsync()
@@ -62,11 +71,28 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 
                 _certificateStore = new Mock<ICertificateStore>();
                 _certificateStore
+                    .Setup(x => x.ExistsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Returns<string, CancellationToken>((t, _) => Task.FromResult(_savedCertificates.Any(x => x.ComputeSHA256Thumbprint() == t)));
+
+                _certificateStore
                     .Setup(x => x.SaveAsync(It.IsAny<X509Certificate2>(), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask)
                     .Callback<X509Certificate2, CancellationToken>((cert, _) => _savedCertificates.Add(cert));
-                
-                _target = new SignaturePartsExtractor(_certificateStore.Object);
+
+                _entitiesContext = new Mock<IValidationEntitiesContext>();
+                _entitiesContext
+                    .Setup(x => x.ParentCertificates)
+                    .Returns(DbSetMockFactory.Create<ParentCertificate>());
+                _entitiesContext
+                    .Setup(x => x.EndCertificates)
+                    .Returns(DbSetMockFactory.Create<EndCertificate>());
+                _entitiesContext
+                    .Setup(x => x.CertificateChainLinks)
+                    .Returns(DbSetMockFactory.Create<CertificateChainLink>());
+
+                _target = new SignaturePartsExtractor(
+                    _certificateStore.Object,
+                    _entitiesContext.Object);
             }
 
             [Fact]
@@ -98,6 +124,132 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
             }
 
             [Fact]
+            public async Task SavesToStorageBeforeDatabaseCommit()
+            {
+                // Arrange
+                using (var package = TestResources.LoadPackage(TestResources.SignedPackageLeaf1))
+                {
+                    const string database = "database";
+                    const string storage = "storage";
+                    var sequence = new List<string>();
+                    _entitiesContext
+                        .Setup(x => x.SaveChangesAsync())
+                        .ReturnsAsync(0)
+                        .Callback(() => sequence.Add(database));
+                    _certificateStore
+                        .Setup(x => x.SaveAsync(It.IsAny<X509Certificate2>(), It.IsAny<CancellationToken>()))
+                        .Returns(Task.CompletedTask)
+                        .Callback(() => sequence.Add(storage));
+
+                    // Act
+                    await _target.ExtractAsync(package, _token);
+
+                    // Assert
+                    Assert.NotEqual(database, storage);
+                    Assert.Single(sequence, database);
+                    Assert.Equal(database, sequence.Last());
+                    Assert.Contains(storage, sequence);
+                }
+            }
+
+            [Fact]
+            public async Task ProperlyInitializesEndCertificates()
+            {
+                // Arrange
+                using (var package = TestResources.LoadPackage(TestResources.SignedPackageLeaf1))
+                {
+                    // Act
+                    await _target.ExtractAsync(package, _token);
+
+                    // Assert
+                    var endCertificates = _entitiesContext.Object.EndCertificates.ToList();
+                    foreach (var endCertificate in endCertificates)
+                    {
+                        
+                        Assert.Null(endCertificate.LastVerificationTime);
+                        Assert.Null(endCertificate.NextStatusUpdateTime);
+                        Assert.Null(endCertificate.RevocationTime);
+                        Assert.Equal(EndCertificateStatus.Unknown, endCertificate.Status);
+                        Assert.Null(endCertificate.StatusUpdateTime);
+                        Assert.NotNull(endCertificate.Thumbprint);
+                        Assert.Equal(64, endCertificate.Thumbprint.Length);
+                    }
+                }
+            }
+
+            [Fact]
+            public async Task DoesNotDuplicateWhenAllLinksAlreadyExist()
+            {
+                // Arrange
+                using (var package = TestResources.LoadPackage(TestResources.SignedPackageLeaf1))
+                {
+                    await _target.ExtractAsync(package, _token);
+                    AssignIds();
+                    _entitiesContext.ResetCalls();
+
+                    // Act
+                    await _target.ExtractAsync(package, _token);
+                    
+                    // Assert
+                    VerifySavedCertificates(Leaf1Certificates);
+                    Assert.Equal(2, _entitiesContext.Object.EndCertificates.Count());
+                    Assert.Equal(3, _entitiesContext.Object.ParentCertificates.Count());
+                    Assert.Equal(3, _entitiesContext.Object.CertificateChainLinks.Count());
+                }
+            }
+
+            [Fact]
+            public async Task DoesNotDuplicateWhenSomeLinksAlreadyExist()
+            {
+                // Arrange
+                using (var package = TestResources.LoadPackage(TestResources.SignedPackageLeaf1))
+                {
+                    var existingParentCertificate = new ParentCertificate
+                    {
+                        Key = 1,
+                        Thumbprint = TestResources.RootThumbprint,
+                        CertificateChainLinks = new List<CertificateChainLink>(),
+                    };
+                    var existingEndCertificate = new EndCertificate
+                    {
+                        Key = 1,
+                        Thumbprint = TestResources.Leaf1Thumbprint,
+                        Status = EndCertificateStatus.Good, // Different than the default.
+                        CertificateChainLinks = new List<CertificateChainLink>(),
+                    };
+                    var existingLink = new CertificateChainLink
+                    {
+                        ParentCertificate = existingParentCertificate,
+                        ParentCertificateKey = existingParentCertificate.Key,
+                        EndCertificate = existingEndCertificate,
+                        EndCertificateKey = existingEndCertificate.Key,
+                    };
+                    existingParentCertificate.CertificateChainLinks.Add(existingLink);
+                    existingEndCertificate.CertificateChainLinks.Add(existingLink);
+
+                    _entitiesContext
+                        .Setup(x => x.ParentCertificates)
+                        .Returns(DbSetMockFactory.Create(existingParentCertificate));
+                    _entitiesContext
+                        .Setup(x => x.EndCertificates)
+                        .Returns(DbSetMockFactory.Create(existingEndCertificate));
+                    _entitiesContext
+                        .Setup(x => x.CertificateChainLinks)
+                        .Returns(DbSetMockFactory.Create(existingLink));
+
+                    // Act
+                    await _target.ExtractAsync(package, _token);
+
+                    // Assert
+                    VerifySavedCertificates(Leaf1Certificates);
+                    Assert.Equal(2, _entitiesContext.Object.EndCertificates.Count());
+                    Assert.Equal(3, _entitiesContext.Object.ParentCertificates.Count());
+                    Assert.Equal(3, _entitiesContext.Object.CertificateChainLinks.Count());
+                    Assert.Equal(EndCertificateStatus.Good, existingEndCertificate.Status);
+                }
+            }
+
+            [Fact]
             public async Task IgnoreExtraCertificates()
             {
                 // Arrange
@@ -122,21 +274,78 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
                     // Assert
                     VerifySavedCertificates(Leaf1Certificates);
                     Assert.Equal(
-                        Leaf1Certificates.Count + 1,
+                        Leaf1Certificates.Certificates.Count + 1,
                         signature.SignedCms.Certificates.Count + signature.Timestamps.Sum(x => x.SignedCms.Certificates.Count));
                 }
             }
 
-            private void VerifySavedCertificates(IReadOnlyList<SubjectAndThumbprint> expected)
+            private void AssignIds()
             {
-                Assert.Equal(expected.Count, _savedCertificates.Count);
+                var endCertificates = _entitiesContext.Object.EndCertificates.AsQueryable().ToList();
+                for (var key = 1; key <= endCertificates.Count; key++)
+                {
+                    endCertificates[key - 1].Key = key;
+                    foreach (var link in endCertificates[key - 1].CertificateChainLinks.ToList())
+                    {
+                        link.EndCertificateKey = key;
+                    }
+                }
+
+                var parentCertificates = _entitiesContext.Object.ParentCertificates.AsQueryable().ToList();
+                for (var key = 1; key <= parentCertificates.Count; key++)
+                {
+                    parentCertificates[key - 1].Key = key;
+                    foreach (var link in parentCertificates[key - 1].CertificateChainLinks.ToList())
+                    {
+                        link.ParentCertificateKey = key;
+                    }
+                }
+            }
+
+            private void VerifySavedCertificates(ExtractedCertificatesThumbprints expected)
+            {
+                // Assert the certificates saved to the store.
+                Assert.Equal(expected.Certificates.Count, _savedCertificates.Count);
                 for (var i = 0; i < _savedCertificates.Count; i++)
                 {
                     var subject = _savedCertificates[i].Subject;
                     var thumbprint = _savedCertificates[i].ComputeSHA256Thumbprint();
-                    Assert.Equal(expected[i].Subject, subject);
-                    Assert.Equal(expected[i].Thumbprint, thumbprint);
+                    Assert.Equal(expected.Certificates[i].Subject, subject);
+                    Assert.Equal(expected.Certificates[i].Thumbprint, thumbprint);
                 }
+
+                // Assert the certificates saved to the database.
+                var signatureEndCertificate = Assert.Single(_entitiesContext
+                    .Object
+                    .EndCertificates
+                    .Where(x => x.Thumbprint == expected.SignatureEndCertificate.Thumbprint));
+
+                Assert.Equal(
+                    expected
+                        .SignatureParentCertificates
+                        .Select(x => x.Thumbprint)
+                        .OrderBy(x => x),
+                     signatureEndCertificate
+                        .CertificateChainLinks
+                        .Select(x => x.ParentCertificate.Thumbprint)
+                        .OrderBy(x => x));
+
+                var timestampEndCertificate = Assert.Single(_entitiesContext
+                    .Object
+                    .EndCertificates
+                    .Where(x => x.Thumbprint == expected.TimestampEndCertificate.Thumbprint));
+
+                Assert.Equal(
+                    expected
+                        .TimestampParentCertificates
+                        .Select(x => x.Thumbprint)
+                        .OrderBy(x => x),
+                     timestampEndCertificate
+                        .CertificateChainLinks
+                        .Select(x => x.ParentCertificate.Thumbprint)
+                        .OrderBy(x => x));
+
+                _entitiesContext.Verify(x => x.SaveChangesAsync(), Times.Once);
             }
         }
 
@@ -173,6 +382,21 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
                 .GetCertificates(BouncyCastleCollection)
                 .GetMatches(selector: null)
                 .Cast<Org.BouncyCastle.X509.X509Certificate>()
+                .ToList();
+        }
+
+        private class ExtractedCertificatesThumbprints
+        {
+            public IReadOnlyList<SubjectAndThumbprint> SignatureParentCertificates { get; set; }
+            public SubjectAndThumbprint SignatureEndCertificate { get; set; }
+            public IReadOnlyList<SubjectAndThumbprint> TimestampParentCertificates { get; set; }
+            public SubjectAndThumbprint TimestampEndCertificate { get; set; }
+            public IReadOnlyList<SubjectAndThumbprint> Certificates => Enumerable
+                .Empty<SubjectAndThumbprint>()
+                .Concat(SignatureParentCertificates)
+                .Concat(new[] { SignatureEndCertificate })
+                .Concat(TimestampParentCertificates)
+                .Concat(new[] { TimestampEndCertificate })
                 .ToList();
         }
     }

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/DbSetMockFactory.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/DbSetMockFactory.cs
@@ -13,13 +13,12 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
         internal static IDbSet<T> Create<T>(params T[] sourceList) where T : class
         {
             var list = new List<T>(sourceList);
-            var queryable = list.AsQueryable();
 
             var dbSet = new Mock<IDbSet<T>>();
-            dbSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(new DbAsyncQueryProviderMock(queryable));
-            dbSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
-            dbSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
-            dbSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(list.GetEnumerator());
+            dbSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(() => new TestDbAsyncQueryProvider<T>(list.AsQueryable().Provider));
+            dbSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(() => list.AsQueryable().Expression);
+            dbSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(() => list.AsQueryable().ElementType);
+            dbSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => list.GetEnumerator());
             dbSet.Setup(m => m.Add(It.IsAny<T>())).Callback<T>(e => list.Add(e));
 
             return dbSet.Object;

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestDbAsyncEnumerable.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestDbAsyncEnumerable.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    /// <summary>
+    /// Source: https://msdn.microsoft.com/en-us/data/dn314429
+    /// </summary>
+    internal class TestDbAsyncEnumerable<T> : EnumerableQuery<T>, IDbAsyncEnumerable<T>, IQueryable<T>
+    {
+        public TestDbAsyncEnumerable(IEnumerable<T> enumerable) : base(enumerable)
+        {
+        }
+
+        public TestDbAsyncEnumerable(Expression expression) : base(expression)
+        {
+        }
+
+        public IDbAsyncEnumerator<T> GetAsyncEnumerator()
+        {
+            return new TestDbAsyncEnumerator<T>(this.AsEnumerable().GetEnumerator());
+        }
+
+        IDbAsyncEnumerator IDbAsyncEnumerable.GetAsyncEnumerator()
+        {
+            return GetAsyncEnumerator();
+        }
+
+        IQueryProvider IQueryable.Provider
+        {
+            get { return new TestDbAsyncQueryProvider<T>(this); }
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestDbAsyncEnumerator.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestDbAsyncEnumerator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    /// <summary>
+    /// Source: https://msdn.microsoft.com/en-us/data/dn314429
+    /// </summary>
+    internal class TestDbAsyncEnumerator<T> : IDbAsyncEnumerator<T>
+    {
+        private readonly IEnumerator<T> _inner;
+
+        public TestDbAsyncEnumerator(IEnumerator<T> inner)
+        {
+            _inner = inner;
+        }
+
+        public void Dispose()
+        {
+            _inner.Dispose();
+        }
+
+        public Task<bool> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_inner.MoveNext());
+        }
+
+        public T Current
+        {
+            get { return _inner.Current; }
+        }
+
+        object IDbAsyncEnumerator.Current
+        {
+            get { return Current; }
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestDbAsyncQueryProvider.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestDbAsyncQueryProvider.cs
@@ -9,34 +9,36 @@ using System.Threading.Tasks;
 
 namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 {
-    internal class DbAsyncQueryProviderMock
-        : IDbAsyncQueryProvider
+    /// <summary>
+    /// Source: https://msdn.microsoft.com/en-us/data/dn314429
+    /// </summary>
+    internal class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
     {
-        private readonly IQueryable _queryable;
+        private readonly IQueryProvider _inner;
 
-        public DbAsyncQueryProviderMock(IQueryable queryable)
+        internal TestDbAsyncQueryProvider(IQueryProvider inner)
         {
-            _queryable = queryable;
+            _inner = inner;
         }
 
         public IQueryable CreateQuery(Expression expression)
         {
-            return _queryable.Provider.CreateQuery(expression);
+            return new TestDbAsyncEnumerable<TEntity>(expression);
         }
 
         public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
         {
-            return _queryable.Provider.CreateQuery<TElement>(expression);
+            return new TestDbAsyncEnumerable<TElement>(expression);
         }
 
         public object Execute(Expression expression)
         {
-            return _queryable.Provider.Execute(expression);
+            return _inner.Execute(expression);
         }
 
         public TResult Execute<TResult>(Expression expression)
         {
-            return _queryable.Provider.Execute<TResult>(expression);
+            return _inner.Execute<TResult>(expression);
         }
 
         public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestResources.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestResources.cs
@@ -15,6 +15,11 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
         public const string SignedPackageLeaf2 = ResourceNamespace + ".TestSigned.leaf-2.2.0.0.nupkg";
 
         /// <summary>
+        /// This is the SHA-256 thumbprint of the root CA certificate for the signing certificate of <see cref="SignedPackageLeaf1"/>.
+        /// </summary>
+        public const string RootThumbprint = "0e829fa17cfd9be513a41d9f205320f7d035f48d6c4cc7acbaa95f1744c1d6bb";
+
+        /// <summary>
         /// This is the SHA-256 thumbprint of the signing certificate in <see cref="SignedPackageLeaf1"/>.
         /// </summary>
         public const string Leaf1Thumbprint = "56a23ed7c0ef80bd0269d4a3b41e3e2830243a9fc85594b6c311e27423df6023";

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
@@ -38,7 +38,9 @@
     <Compile Include="HashFacts.cs" />
     <Compile Include="SignaturePartsExtractorFacts.cs" />
     <Compile Include="SignatureValidatorFacts.cs" />
-    <Compile Include="Support\DbAsyncQueryProviderMock.cs" />
+    <Compile Include="Support\TestDbAsyncEnumerable.cs" />
+    <Compile Include="Support\TestDbAsyncEnumerator.cs" />
+    <Compile Include="Support\TestDbAsyncQueryProvider.cs" />
     <Compile Include="Support\DbSetMockFactory.cs" />
     <Compile Include="Support\EmbeddedResourceTestHandler.cs" />
     <Compile Include="PackageSigningStateServiceFacts.cs" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/785.

This writes the timestamp and signing certificates found in a signature to the database after writing them to storage. Handles existing certificates and existing links. That is, the following tables are now populated:

1. `signature.EndCertificates` = leaf
1. `signature.ParentCertificates` = all levels of ancestors
1. `signature.CertificateChainLinks` = n-to-n relationship between end and parent certificates

Note that an end certificate's chain can change over time so an end certificate may have multiple "sets" of parents persisted. The schema has no way of distinguishing these "sets" since all of the parents are clobbered together. This is okay.

Also, added more the EF async query mocking stuff from here:
https://msdn.microsoft.com/en-us/data/dn314429

This enables mocking of EF's `ToListAsync()`.