### PR TITLE
Update ServerCommon packages and start emitting issues from extract and validate

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -135,25 +135,25 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>4.3.0</Version>

--- a/src/Validation.Callback.Vcs/Web.config
+++ b/src/Validation.Callback.Vcs/Web.config
@@ -70,7 +70,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.7.1.0" newVersion="2.7.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.7.2.0" newVersion="2.7.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/src/Validation.Common/Validation.Common.csproj
+++ b/src/Validation.Common/Validation.Common.csproj
@@ -105,11 +105,11 @@
     <Reference Include="NuGet.ApplicationInsights.Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.ApplicationInsights.Owin.4.1.0\lib\net452\NuGet.ApplicationInsights.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=2.7.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.7.1\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.7.2\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Logging, Version=2.7.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Logging.2.7.1\lib\net452\NuGet.Services.Logging.dll</HintPath>
+    <Reference Include="NuGet.Services.Logging, Version=2.7.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Logging.2.7.2\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.VirusScanning.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.VirusScanning.Vcs.3.2.0\lib\net452\NuGet.Services.VirusScanning.Core.dll</HintPath>

--- a/src/Validation.Common/app.config
+++ b/src/Validation.Common/app.config
@@ -1,74 +1,74 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.7.1.0" newVersion="2.7.1.0"/>
+        <assemblyIdentity name="NuGet.Services.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.7.1.0" newVersion="2.7.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0"/>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0"/>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0"/>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Azure.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.13.5.907" newVersion="3.13.5.907"/>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.13.5.907" newVersion="3.13.5.907" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.13.5.907" newVersion="3.13.5.907"/>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.13.5.907" newVersion="3.13.5.907" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.7.1.0" newVersion="2.7.1.0"/>
+        <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.7.2.0" newVersion="2.7.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.0" newVersion="1.1.2.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0"/>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
   </startup>
 </configuration>

--- a/src/Validation.Common/packages.config
+++ b/src/Validation.Common/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.ApplicationInsights.Owin" version="4.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="2.7.1" targetFramework="net452" />
-  <package id="NuGet.Services.Logging" version="2.7.1" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="2.7.2" targetFramework="net452" />
+  <package id="NuGet.Services.Logging" version="2.7.2" targetFramework="net452" />
   <package id="NuGet.Services.VirusScanning.Vcs" version="3.2.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Serilog" version="2.0.0" targetFramework="net452" />

--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -39,13 +39,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/ISignatureValidator.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/ISignatureValidator.cs
@@ -5,15 +5,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
 using NuGet.Packaging.Signing;
-using NuGet.Services.Validation;
 
 namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 {
     public interface ISignatureValidator
     {
-        Task ValidateAsync(
+        Task<SignatureValidatorResult> ValidateAsync(
+            int packageKey,
             ISignedPackageReader signedPackageReader,
-            ValidatorStatus validation,
             SignatureValidationMessage message,
             CancellationToken cancellationToken);
     }

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidatorResult.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidatorResult.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Services.Validation;
+
+namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
+{
+    public class SignatureValidatorResult
+    {
+        public SignatureValidatorResult(ValidationStatus state) 
+            : this(state, new IValidationIssue[0])
+        {
+        }
+
+        public SignatureValidatorResult(ValidationStatus state, IReadOnlyList<IValidationIssue> issues)
+        {
+            State = state;
+            Issues = issues ?? throw new ArgumentNullException(nameof(issues));
+
+            if (state != ValidationStatus.Failed
+                && state != ValidationStatus.Succeeded
+                && issues.Any())
+            {
+                throw new ArgumentException("Issues are only allowed for terminal states.", nameof(issues));
+            }
+        }
+
+        public ValidationStatus State { get; }
+        public IReadOnlyList<IValidationIssue> Issues { get; }
+    }
+}

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SignatureValidationMessageHandler.cs" />
+    <Compile Include="SignatureValidatorResult.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -107,22 +108,22 @@
       <Version>4.6.0-preview3-4785</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-19677</Version>

--- a/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
+++ b/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
@@ -103,16 +103,16 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/Validation.Runner/App.config
+++ b/src/Validation.Runner/App.config
@@ -47,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.7.1.0" newVersion="2.7.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.7.2.0" newVersion="2.7.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -68,7 +68,7 @@
       <Version>4.5.23</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.7.1</Version>
+      <Version>2.7.2</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>


### PR DESCRIPTION
Complete https://github.com/NuGet/NuGetGallery/issues/5256.
Progress on https://github.com/NuGet/Engineering/issues/785.
Depends on https://github.com/NuGet/ServerCommon/pull/114.

This updates to new ServerCommon packages to allow extract and validate to persist its own issues. I will switch to a real package version when it is merged to master and published.