### PR TITLE
Integrate with client validation APIs and add initial integration tests

### DIFF
--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Job.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Job.cs
@@ -20,6 +20,7 @@ using NuGet.Jobs.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Configuration;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Packaging.Signing;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
 using NuGet.Services.ServiceBus;
@@ -185,6 +186,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
             services.AddTransient<IPackageSigningStateService, PackageSigningStateService>();
             services.AddTransient<ISignatureValidator, SignatureValidator>();
             services.AddTransient<ISignaturePartsExtractor, SignaturePartsExtractor>();
+
+            services.AddTransient(p => PackageSignatureVerifierFactory.Create());
 
             services.AddSingleton(p =>
             {

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/PackageSignatureVerifierFactory.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/PackageSignatureVerifierFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Packaging.Signing;
+
+namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
+{
+    /// <summary>
+    /// Initializes integration with the client APIs, which handles the actual signature verification.
+    /// </summary>
+    public static class PackageSignatureVerifierFactory
+    {
+        public static IPackageSignatureVerifier Create()
+        {
+            var verificationProviders = new[]
+            {
+                new IntegrityVerificationProvider(),
+            };
+
+            var settings = SignedPackageVerifierSettings.VerifyCommandDefaultPolicy;
+
+            return new PackageSignatureVerifier(
+                verificationProviders,
+                settings);
+        }
+    }
+}

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -45,6 +45,7 @@
     <Compile Include="HashedCertificate.cs" />
     <Compile Include="ISignaturePartsExtractor.cs" />
     <Compile Include="ISignatureValidator.cs" />
+    <Compile Include="PackageSignatureVerifierFactory.cs" />
     <Compile Include="SignaturePartsExtractor.cs" />
     <Compile Include="SignatureValidator.cs" />
     <Compile Include="Storage\PackageSigningStateService.cs" />

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignatureValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignatureValidatorFacts.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NuGet.Common;
 using NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
@@ -27,6 +28,8 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
             private readonly SignatureValidationMessage _message;
             private readonly CancellationToken _cancellationToken;
             private readonly Mock<IPackageSigningStateService> _packageSigningStateService;
+            private VerifySignaturesResult _verifyResult;
+            private readonly Mock<IPackageSignatureVerifier> _packageSignatureVerifier;
             private readonly Mock<ISignaturePartsExtractor> _signaturePartsExtractor;
             private readonly Mock<IEntityRepository<Certificate>> _certificates;
             private readonly Mock<ILogger<SignatureValidator>> _logger;
@@ -52,6 +55,13 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
                 _cancellationToken = CancellationToken.None;
 
                 _packageSigningStateService = new Mock<IPackageSigningStateService>();
+
+                _verifyResult = new VerifySignaturesResult(true);
+                _packageSignatureVerifier = new Mock<IPackageSignatureVerifier>();
+                _packageSignatureVerifier
+                    .Setup(x => x.VerifySignaturesAsync(It.IsAny<ISignedPackageReader>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => _verifyResult);
+
                 _signaturePartsExtractor = new Mock<ISignaturePartsExtractor>();
                 _certificates = new Mock<IEntityRepository<Certificate>>();
                 _logger = new Mock<ILogger<SignatureValidator>>();
@@ -62,6 +72,7 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 
                 _target = new SignatureValidator(
                     _packageSigningStateService.Object,
+                    _packageSignatureVerifier.Object,
                     _signaturePartsExtractor.Object,
                     _certificates.Object,
                     _logger.Object);
@@ -104,17 +115,9 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
             public async Task AcceptsSignedPackagesWithKnownCertificates()
             {
                 // Arrange
-                var signatures = await TestResources.SignedPackageLeaf1Reader.GetSignaturesAsync(CancellationToken.None);
-
-                _packageMock
-                    .Setup(x => x.IsSignedAsync(It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(true);
-                _packageMock
-                    .Setup(x => x.GetSignaturesAsync(It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(signatures);
-                _certificates
-                    .Setup(x => x.GetAll())
-                    .Returns(new[] { new Certificate { Thumbprint = TestResources.Leaf1Thumbprint } }.AsQueryable());
+                await ConfigureKnownSignedPackage(
+                    TestResources.SignedPackageLeaf1Reader,
+                    TestResources.Leaf1Thumbprint);
 
                 // Act
                 await _target.ValidateAsync(
@@ -125,6 +128,85 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 
                 // Assert
                 Validate(ValidationStatus.Succeeded, PackageSigningStatus.Valid);
+            }
+
+            [Fact]
+            public async Task RejectsSignedPackagesWithKnownCertificatesButFailedVerifyResult()
+            {
+                // Arrange
+                await ConfigureKnownSignedPackage(
+                    TestResources.SignedPackageLeaf1Reader,
+                    TestResources.Leaf1Thumbprint);
+
+                _verifyResult = new VerifySignaturesResult(valid: false);
+
+                // Act
+                await _target.ValidateAsync(
+                    _packageMock.Object,
+                    _validation,
+                    _message,
+                    _cancellationToken);
+
+                // Assert
+                Validate(ValidationStatus.Failed, PackageSigningStatus.Invalid);
+            }
+
+            [Fact]
+            public async Task LogsVerificationErrorsAndWarnings()
+            {
+                // Arrange
+                await ConfigureKnownSignedPackage(
+                    TestResources.SignedPackageLeaf1Reader,
+                    TestResources.Leaf1Thumbprint);
+
+                var messages = new List<string>();
+                _logger
+                    .Setup(x => x.Log(
+                        It.IsAny<Microsoft.Extensions.Logging.LogLevel>(),
+                        It.IsAny<EventId>(),
+                        It.IsAny<object>(),
+                        It.IsAny<Exception>(),
+                        It.IsAny<Func<object, Exception, string>>()))
+                    .Callback<Microsoft.Extensions.Logging.LogLevel, EventId, object, Exception, Func<object, Exception, string>>(
+                        (ll, eid, state, ex, formatter) =>
+                        {
+                            messages.Add(formatter(state, ex));
+                        });
+
+                _verifyResult = new VerifySignaturesResult(
+                    valid: false,
+                    results: new[]
+                    {
+                        new InvalidSignaturePackageVerificationResult(
+                            SignatureVerificationStatus.Invalid,
+                            new[]
+                            {
+                                SignatureLog.Issue(
+                                    fatal: true,
+                                    code: NuGetLogCode.NU3008,
+                                    message: "The package integrity check failed."),
+                                SignatureLog.Issue(
+                                    fatal: false,
+                                    code: NuGetLogCode.NU3016,
+                                    message: "The package hash uses an unsupported hash algorithm."),
+                            })
+                    });
+
+                // Act
+                await _target.ValidateAsync(
+                    _packageMock.Object,
+                    _validation,
+                    _message,
+                    _cancellationToken);
+
+                // Assert
+                Validate(ValidationStatus.Failed, PackageSigningStatus.Invalid);
+                var message = Assert.Single(messages);
+                Assert.Equal(
+                    $"Signed package {_message.PackageId} {_message.PackageVersion} is blocked for validation " +
+                    $"{_message.ValidationId} due to verify failures. Errors: NU3008: The package integrity check " +
+                    $"failed. Warnings: NU3016: The package hash uses an unsupported hash algorithm.",
+                    message);
             }
 
             [Fact]
@@ -224,6 +306,21 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 
                 // Assert
                 Validate(ValidationStatus.Succeeded, PackageSigningStatus.Unsigned);
+            }
+
+            private async Task ConfigureKnownSignedPackage(ISignedPackageReader package, string thumbprint)
+            {
+                var signatures = await package.GetSignaturesAsync(CancellationToken.None);
+
+                _packageMock
+                    .Setup(x => x.IsSignedAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(true);
+                _packageMock
+                    .Setup(x => x.GetSignaturesAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(signatures);
+                _certificates
+                    .Setup(x => x.GetAll())
+                    .Returns(new[] { new Certificate { Thumbprint = thumbprint } }.AsQueryable());
             }
         }
     }

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature;
+using NuGet.Jobs.Validation.PackageSigning.Messages;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Packaging;
+using NuGet.Packaging.Signing;
+using NuGet.Services.Validation;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    public class SignatureValidatorIntegrationTests : IDisposable
+    {
+        private readonly Mock<IPackageSigningStateService> _packageSigningStateService;
+        private readonly Mock<ISignaturePartsExtractor> _signaturePartsExtractor;
+        private readonly Mock<IEntityRepository<Certificate>> _certificates;
+        private readonly IPackageSignatureVerifier _packageSignatureVerifier;
+        private readonly ILogger<SignatureValidator> _logger;
+        private PackageArchiveReader _package;
+        private readonly ValidatorStatus _validation;
+        private readonly SignatureValidationMessage _message;
+        private readonly CancellationToken _token;
+        private readonly SignatureValidator _target;
+
+        public SignatureValidatorIntegrationTests(ITestOutputHelper output)
+        {
+            // These dependencies have their own dependencies on the database or blob storage, which don't have good
+            // integration test infrastructure in the jobs yet. Therefore, we'll mock them for now.
+            _packageSigningStateService = new Mock<IPackageSigningStateService>();
+
+            _signaturePartsExtractor = new Mock<ISignaturePartsExtractor>();
+
+            _certificates = new Mock<IEntityRepository<Certificate>>();
+
+            // These dependencies are concrete.
+            _packageSignatureVerifier = PackageSignatureVerifierFactory.Create();
+
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddXunit(output);
+            _logger = loggerFactory.CreateLogger<SignatureValidator>();
+
+            // Initialize data.
+            _validation = new ValidatorStatus
+            {
+                PackageKey = 23,
+                ValidationId = new Guid("8eb5affc-2d0e-4315-9b79-5a194d39ebd1"),
+            };
+            _message = new SignatureValidationMessage(
+                "SomePackageId",
+                "1.2.3",
+                new Uri("https://example/validation/somepackageid.1.2.3.nupkg"),
+                _validation.ValidationId);
+            _token = CancellationToken.None;
+
+            // Initialize the subject of testing.
+            _target = new SignatureValidator(
+                _packageSigningStateService.Object,
+                _packageSignatureVerifier,
+                _signaturePartsExtractor.Object,
+                _certificates.Object,
+                _logger);
+        }
+
+        [Theory]
+        [InlineData(TestResources.SignedPackageLeaf1, TestResources.Leaf1Thumbprint)]
+        [InlineData(TestResources.SignedPackageLeaf2, TestResources.Leaf2Thumbprint)]
+        public async Task SuccessfullyValidatesLeaves(string resourceName, string thumbprint)
+        {
+            // Arrange
+            _package = TestResources.LoadPackage(resourceName);
+            AllowCertificateThumbprint(thumbprint);
+
+            // Act
+            await _target.ValidateAsync(
+                _package,
+                _validation,
+                _message,
+                _token);
+
+            // Assert
+            VerifyResult(ValidationStatus.Succeeded, PackageSigningStatus.Valid);
+        }
+
+        [Fact]
+        public async Task RejectsPackageWithAddedFile()
+        {
+            // Arrange
+            AllowCertificateThumbprint(TestResources.Leaf1Thumbprint);
+            var packageStream = TestResources.GetResourceStream(TestResources.SignedPackageLeaf1);
+
+            try
+            {
+                using (var zipArchive = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
+                using (var entryStream = zipArchive.CreateEntry("new-file.txt").Open())
+                using (var writer = new StreamWriter(entryStream))
+                {
+                    writer.WriteLine("These contents were added after the package was signed.");
+                }
+
+                _package = new PackageArchiveReader(packageStream);
+            }
+            catch
+            {
+                packageStream?.Dispose();
+                throw;
+            }
+
+            // Act
+            await _target.ValidateAsync(
+                _package,
+                _validation,
+                _message,
+                _token);
+
+            // Assert
+            VerifyResult(ValidationStatus.Failed, PackageSigningStatus.Invalid);
+        }
+
+        [Fact]
+        public async Task RejectsPackageWithModifiedFile()
+        {
+            // Arrange
+            AllowCertificateThumbprint(TestResources.Leaf1Thumbprint);
+            var packageStream = TestResources.GetResourceStream(TestResources.SignedPackageLeaf1);
+
+            try
+            {
+                using (var zipArchive = new ZipArchive(packageStream, ZipArchiveMode.Update, leaveOpen: true))
+                using (var entryStream = zipArchive.GetEntry("TestSigned.leaf-1.nuspec").Open())
+                {
+                    entryStream.Seek(0, SeekOrigin.End);
+                    var extraBytes = Encoding.ASCII.GetBytes(Environment.NewLine);
+                    entryStream.Write(extraBytes, 0, extraBytes.Length);
+                }
+
+                _package = new PackageArchiveReader(packageStream);
+            }
+            catch
+            {
+                packageStream?.Dispose();
+                throw;
+            }
+
+            // Act
+            await _target.ValidateAsync(
+                _package,
+                _validation,
+                _message,
+                _token);
+
+            // Assert
+            VerifyResult(ValidationStatus.Failed, PackageSigningStatus.Invalid);
+        }
+
+        private void AllowCertificateThumbprint(string thumbprint)
+        {
+            _certificates
+                .Setup(x => x.GetAll())
+                .Returns(new[] { new Certificate { Thumbprint = thumbprint } }.AsQueryable());
+        }
+
+        private void VerifyResult(ValidationStatus state, PackageSigningStatus status)
+        {
+            Assert.Equal(state, _validation.State);
+            _packageSigningStateService.Verify(
+                x => x.SetPackageSigningState(
+                    _validation.PackageKey,
+                    _message.PackageId,
+                    _message.PackageVersion,
+                    status),
+                Times.Once);
+        }
+
+        public void Dispose()
+        {
+            _package?.Dispose();
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="HashFacts.cs" />
     <Compile Include="SignaturePartsExtractorFacts.cs" />
     <Compile Include="SignatureValidatorFacts.cs" />
+    <Compile Include="SignatureValidatorIntegrationTests.cs" />
     <Compile Include="Support\TestDbAsyncEnumerable.cs" />
     <Compile Include="Support\TestDbAsyncEnumerator.cs" />
     <Compile Include="Support\TestDbAsyncQueryProvider.cs" />


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Jobs/pull/299. Progress on https://github.com/NuGet/Engineering/issues/785.

Executes integrity validation of signed packages, using the client APIs. Right now the following cases are tests:

1. Accepts signed package with valid integrity.
1. Rejects tampered package - added file
1. Rejects tampered package - modified file

Next step will be using client APIs to run signature `SignatureTrustAndValidityVerificationProvider` or some subset of helper functions. I've also added some integration tests that actually exercise the client APIs.