### PR TITLE
Use IPackageSignatureVerifier to verify the format of the signature file before reading the signature

### DIFF
--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Job.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Job.cs
@@ -184,10 +184,15 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
             services.AddTransient<IBrokeredMessageSerializer<SignatureValidationMessage>, SignatureValidationMessageSerializer>();
             services.AddTransient<IMessageHandler<SignatureValidationMessage>, SignatureValidationMessageHandler>();
             services.AddTransient<IPackageSigningStateService, PackageSigningStateService>();
-            services.AddTransient<ISignatureValidator, SignatureValidator>();
             services.AddTransient<ISignaturePartsExtractor, SignaturePartsExtractor>();
 
-            services.AddTransient(p => PackageSignatureVerifierFactory.Create());
+            services.AddTransient<ISignatureValidator, SignatureValidator>(p => new SignatureValidator(
+                p.GetRequiredService<IPackageSigningStateService>(),
+                PackageSignatureVerifierFactory.CreateMinimal(),
+                PackageSignatureVerifierFactory.CreateFull(),
+                p.GetRequiredService<ISignaturePartsExtractor>(),
+                p.GetRequiredService<IEntityRepository<Certificate>>(),
+                p.GetRequiredService<ILogger<SignatureValidator>>()));
 
             services.AddSingleton(p =>
             {

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/MinimalSignatureVerificationProvider.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/MinimalSignatureVerificationProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Signing;
+
+namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
+{
+    /// <summary>
+    /// A signature verification provider which performs no verification at all. It allows amount of verification to be
+    /// done by <see cref="IPackageSignatureVerifier"/> before performing more in-depth analysis.
+    /// </summary>
+    public class MinimalSignatureVerificationProvider : ISignatureVerificationProvider
+    {
+        public Task<PackageVerificationResult> GetTrustResultAsync(
+            ISignedPackageReader package,
+            Signature signature,
+            SignedPackageVerifierSettings settings,
+            CancellationToken token)
+        {
+            var result = new SignedPackageVerificationResult(
+                SignatureVerificationStatus.Trusted,
+                signature,
+                Enumerable.Empty<SignatureLog>());
+
+            return Task.FromResult<PackageVerificationResult>(result);
+        }
+    }
+}

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/PackageSignatureVerifierFactory.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/PackageSignatureVerifierFactory.cs
@@ -10,7 +10,33 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
     /// </summary>
     public static class PackageSignatureVerifierFactory
     {
-        public static IPackageSignatureVerifier Create()
+        /// <summary>
+        /// Initializes a verifier that only verifies the format of the signature. No integrity or trust checks are
+        /// performed.
+        /// </summary>
+        public static IPackageSignatureVerifier CreateMinimal()
+        {
+            var verificationProviders = new[]
+            {
+                new MinimalSignatureVerificationProvider(),
+            };
+
+            var settings = new SignedPackageVerifierSettings(
+                allowUnsigned: true,
+                allowUntrusted: false, // Invalid format of the signature uses this flag to determine success.
+                allowIgnoreTimestamp: true,
+                failWithMultipleTimestamps: false,
+                allowNoTimestamp: true);
+
+            return new PackageSignatureVerifier(
+                verificationProviders,
+                settings);
+        }
+
+        /// <summary>
+        /// Initializes a verifier that performs all integrity and trust checks required by the server.
+        /// </summary>
+        public static IPackageSignatureVerifier CreateFull()
         {
             var verificationProviders = new[]
             {

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -45,6 +45,7 @@
     <Compile Include="HashedCertificate.cs" />
     <Compile Include="ISignaturePartsExtractor.cs" />
     <Compile Include="ISignatureValidator.cs" />
+    <Compile Include="MinimalSignatureVerificationProvider.cs" />
     <Compile Include="PackageSignatureVerifierFactory.cs" />
     <Compile Include="SignaturePartsExtractor.cs" />
     <Compile Include="SignatureValidator.cs" />

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/ChainCertificateRequest.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/ChainCertificateRequest.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    /// <summary>
+    /// Source:
+    /// https://github.com/NuGet/NuGet.Client/blob/8aabf8dcf1d1ffdd6cdc32670eb0a33320adcdf2/test/TestUtilities/Test.Utility/Signing/ChainCertificateRequest.cs
+    /// </summary>
+    public class ChainCertificateRequest
+    {
+        public string CrlServerBaseUri { get; set; }
+
+        public string CrlLocalBaseUri { get; set; }
+
+        public bool IsCA { get; set; }
+
+        public bool ConfigureCrl { get; set; } = true;
+
+        public X509Certificate2 Issuer { get; set; }
+
+        public string IssuerDN => Issuer?.Subject;
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/SigningTestUtility.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/SigningTestUtility.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Utilities;
+using Org.BouncyCastle.X509;
+using Org.BouncyCastle.X509.Extension;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+{
+    /// <summary>
+    /// Source:
+    /// https://github.com/NuGet/NuGet.Client/blob/7a8fe0bd7397e28a4fda6479b49e22df76578ece/test/TestUtilities/Test.Utility/Signing/SigningTestUtility.cs
+    /// </summary>
+    public static class SigningTestUtility
+    {
+        public static X509Certificate2 GenerateCertificate(
+            string subjectName,
+            Action<X509V3CertificateGenerator> modifyGenerator,
+            string signatureAlgorithm = "SHA256WITHRSA",
+            int publicKeyLength = 2048,
+            ChainCertificateRequest chainCertificateRequest = null)
+        {
+            if (string.IsNullOrEmpty(subjectName))
+            {
+                subjectName = "NuGetTest";
+            }
+
+            var random = new SecureRandom();
+            var pairGenerator = new RsaKeyPairGenerator();
+            var genParams = new KeyGenerationParameters(random, publicKeyLength);
+            pairGenerator.Init(genParams);
+            var issuerKeyPair = pairGenerator.GenerateKeyPair();
+
+            // Create cert
+            var subjectDN = $"CN={subjectName}";
+            var certGen = new X509V3CertificateGenerator();
+            certGen.SetSubjectDN(new X509Name(subjectDN));
+
+            // default to new key pair
+            var issuerPrivateKey = issuerKeyPair.Private;
+            var keyUsage = KeyUsage.DigitalSignature;
+            var issuerDN = chainCertificateRequest?.IssuerDN ?? subjectDN;
+            certGen.SetIssuerDN(new X509Name(issuerDN));
+            
+            if (chainCertificateRequest != null)
+            {
+                if (chainCertificateRequest.Issuer != null)
+                {
+                    // for a certificate with an issuer assign Authority Key Identifier
+                    var issuer = chainCertificateRequest?.Issuer;
+                    var bcIssuer = DotNetUtilities.FromX509Certificate(issuer);
+                    var authorityKeyIdentifier = new AuthorityKeyIdentifierStructure(bcIssuer);
+                    issuerPrivateKey = DotNetUtilities.GetKeyPair(issuer.PrivateKey).Private;
+                    certGen.AddExtension(X509Extensions.AuthorityKeyIdentifier.Id, false, authorityKeyIdentifier);
+                }
+
+                if (chainCertificateRequest.ConfigureCrl)
+                {
+                    // for a certificate in a chain create CRL distribution point extension
+                    var crlServerUri = $"{chainCertificateRequest.CrlServerBaseUri}{issuerDN}.crl";
+                    var generalName = new GeneralName(GeneralName.UniformResourceIdentifier, new DerIA5String(crlServerUri));
+                    var distPointName = new DistributionPointName(new GeneralNames(generalName));
+                    var distPoint = new DistributionPoint(distPointName, null, null);
+
+                    certGen.AddExtension(X509Extensions.CrlDistributionPoints, critical: false, extensionValue: new DerSequence(distPoint));
+                }
+
+                if (chainCertificateRequest.IsCA)
+                {
+                    // update key usage with CA cert sign and crl sign attributes
+                    keyUsage |= KeyUsage.CrlSign | KeyUsage.KeyCertSign;
+                }
+            }
+
+            certGen.SetNotAfter(DateTime.UtcNow.Add(TimeSpan.FromHours(1)));
+            certGen.SetNotBefore(DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
+            certGen.SetPublicKey(issuerKeyPair.Public);
+
+            var serialNumber = BigIntegers.CreateRandomInRange(BigInteger.One, BigInteger.ValueOf(long.MaxValue), random);
+            certGen.SetSerialNumber(serialNumber);
+
+            var subjectKeyIdentifier = new SubjectKeyIdentifier(SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(issuerKeyPair.Public));
+            certGen.AddExtension(X509Extensions.SubjectKeyIdentifier.Id, false, subjectKeyIdentifier);
+
+            certGen.AddExtension(X509Extensions.KeyUsage.Id, false, new KeyUsage(keyUsage));
+            certGen.AddExtension(X509Extensions.BasicConstraints.Id, true, new BasicConstraints(chainCertificateRequest?.IsCA ?? false));
+
+            // Allow changes
+            modifyGenerator?.Invoke(certGen);
+
+            var signatureFactory = new Asn1SignatureFactory(signatureAlgorithm, issuerPrivateKey, random);
+            var certificate = certGen.Generate(signatureFactory);
+            var certResult = new X509Certificate2(certificate.GetEncoded());
+            
+            certResult.PrivateKey = DotNetUtilities.ToRSA(issuerKeyPair.Private as RsaPrivateCrtKeyParameters);
+
+            return certResult;
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
@@ -39,6 +39,8 @@
     <Compile Include="SignaturePartsExtractorFacts.cs" />
     <Compile Include="SignatureValidatorFacts.cs" />
     <Compile Include="SignatureValidatorIntegrationTests.cs" />
+    <Compile Include="Support\ChainCertificateRequest.cs" />
+    <Compile Include="Support\SigningTestUtility.cs" />
     <Compile Include="Support\TestDbAsyncEnumerable.cs" />
     <Compile Include="Support\TestDbAsyncEnumerator.cs" />
     <Compile Include="Support\TestDbAsyncQueryProvider.cs" />


### PR DESCRIPTION
Previously, an invalid signed CMS would result in an exception (and cause the message to eventually dead-letter). I fixed this by doing a first pass with 
`IPackageSignatureVerifier`. The implementation of this interface handles two sorts of expected exception types: `SignatureException` and `CryptographicException`.

Also, reject non-author signatures.

Progress on https://github.com/NuGet/Engineering/issues/785.