### PR TITLE
Copy validator issues to package validation issues in orchestrator process

### DIFF
--- a/src/Validation.PackageSigning.Core/Storage/AddStatusResult.cs
+++ b/src/Validation.PackageSigning.Core/Storage/AddStatusResult.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
 namespace NuGet.Jobs.Validation.PackageSigning.Storage
 {
     /// <summary>

--- a/src/Validation.PackageSigning.Core/Storage/IValidatorStateService.cs
+++ b/src/Validation.PackageSigning.Core/Storage/IValidatorStateService.cs
@@ -65,7 +65,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
         /// <param name="validatorStatus">The validaiton request's validator status that should be added to the database.</param>
         /// <param name="desiredState">The desired state for the validator's status.</param>
         /// <returns>The persisted state. This may not be the desired state if the add operation fails.</returns>
-        Task<ValidationStatus> TryAddValidatorStatusAsync(IValidationRequest request, ValidatorStatus status, ValidationStatus desiredState);
+        Task<ValidatorStatus> TryAddValidatorStatusAsync(IValidationRequest request, ValidatorStatus status, ValidationStatus desiredState);
 
         /// <summary>
         /// Try to persist the validator's status. If the update fails, the result of <see cref="GetStatusAsync(IValidationRequest)"/>
@@ -75,6 +75,6 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
         /// <param name="validatorStatus">The state of the validator's validation request that should be updated.</param>
         /// <param name="desiredState">The desired state for the validator's status.</param>
         /// <returns>The persisted state. This may not be the desired state if the update operation fails.</returns>
-        Task<ValidationStatus> TryUpdateValidationStatusAsync(IValidationRequest request, ValidatorStatus validatorStatus, ValidationStatus desiredState);
+        Task<ValidatorStatus> TryUpdateValidationStatusAsync(IValidationRequest request, ValidatorStatus validatorStatus, ValidationStatus desiredState);
     }
 }

--- a/src/Validation.PackageSigning.Core/Storage/SerializedValidationIssue.cs
+++ b/src/Validation.PackageSigning.Core/Storage/SerializedValidationIssue.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Validation;
+
+namespace NuGet.Jobs.Validation.PackageSigning.Storage
+{
+    public class SerializedValidationIssue : IValidationIssue
+    {
+        private readonly string _data;
+
+        public SerializedValidationIssue(ValidationIssueCode issueCode, string data)
+        {
+            IssueCode = issueCode;
+            _data = data;
+        }
+
+        public ValidationIssueCode IssueCode { get; }
+        public string Serialize() => _data;
+    }
+}

--- a/src/Validation.PackageSigning.Core/Storage/ValidatorStateService.cs
+++ b/src/Validation.PackageSigning.Core/Storage/ValidatorStateService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
@@ -50,6 +51,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
                     PackageKey = request.PackageKey,
                     ValidatorName = _validatorName,
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
             }
             else if (status.PackageKey != request.PackageKey)
@@ -136,7 +138,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
             }
         }
 
-        public async Task<ValidationStatus> TryAddValidatorStatusAsync(IValidationRequest request, ValidatorStatus status, ValidationStatus desiredState)
+        public async Task<ValidatorStatus> TryAddValidatorStatusAsync(IValidationRequest request, ValidatorStatus status, ValidationStatus desiredState)
         {
             status.State = desiredState;
 
@@ -153,17 +155,17 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
                     request.PackageId,
                     request.PackageVersion);
 
-                return (await GetStatusAsync(request)).State;
+                return await GetStatusAsync(request);
             }
             else if (result != AddStatusResult.Success)
             {
                 throw new NotSupportedException($"Unknown {nameof(AddStatusResult)}: {result}");
             }
 
-            return desiredState;
+            return status;
         }
 
-        public async Task<ValidationStatus> TryUpdateValidationStatusAsync(IValidationRequest request, ValidatorStatus validatorStatus, ValidationStatus desiredState)
+        public async Task<ValidatorStatus> TryUpdateValidationStatusAsync(IValidationRequest request, ValidatorStatus validatorStatus, ValidationStatus desiredState)
         {
             validatorStatus.State = desiredState;
 
@@ -180,14 +182,14 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
                     request.PackageId,
                     request.PackageVersion);
 
-                return (await GetStatusAsync(request)).State;
+                return await GetStatusAsync(request);
             }
             else if (result != SaveStatusResult.Success)
             {
                 throw new NotSupportedException($"Unknown {nameof(SaveStatusResult)}: {result}");
             }
 
-            return desiredState;
+            return validatorStatus;
         }
     }
 }

--- a/src/Validation.PackageSigning.Core/Storage/ValidatorStatusExtensions.cs
+++ b/src/Validation.PackageSigning.Core/Storage/ValidatorStatusExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using NuGet.Services.Validation;
+
+namespace NuGet.Jobs.Validation.PackageSigning.Storage
+{
+    public static class ValidatorStatusExtensions
+    {
+        /// <summary>
+        /// Maps the provided validation status entity and its associated issues to a <see cref="IValidationResult"/>.
+        /// This method does not attempt to deserialize the issue data.
+        /// </summary>
+        public static IValidationResult ToValidationResult(this ValidatorStatus validatorStatus)
+        {
+            if (validatorStatus == null)
+            {
+                throw new ArgumentNullException(nameof(validatorStatus));
+            }
+
+            if (validatorStatus.ValidatorIssues == null)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(ValidatorStatus.ValidatorIssues)} property must not be null.",
+                    nameof(validatorStatus));
+            }
+
+            /// Don't attempt to deserialize the issues. Instead, pass the issue code and data along to the orchestrator
+            /// to be persisted as-is. This makes the orchestrator more resilient when having outdated version of the
+            /// issues library. Note that this essentially assumes that the data stored in <see cref="ValidatorIssue"/>
+            /// and <see cref="PackageValidationIssue"/> have the same schema.
+            var issues = validatorStatus
+                .ValidatorIssues
+                .Select(x => new SerializedValidationIssue(x.IssueCode, x.Data))
+                .ToList();
+
+            return new ValidationResult(validatorStatus.State, issues);
+        }
+    }
+}

--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -67,7 +67,9 @@
     <Compile Include="Messages\SignatureValidationMessageSerializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\SaveStatusResult.cs" />
+    <Compile Include="Storage\SerializedValidationIssue.cs" />
     <Compile Include="Storage\ValidatorStateService.cs" />
+    <Compile Include="Storage\ValidatorStatusExtensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageCertificates/PackageCertificatesValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageCertificates/PackageCertificatesValidatorFacts.cs
@@ -33,6 +33,48 @@ namespace NuGet.Services.Validation.PackageSigning
                            .Select(s => new object[] { s });
             }
 
+            [Fact]
+            public async Task ReturnsValidatorIssues()
+            {
+                // Arrange
+                _validationContext.Mock(validatorStatuses: new[]
+                {
+                    new ValidatorStatus
+                    {
+                        ValidationId = ValidationId,
+                        PackageKey = PackageKey,
+                        ValidatorName = nameof(PackageCertificatesValidator),
+                        State = ValidationStatus.Failed,
+                        ValidatorIssues = new List<ValidatorIssue>
+                        {
+                            new ValidatorIssue
+                            {
+                                IssueCode = (ValidationIssueCode)987,
+                                Data = "{}",
+                            },
+                            new ValidatorIssue
+                            {
+                                IssueCode = ValidationIssueCode.ClientSigningVerificationFailure,
+                                Data = "unknown contract",
+                            },
+                        },
+                    }
+                });
+
+                // Act
+                var actual = await _target.GetResultAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.Failed, actual.Status);
+                Assert.Equal(2, actual.Issues.Count);
+
+                Assert.Equal((ValidationIssueCode)987, actual.Issues[0].IssueCode);
+                Assert.Equal("{}", actual.Issues[0].Serialize());
+
+                Assert.Equal(ValidationIssueCode.ClientSigningVerificationFailure, actual.Issues[1].IssueCode);
+                Assert.Equal("unknown contract", actual.Issues[1].Serialize());
+            }
+
             [Theory]
             [MemberData(nameof(ReturnsPersistedStatusIfNotIncompleteData))]
             public async Task ReturnsPersistedStatusIfNotIncomplete(ValidationStatus status)
@@ -46,6 +88,7 @@ namespace NuGet.Services.Validation.PackageSigning
                         PackageKey = PackageKey,
                         ValidatorName = nameof(PackageCertificatesValidator),
                         State = status,
+                        ValidatorIssues = new List<ValidatorIssue>(),
                     }
                 });
 
@@ -156,6 +199,7 @@ namespace NuGet.Services.Validation.PackageSigning
                             ValidatorName = nameof(PackageCertificatesValidator),
                             PackageKey = PackageKey,
                             State = ValidationStatus.Incomplete,
+                            ValidatorIssues = new List<ValidatorIssue>(),
                         }
                     },
                     packageSigningStates: new PackageSigningState[]
@@ -237,6 +281,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.Incomplete,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -378,6 +423,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.Incomplete,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -437,6 +483,7 @@ namespace NuGet.Services.Validation.PackageSigning
                         PackageKey = PackageKey,
                         ValidatorName = nameof(PackageCertificatesValidator),
                         State = status,
+                            ValidatorIssues = new List<ValidatorIssue>(),
                     }
                 });
 
@@ -458,6 +505,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     PackageKey = PackageKey,
                     ValidatorName = nameof(PackageCertificatesValidator),
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -493,6 +541,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -557,6 +606,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -673,6 +723,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -763,6 +814,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -852,6 +904,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var otherValidatorStatus = new ValidatorStatus
@@ -860,6 +913,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.Succeeded,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState
@@ -1033,6 +1087,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     ValidatorName = nameof(PackageCertificatesValidator),
                     PackageKey = PackageKey,
                     State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
                 };
 
                 var packageSigningState = new PackageSigningState

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
@@ -58,6 +58,8 @@ namespace NuGet.Services.Validation
                 Assert.Equal(PackageKey, status.PackageKey);
                 Assert.Equal(nameof(AValidator), status.ValidatorName);
                 Assert.Equal(ValidationStatus.NotStarted, status.State);
+                Assert.NotNull(status.ValidatorIssues);
+                Assert.Empty(status.ValidatorIssues);
             }
 
             [Fact]
@@ -440,7 +442,7 @@ namespace NuGet.Services.Validation
                                 && s.State == ValidationStatus.NotStarted)),
                     Times.Once);
 
-                Assert.Equal(ValidationStatus.NotStarted, result);
+                Assert.Equal(ValidationStatus.NotStarted, result.State);
             }
         }
 
@@ -469,9 +471,9 @@ namespace NuGet.Services.Validation
                                             ValidationStatus.Succeeded);
 
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
-
-                Assert.Equal(ValidationStatus.Succeeded, result);
+                
                 Assert.Equal(ValidationStatus.Succeeded, existingStatus.State);
+                Assert.Same(existingStatus, result);
             }
         }
 

--- a/tests/Validation.PackageSigning.Core.Tests/Storage/ValidatorStatusExtensionsFacts.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Storage/ValidatorStatusExtensionsFacts.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Services.Validation;
+using Xunit;
+
+namespace Validation.PackageSigning.Core.Tests.Storage
+{
+    public class ValidatorStatusExtensionsFacts
+    {
+        public class ToValidationResult
+        {
+            [Fact]
+            public void RejectsNullValidatorStatus()
+            {
+                // Arrange
+                ValidatorStatus validatorStatus = null;
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentNullException>(() => validatorStatus.ToValidationResult());
+                Assert.Equal("validatorStatus", ex.ParamName);
+            }
+
+            [Fact]
+            public void RejectsNullValidatorIssues()
+            {
+                // Arrange
+                var validatorStatus = new ValidatorStatus
+                {
+                    ValidatorIssues = null,
+                };
+
+                // Act & Assert
+                var ex = Assert.Throws<ArgumentException>(() => validatorStatus.ToValidationResult());
+                Assert.Contains("The ValidatorIssues property must not be null.", ex.Message);
+                Assert.Equal("validatorStatus", ex.ParamName);
+            }
+
+            [Fact]
+            public void AllowsEmptyIssueList()
+            {
+                // Arrange
+                var validatorStatus = new ValidatorStatus
+                {
+                    State = ValidationStatus.Succeeded,
+                    ValidatorIssues = new List<ValidatorIssue>(),
+                };
+
+                // Act
+                var result = validatorStatus.ToValidationResult();
+
+                // Assert
+                Assert.Equal(ValidationStatus.Succeeded, result.Status);
+                Assert.NotNull(result.Issues);
+                Assert.Empty(result.Issues);
+            }
+
+            [Fact]
+            public void BlindlyConvertsIssues()
+            {
+                // Arrange
+                var validatorStatus = new ValidatorStatus
+                {
+                    State = ValidationStatus.Failed,
+                    ValidatorIssues = new List<ValidatorIssue>
+                    {
+                        new ValidatorIssue { IssueCode = (ValidationIssueCode)int.MaxValue, Data = "unknown issue data" },
+                        new ValidatorIssue { IssueCode = ValidationIssueCode.Unknown, Data = "{}" },
+                        new ValidatorIssue { IssueCode = ValidationIssueCode.ClientSigningVerificationFailure, Data = "{\"invalid\":\"data\"}" },
+                    },
+                };
+
+                // Act
+                var result = validatorStatus.ToValidationResult();
+
+                // Assert
+                Assert.Equal(ValidationStatus.Failed, result.Status);
+                Assert.Equal(3, result.Issues.Count);
+
+                Assert.Equal((ValidationIssueCode)int.MaxValue, result.Issues[0].IssueCode);
+                Assert.Equal("unknown issue data", result.Issues[0].Serialize());
+
+                Assert.Equal(ValidationIssueCode.Unknown, result.Issues[1].IssueCode);
+                Assert.Equal("{}", result.Issues[1].Serialize());
+
+                Assert.Equal(ValidationIssueCode.ClientSigningVerificationFailure, result.Issues[2].IssueCode);
+                Assert.Equal("{\"invalid\":\"data\"}", result.Issues[2].Serialize());
+            }
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\CertificateStoreTests.cs" />
+    <Compile Include="Storage\ValidatorStatusExtensionsFacts.cs" />
     <Compile Include="TestData\TestResources.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/785.
Complete https://github.com/NuGet/NuGetGallery/issues/5256.

This applies to both extract and validate as well as validate signature validators.

Previously, issues we generated in memory, in the orchestrator process based off of a convention: if extract and validator job fails, assume the issue is that the package is signed and therefore rejected. 

I changed to the model to allow downstream validators to persist other issues in the `ValidatorIssues` table. This is joined against the existing `ValidatorStatuses` table and used to populate the `IValidationResult` returned to the orchestrator.

One design decision that could be debated is whether the `IValidator` implementations should deserialize the issues found in the `ValidatorIssues` table before passing them to the orchestrator. I chose not to do this so that new issues introduced in both the gallery and downstream validator do not require an orchestrator deployment. This is a choice to harden the pipeline for cases when we need to deploy new issues.

This is what it looks like when an issue bubbles all the way out to the gallery:
![image](https://user-images.githubusercontent.com/94054/35009261-e3c838ba-fab3-11e7-9397-93db80b7db69.png)



