### PR TITLE
Add initial telemetry service with stub implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ Results.*.xml
 AssemblyInfo.*.cs
 /tests/Validation.Helper.Tests/Validation.Helper.Tests.nuget.props
 /tests/Validation.Common.Tests/Validation.Common.Tests.nuget.props
+/tests/Validation.Common.Tests/Validation.Common.Tests.nuget.targets
+/tests/Validation.Helper.Tests/Validation.Helper.Tests.nuget.targets

--- a/src/NuGet.Services.Validation.Orchestrator/IValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidationStorageService.cs
@@ -26,6 +26,13 @@ namespace NuGet.Services.Validation.Orchestrator
         Task<PackageValidationSet> GetValidationSetAsync(Guid validationTrackingId);
 
         /// <summary>
+        /// Gets the number of validation sets that the provided package key has.
+        /// </summary>
+        /// <param name="packageKey">The package key.</param>
+        /// <returns>The count.</returns>
+        Task<int> GetValidationSetCountAsync(int packageKey);
+
+        /// <summary>
         /// Updates the passed <see cref="PackageValidation"/> with the validation result's status,
         /// updates the <see cref="PackageValidation.ValidationStatusTimestamp"/> to current timestamp,
         /// and persists changes in the storage. The result's status cannot be <see cref="ValidationStatus.NotStarted"/>
@@ -62,8 +69,7 @@ namespace NuGet.Services.Validation.Orchestrator
         /// <param name="currentValidationSetTrackingId">Validation set tracking for the currently processed request.</param>
         /// <returns>True if validation set exists, false otherwise.</returns>
         Task<bool> OtherRecentValidationSetForPackageExists(
-            string packageId,
-            string normalizedVersion,
+            int packageKey,
             TimeSpan recentDuration,
             Guid currentValidationSetTrackingId);
     }

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -23,6 +23,7 @@ using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
 using NuGet.Services.ServiceBus;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
 using NuGet.Services.Validation.PackageCertificates;
 using NuGet.Services.Validation.PackageSigning;
 using NuGet.Services.Validation.Vcs;
@@ -207,6 +208,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<ICoreMessageServiceConfiguration, CoreMessageServiceConfiguration>();
             services.AddTransient<ICoreMessageService, CoreMessageService>();
             services.AddTransient<IMessageService, MessageService>();
+            services.AddTransient<ITelemetryService, TelemetryService>();
         }
 
         private static IServiceProvider CreateProvider(IServiceCollection services)

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -72,6 +72,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="SmtpConfiguration.cs" />
+    <Compile Include="Telemetry\ITelemetryService.cs" />
+    <Compile Include="Telemetry\TelemetryService.cs" />
     <Compile Include="ValidationConfiguration.cs" />
     <Compile Include="ValidationConfigurationItem.cs" />
     <Compile Include="ValidationFailureBehavior.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Orchestrator.Telemetry
+{
+    /// <summary>
+    /// The interface used for emitting telemetry from the validation orchestrator.
+    /// </summary>
+    public interface ITelemetryService
+    {
+        /// <summary>
+        /// The duration from when the package was created to when the first validation set was created. This metric
+        /// is not emitted for revalidation requests.
+        /// </summary>
+        void TrackDurationToValidationSetCreation(TimeSpan duration);
+
+        /// <summary>
+        /// A counter metric emitted when a package changes package status. This metric is not emitted if package status
+        /// does not change. This metric is emitted for revalidation if the terminal state changes.
+        /// </summary>
+        /// <param name="fromStatus">The status that the package moved from.</param>
+        /// <param name="toStatus">The status that the package moved tp.</param>
+        void TrackPackageStatusChange(PackageStatus fromStatus, PackageStatus toStatus);
+
+        /// <summary>
+        /// The total duration of all validators. This is the time that the validation set is first created until all of
+        /// the validators have completed. This metric is also emitted for revalidations.
+        /// </summary>
+        /// <param name="duration">The duration.</param>
+        /// <param name="isSuccess">Whether or not all of the validations succeeded.</param>
+        void TrackTotalValidationDuration(TimeSpan duration, bool isSuccess);
+
+        /// <summary>
+        /// A counter metric emitted when a validator fails due to the <see cref="ValidationConfigurationItem.FailAfter"/>
+        /// configuration.
+        /// </summary>
+        /// <param name="validatorType">The validator type (name).</param>
+        void TrackValidatorTimeout(string validatorType);
+
+        /// <summary>
+        /// The total duration of a single validator. This is the time from when the validation is first started until
+        /// when the validation either completes or times out.
+        /// </summary>
+        /// <param name="duration">The duration.</param>
+        /// <param name="validatorType">The validator type (name).</param>
+        /// <param name="isSuccess">Whether or not the validation succeeded.</param>
+        void TrackValidatorDuration(TimeSpan duration, string validatorType, bool isSuccess);
+
+        /// <summary>
+        /// A counter metric emitted when a validator is started.
+        /// </summary>
+        /// <param name="validatorType">The validator type (name).</param>
+        void TrackValidatorStarted(string validatorType);
+
+        /// <summary>
+        /// A counter metric emmitted when a validator reaches a terminal state and potentially persists validation
+        /// issues. A count of zero is emitted if the validator does not produce any issues. This metric is not emitted
+        /// if the validation is still at a non-terminal state.
+        /// </summary>
+        /// <param name="count">The number of issues.</param>
+        /// <param name="validatorType">The validator type (name) that returned the issue list.</param>
+        /// <param name="isSuccess">Whether or not the validation succeeded.</param>
+        void TrackValidationIssueCount(int count, string validatorType, bool isSuccess);
+
+        /// <summary>
+        /// A counter metric emitted when a validation issue is created.
+        /// </summary>
+        /// <param name="validatorType">The validator type (name) the produced the issue.</param>
+        /// <param name="code">The issue code.</param>
+        void TrackValidationIssue(string validatorType, ValidationIssueCode code);
+
+        /// <summary>
+        /// A counter metric emitted when a client-mastered validation issue is emitted.
+        /// </summary>
+        /// <param name="validatorType">The validator type (name) the produced the issue.</param>
+        /// <param name="clientCode">The client code.</param>
+        void TrackClientValidationIssue(string validatorType, string clientCode);
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Orchestrator.Telemetry
+{
+    public class TelemetryService : ITelemetryService
+    {
+        public void TrackDurationToValidationSetCreation(TimeSpan duration)
+        {
+        }
+
+        public void TrackPackageStatusChange(PackageStatus fromStatus, PackageStatus toStatus)
+        {
+        }
+
+        public void TrackTotalValidationDuration(TimeSpan duration, bool isSuccess)
+        {
+        }
+
+        public void TrackValidationIssue(string validatorType, ValidationIssueCode code)
+        {
+        }
+
+        public void TrackValidationIssueCount(int count, string validatorType, bool isSuccess)
+        {
+        }
+
+        public void TrackValidatorTimeout(string validatorType)
+        {
+        }
+
+        public void TrackValidatorDuration(TimeSpan duration, string validatorType, bool isSuccess)
+        {
+        }
+
+        public void TrackValidatorStarted(string validatorType)
+        {
+        }
+
+        public void TrackClientValidationIssue(string validatorType, string clientCode)
+        {
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
@@ -7,6 +7,8 @@ using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using NuGet.Services.Validation.Issues;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
 
 namespace NuGet.Services.Validation.Orchestrator
 {
@@ -15,12 +17,17 @@ namespace NuGet.Services.Validation.Orchestrator
     /// </summary>
     public class ValidationStorageService : IValidationStorageService
     {
-        private readonly ValidationEntitiesContext _validationContext;
+        private readonly IValidationEntitiesContext _validationContext;
+        private readonly ITelemetryService _telemetryService;
         private readonly ILogger<ValidationStorageService> _logger;
 
-        public ValidationStorageService(ValidationEntitiesContext validationContext, ILogger<ValidationStorageService> logger)
+        public ValidationStorageService(
+            IValidationEntitiesContext validationContext,
+            ITelemetryService telemetryService,
+            ILogger<ValidationStorageService> logger)
         {
             _validationContext = validationContext ?? throw new ArgumentNullException(nameof(validationContext));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -79,6 +86,8 @@ namespace NuGet.Services.Validation.Orchestrator
             packageValidation.ValidationStatusTimestamp = now;
             packageValidation.Started = now;
             await _validationContext.SaveChangesAsync();
+
+            TrackValidationStatus(packageValidation);
         }
 
         public async Task UpdateValidationStatusAsync(PackageValidation packageValidation, IValidationResult validationResult)
@@ -90,31 +99,80 @@ namespace NuGet.Services.Validation.Orchestrator
                 packageValidation.PackageValidationSet.PackageId,
                 packageValidation.PackageValidationSet.PackageNormalizedVersion,
                 validationResult.Status);
+
             if (packageValidation.ValidationStatus == validationResult.Status)
             {
                 return;
             }
+
+            var previousValidationStatus = packageValidation.ValidationStatus;
 
             AddValidationIssues(packageValidation, validationResult.Issues);
 
             packageValidation.ValidationStatus = validationResult.Status;
             packageValidation.ValidationStatusTimestamp = DateTime.UtcNow;
             await _validationContext.SaveChangesAsync();
+
+            TrackValidationStatus(packageValidation);
+        }
+
+        private void TrackValidationStatus(PackageValidation packageValidation)
+        {
+            if (packageValidation.ValidationStatus != ValidationStatus.Failed
+                && packageValidation.ValidationStatus != ValidationStatus.Succeeded)
+            {
+                return;
+            }
+
+            var isSuccess = packageValidation.ValidationStatus == ValidationStatus.Succeeded;
+
+            TimeSpan validatorDuration = TimeSpan.Zero;
+            if (packageValidation.Started.HasValue)
+            {
+                validatorDuration = packageValidation.ValidationStatusTimestamp - packageValidation.Started.Value;
+            }
+
+            _telemetryService.TrackValidatorDuration(
+               validatorDuration,
+               packageValidation.Type,
+               isSuccess);
+
+            _telemetryService.TrackValidationIssueCount(
+                packageValidation.PackageValidationIssues.Count,
+                packageValidation.Type,
+                isSuccess);
+
+            foreach (var issue in packageValidation?.PackageValidationIssues ?? Enumerable.Empty<PackageValidationIssue>())
+            {
+                _telemetryService.TrackValidationIssue(packageValidation.Type, issue.IssueCode);
+
+                var deserializedIssue = ValidationIssue.Deserialize(issue.IssueCode, issue.Data);
+                if (issue.IssueCode == ValidationIssueCode.ClientSigningVerificationFailure
+                    && deserializedIssue is ClientSigningVerificationFailure typedIssue)
+                {
+                    _telemetryService.TrackClientValidationIssue(packageValidation.Type, typedIssue.ClientCode);
+                }
+            }
         }
 
         public async Task<bool> OtherRecentValidationSetForPackageExists(
-            string packageId,
-            string normalizedVersion,
+            int packageKey,
             TimeSpan recentDuration,
             Guid currentValidationSetTrackingId)
         {
             var cutoffTimestamp = DateTime.UtcNow - recentDuration;
             return await _validationContext
                 .PackageValidationSets
-                .AnyAsync(pvs => pvs.PackageId == packageId
-                    && pvs.PackageNormalizedVersion == normalizedVersion
+                .AnyAsync(pvs => pvs.PackageKey == packageKey
                     && pvs.Created > cutoffTimestamp
                     && pvs.ValidationTrackingId != currentValidationSetTrackingId);
+        }
+
+        public async Task<int> GetValidationSetCountAsync(int packageKey)
+        {
+            return await _validationContext
+                .PackageValidationSets
+                .CountAsync(x => x.PackageKey == packageKey);
         }
 
         private void AddValidationIssues(PackageValidation packageValidation, IReadOnlyList<IValidationIssue> validationIssues)

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/MessageServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/MessageServiceFacts.cs
@@ -52,13 +52,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         private static IEnumerable<string> InvalidValuesToTest => new string[] { null, "", " " };
         private const string ValidValue = "123";
         private const string ValidSettingsUrl = "https://example.com";
-        public static IEnumerable<string[]> EmailConfigurationPropertyValuesCombinations =>
+        public static IEnumerable<object[]> EmailConfigurationPropertyValuesCombinations =>
             (from invalidValue in InvalidValuesToTest
             select new [] 
             {
-                new string[] { invalidValue,   ValidValue, ValidSettingsUrl, "PackageUrlTemplate" },
-                new string[] {   ValidValue, invalidValue, ValidSettingsUrl, "PackageSupportTemplate" },
-                new string[] {   ValidValue,   ValidValue,     invalidValue, "EmailSettingsUrl" }
+                new object[] { invalidValue,   ValidValue, ValidSettingsUrl, "PackageUrlTemplate" },
+                new object[] {   ValidValue, invalidValue, ValidSettingsUrl, "PackageSupportTemplate" },
+                new object[] {   ValidValue,   ValidValue,     invalidValue, "EmailSettingsUrl" }
             }).SelectMany(x => x);
 
         [Theory]

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ValidationProviderFacts.cs" />
     <Compile Include="ValidationSetProcessorFacts.cs" />
     <Compile Include="ValidationSetProviderFacts.cs" />
+    <Compile Include="ValidationStorageServiceFacts.cs" />
     <Compile Include="ValidatorStateServiceFacts.cs" />
     <Compile Include="Vcs\PackageCriteriaEvaluatorFacts.cs" />
     <Compile Include="Vcs\VcsValidatorFacts.cs" />
@@ -65,7 +66,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="moq">
-      <Version>4.5.23</Version>
+      <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
       <Version>2.12.0</Version>
@@ -74,10 +75,10 @@
       <Version>4.3.3</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.1.0</Version>
+      <Version>2.3.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.1.0</Version>
+      <Version>2.3.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -92,6 +93,10 @@
     <ProjectReference Include="..\..\src\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj">
       <Project>{91C060DA-736F-4DA9-A57F-CB3AC0E6CB10}</Project>
       <Name>Validation.PackageSigning.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Validation.PackageSigning.Core.Tests\Validation.PackageSigning.Core.Tests.csproj">
+      <Project>{b4b7564a-965b-447b-927f-6749e2c08880}</Project>
+      <Name>Validation.PackageSigning.Core.Tests</Name>
     </ProjectReference>
     <ProjectReference Include="..\Validation.PackageSigning.Helpers\Validation.PackageSigning.Helpers.csproj">
       <Project>{2c5be067-adfd-49e3-ba9f-13a74436e5db}</Project>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -50,7 +50,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             ValidationSetProviderMock
                 .Setup(vsp => vsp.TryGetOrCreateValidationSetAsync(messageData.ValidationTrackingId, package))
-                .ReturnsAsync(null)
+                .ReturnsAsync((PackageValidationSet)null)
                 .Verifiable();
 
             var handler = CreateHandler();

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
@@ -1,0 +1,301 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Services.Validation.Issues;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+using Validation.PackageSigning.Core.Tests.Support;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.Validation.Orchestrator.Tests
+{
+    public class ValidationStorageServiceFacts
+    {
+        public class UpdateValidationStatusAsync : TelemetryFacts
+        {
+            public UpdateValidationStatusAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            protected override async Task ExecuteAsync(ValidationResult validationResult)
+            {
+                await _target.UpdateValidationStatusAsync(_packageValidation, validationResult);
+            }
+
+            [Theory]
+            [InlineData(ValidationStatus.Failed)]
+            [InlineData(ValidationStatus.Succeeded)]
+            [InlineData(ValidationStatus.Incomplete)]
+            public async Task DoesNotEmitTelemtryForNoStatusChange(ValidationStatus status)
+            {
+                // Arrange
+                _packageValidation.ValidationStatus = status;
+                var validationResult = new ValidationResult(status);
+
+                _telemetryService = new Mock<ITelemetryService>(MockBehavior.Strict);
+                InitializeTarget();
+
+                // Act
+                await ExecuteAsync(validationResult);
+
+                // Assert
+                _telemetryService.VerifyAll();
+            }
+        }
+
+        public class MarkValidationStartedAsync : TelemetryFacts
+        {
+            public MarkValidationStartedAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            protected override async Task ExecuteAsync(ValidationResult validationResult)
+            {
+                await _target.MarkValidationStartedAsync(_packageValidation, validationResult);
+            }
+        }
+
+        public class GetValidationSetCountAsync : Facts
+        {
+            public GetValidationSetCountAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public async Task ReturnsZeroWhenThereAreNoMatchingValidationSets()
+            {
+                // Arrange & Act
+                var actual = await _target.GetValidationSetCountAsync(_packageKey);
+
+                // Assert
+                Assert.Equal(0, actual);
+            }
+
+            [Fact]
+            public async Task ReturnsMatchingCount()
+            {
+                // Arrange
+                _entitiesContext
+                    .Setup(x => x.PackageValidationSets)
+                    .Returns(DbSetMockFactory.Create(
+                        new PackageValidationSet { PackageKey = _packageKey - 1 },
+                        new PackageValidationSet { PackageKey = _packageKey },
+                        new PackageValidationSet { PackageKey = _packageKey },
+                        new PackageValidationSet { PackageKey = _packageKey },
+                        new PackageValidationSet { PackageKey = _packageKey + 1 }));
+
+                var actual = await _target.GetValidationSetCountAsync(_packageKey);
+
+                Assert.Equal(3, actual);
+            }
+        }
+
+        public class OtherRecentValidationSetForPackageExists : Facts
+        {
+            private readonly DateTime _now;
+            private readonly TimeSpan _duration;
+            private readonly DateTime _before;
+            private readonly Guid _idA;
+            private readonly Guid _idB;
+
+            public OtherRecentValidationSetForPackageExists(ITestOutputHelper output) : base(output)
+            {
+                _now = DateTime.UtcNow;
+                _duration = TimeSpan.FromHours(1);
+                _before = _now - _duration.Add(TimeSpan.FromSeconds(1));
+                _idA = new Guid("925bbbd0-bb0e-4a74-9e4f-563645e14398");
+                _idB = new Guid("2dac1fd6-3d46-405a-9107-12ff230b0500");
+            }
+
+            [Fact]
+            public async Task ReturnsTrueIfOtherValidationSetIsInRange()
+            {
+                // Arrange
+                _entitiesContext
+                    .Setup(x => x.PackageValidationSets)
+                    .Returns(DbSetMockFactory.Create(
+                        new PackageValidationSet { PackageKey = _packageKey, Created = _now, ValidationTrackingId = _idB }));
+
+                // Act
+                var actual = await _target.OtherRecentValidationSetForPackageExists(
+                    _packageKey,
+                    _duration,
+                    _idA);
+
+                // Assert
+                Assert.True(actual, $"The validation set with validation ID {_idB} should have been detected.");
+            }
+
+            [Fact]
+            public async Task ReturnsFalseIfOnlyValidationSetInRangeIsSelf()
+            {
+                // Arrange
+                _entitiesContext
+                    .Setup(x => x.PackageValidationSets)
+                    .Returns(DbSetMockFactory.Create(
+                        new PackageValidationSet { PackageKey = _packageKey, Created = _now, ValidationTrackingId = _idA }));
+
+                // Act
+                var actual = await _target.OtherRecentValidationSetForPackageExists(
+                    _packageKey,
+                    _duration,
+                    _idA);
+
+                // Assert
+                Assert.False(actual, $"The current validation set with ID {_idA} should not have be considered.");
+            }
+
+            [Fact]
+            public async Task ReturnsFalseIfOtherValidationSetIsOutOfRange()
+            {
+                // Arrange
+                _entitiesContext
+                    .Setup(x => x.PackageValidationSets)
+                    .Returns(DbSetMockFactory.Create(
+                        new PackageValidationSet { PackageKey = _packageKey, Created = _before, ValidationTrackingId = _idB }));
+
+                // Act
+                var actual = await _target.OtherRecentValidationSetForPackageExists(
+                    _packageKey,
+                    _duration,
+                    _idA);
+
+                // Assert
+                Assert.False(actual, $"The validation set with ID {_idB} should not have be considered since it was out of the range.");
+            }
+        }
+
+        public abstract class TelemetryFacts : Facts
+        {
+            public TelemetryFacts(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            protected abstract Task ExecuteAsync(ValidationResult validationResult);
+
+            [Theory]
+            [InlineData(ValidationStatus.Failed, false)]
+            [InlineData(ValidationStatus.Succeeded, true)]
+            public async Task EmitsTelemetryWhenStatusChanges(ValidationStatus toStatus, bool isSuccess)
+            {
+                // Arrange
+                TimeSpan duration = default(TimeSpan);
+                _telemetryService
+                    .Setup(x => x.TrackValidatorDuration(It.IsAny<TimeSpan>(), It.IsAny<string>(), It.IsAny<bool>()))
+                    .Callback<TimeSpan, string, bool>((d, _, __) => duration = d);
+
+                var validationResult = new ValidationResult(
+                    toStatus,
+                    new List<IValidationIssue>
+                    {
+                        ValidationIssue.PackageIsSigned,
+                        new ClientSigningVerificationFailure("NU3000", "Issue A"),
+                        new ClientSigningVerificationFailure("NU3001", "Issue B"),
+                    });
+
+                // Act
+                var before = DateTime.UtcNow;
+                await ExecuteAsync(validationResult);
+                var after = DateTime.UtcNow;
+
+                // Assert
+                _telemetryService.Verify(
+                    x => x.TrackValidatorDuration(It.IsAny<TimeSpan>(), _validatorType, isSuccess),
+                    Times.Once);
+                Assert.InRange(duration, before - _packageValidation.Started.Value, after - _packageValidation.Started.Value);
+
+                _telemetryService.Verify(x => x.TrackValidationIssueCount(3, _validatorType, isSuccess), Times.Once);
+                _telemetryService.Verify(x => x.TrackValidationIssue(_validatorType, ValidationIssueCode.PackageIsSigned));
+                _telemetryService.Verify(x => x.TrackValidationIssue(_validatorType, ValidationIssueCode.ClientSigningVerificationFailure));
+                _telemetryService.Verify(x => x.TrackValidationIssue(_validatorType, ValidationIssueCode.ClientSigningVerificationFailure));
+                _telemetryService.Verify(x => x.TrackClientValidationIssue(_validatorType, "NU3000"), Times.Once);
+                _telemetryService.Verify(x => x.TrackClientValidationIssue(_validatorType, "NU3001"), Times.Once);
+            }
+
+            [Fact]
+            public async Task EmitsZeroDurationIfStartedPropertyIsNotSet()
+            {
+                // Arrange
+                _packageValidation.Started = null;
+
+                var validationResult = new ValidationResult(ValidationStatus.Failed);
+
+                // Act
+                await ExecuteAsync(validationResult);
+
+                // Assert
+                _telemetryService.Verify(
+                    x => x.TrackValidatorDuration(TimeSpan.Zero, _validatorType, false),
+                    Times.Once);
+            }
+
+            [Fact]
+            public async Task DoesNotEmitTelemtryForIncomplete()
+            {
+                // Arrange
+                _packageValidation.ValidationStatus = ValidationStatus.NotStarted;
+                var validationResult = new ValidationResult(ValidationStatus.Incomplete);
+
+                _telemetryService = new Mock<ITelemetryService>(MockBehavior.Strict);
+                InitializeTarget();
+
+                // Act
+                await ExecuteAsync(validationResult);
+
+                // Assert
+                _telemetryService.VerifyAll();
+            }
+        }
+
+        public abstract class Facts
+        {
+            protected int _packageKey;
+            protected string _validatorType;
+            protected PackageValidation _packageValidation;
+            protected Mock<IValidationEntitiesContext> _entitiesContext;
+            protected Mock<ITelemetryService> _telemetryService;
+            protected LoggerFactory _loggerFactory;
+            protected ValidationStorageService _target;
+
+            public Facts(ITestOutputHelper output)
+            {
+                _packageKey = 23;
+
+                _validatorType = "ExampleValidator";
+                _packageValidation = new PackageValidation
+                {
+                    Type = _validatorType,
+                    ValidationStatus = ValidationStatus.Incomplete,
+                    Started = new DateTime(2017, 1, 1, 8, 30, 0, DateTimeKind.Utc),
+                    PackageValidationIssues = new List<PackageValidationIssue>(),
+                    PackageValidationSet = new PackageValidationSet(),
+                };
+
+                _entitiesContext = new Mock<IValidationEntitiesContext>();
+                _entitiesContext
+                    .Setup(x => x.PackageValidationSets)
+                    .Returns(DbSetMockFactory.Create<PackageValidationSet>());
+
+                _telemetryService = new Mock<ITelemetryService>();
+
+                _loggerFactory = new LoggerFactory();
+                _loggerFactory.AddXunit(output);
+
+                InitializeTarget();
+            }
+
+            protected void InitializeTarget()
+            {
+                _target = new ValidationStorageService(
+                    _entitiesContext.Object,
+                    _telemetryService.Object,
+                    _loggerFactory.CreateLogger<ValidationStorageService>());
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
@@ -393,7 +393,7 @@ namespace NuGet.Services.Validation
                     ValidationId = ValidationId,
                     PackageKey = PackageKey,
                     ValidatorName = nameof(AValidator),
-                    State = ValidationStatus.NotStarted,
+                    State = status,
                 };
 
                 _validationContext.Mock();

--- a/tests/Validation.Common.Tests/project.json
+++ b/tests/Validation.Common.Tests/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+    "Moq": "4.7.145",
     "NuGet.Services.VirusScanning.Vcs": "3.2.0",
-    "moq": "4.5.23",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
+    "xunit": "2.3.1",
+    "xunit.runner.visualstudio": "2.3.1"
   },
   "frameworks": {
     "net46": {}

--- a/tests/Validation.Helper.Tests/project.json
+++ b/tests/Validation.Helper.Tests/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
-    "moq": "4.5.23",
-    "xunit": "2.1.0",
-    "xunit.runner.visualstudio": "2.1.0"
+    "Moq": "4.7.145",
+    "xunit": "2.3.1",
+    "xunit.runner.visualstudio": "2.3.1"
   },
   "frameworks": {
     "net452": {}

--- a/tests/Validation.PackageSigning.Core.Tests/Support/DbSetMockFactory.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/DbSetMockFactory.cs
@@ -6,11 +6,11 @@ using System.Data.Entity;
 using System.Linq;
 using Moq;
 
-namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+namespace Validation.PackageSigning.Core.Tests.Support
 {
-    internal static class DbSetMockFactory
+    public static class DbSetMockFactory
     {
-        internal static IDbSet<T> Create<T>(params T[] sourceList) where T : class
+        public static IDbSet<T> Create<T>(params T[] sourceList) where T : class
         {
             var list = new List<T>(sourceList);
 

--- a/tests/Validation.PackageSigning.Core.Tests/Support/TestDbAsyncEnumerable.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/TestDbAsyncEnumerable.cs
@@ -6,12 +6,12 @@ using System.Data.Entity.Infrastructure;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+namespace Validation.PackageSigning.Core.Tests.Support
 {
     /// <summary>
     /// Source: https://msdn.microsoft.com/en-us/data/dn314429
     /// </summary>
-    internal class TestDbAsyncEnumerable<T> : EnumerableQuery<T>, IDbAsyncEnumerable<T>, IQueryable<T>
+    public class TestDbAsyncEnumerable<T> : EnumerableQuery<T>, IDbAsyncEnumerable<T>, IQueryable<T>
     {
         public TestDbAsyncEnumerable(IEnumerable<T> enumerable) : base(enumerable)
         {

--- a/tests/Validation.PackageSigning.Core.Tests/Support/TestDbAsyncEnumerator.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/TestDbAsyncEnumerator.cs
@@ -6,12 +6,12 @@ using System.Data.Entity.Infrastructure;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+namespace Validation.PackageSigning.Core.Tests.Support
 {
     /// <summary>
     /// Source: https://msdn.microsoft.com/en-us/data/dn314429
     /// </summary>
-    internal class TestDbAsyncEnumerator<T> : IDbAsyncEnumerator<T>
+    public class TestDbAsyncEnumerator<T> : IDbAsyncEnumerator<T>
     {
         private readonly IEnumerator<T> _inner;
 

--- a/tests/Validation.PackageSigning.Core.Tests/Support/TestDbAsyncQueryProvider.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/TestDbAsyncQueryProvider.cs
@@ -7,12 +7,12 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+namespace Validation.PackageSigning.Core.Tests.Support
 {
     /// <summary>
     /// Source: https://msdn.microsoft.com/en-us/data/dn314429
     /// </summary>
-    internal class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
+    public class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
     {
         private readonly IQueryProvider _inner;
 

--- a/tests/Validation.PackageSigning.Core.Tests/Support/XunitLogger.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/XunitLogger.cs
@@ -7,47 +7,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Logging
 {
-    public static class XunitLoggerFactoryExtensions
-    {
-        public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output)
-        {
-            loggerFactory.AddProvider(new XunitLoggerProvider(output));
-            return loggerFactory;
-        }
-
-        public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output, LogLevel minLevel)
-        {
-            loggerFactory.AddProvider(new XunitLoggerProvider(output, minLevel));
-            return loggerFactory;
-        }
-    }
-
-    public class XunitLoggerProvider : ILoggerProvider
-    {
-        private readonly ITestOutputHelper _output;
-        private readonly LogLevel _minLevel;
-
-        public XunitLoggerProvider(ITestOutputHelper output)
-            : this(output, LogLevel.Trace)
-        {
-        }
-
-        public XunitLoggerProvider(ITestOutputHelper output, LogLevel minLevel)
-        {
-            _output = output;
-            _minLevel = minLevel;
-        }
-
-        public ILogger CreateLogger(string categoryName)
-        {
-            return new XunitLogger(_output, categoryName, _minLevel);
-        }
-
-        public void Dispose()
-        {
-        }
-    }
-
     public class XunitLogger : ILogger
     {
         private static readonly char[] NewLineChars = new[] { '\r', '\n' };

--- a/tests/Validation.PackageSigning.Core.Tests/Support/XunitLoggerFactoryExtensions.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/XunitLoggerFactoryExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging
+{
+    public static class XunitLoggerFactoryExtensions
+    {
+        public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output)
+        {
+            loggerFactory.AddProvider(new XunitLoggerProvider(output));
+            return loggerFactory;
+        }
+
+        public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output, LogLevel minLevel)
+        {
+            loggerFactory.AddProvider(new XunitLoggerProvider(output, minLevel));
+            return loggerFactory;
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.Core.Tests/Support/XunitLoggerProvider.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/XunitLoggerProvider.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging
+{
+    public class XunitLoggerProvider : ILoggerProvider
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly LogLevel _minLevel;
+
+        public XunitLoggerProvider(ITestOutputHelper output)
+            : this(output, LogLevel.Trace)
+        {
+        }
+
+        public XunitLoggerProvider(ITestOutputHelper output, LogLevel minLevel)
+        {
+            _output = output;
+            _minLevel = minLevel;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new XunitLogger(_output, categoryName, _minLevel);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -38,6 +38,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\CertificateStoreTests.cs" />
     <Compile Include="Storage\ValidatorStatusExtensionsFacts.cs" />
+    <Compile Include="Support\DbSetMockFactory.cs" />
+    <Compile Include="Support\TestDbAsyncEnumerable.cs" />
+    <Compile Include="Support\TestDbAsyncEnumerator.cs" />
+    <Compile Include="Support\TestDbAsyncQueryProvider.cs" />
+    <Compile Include="Support\XunitLogger.cs" />
+    <Compile Include="Support\XunitLoggerFactoryExtensions.cs" />
+    <Compile Include="Support\XunitLoggerProvider.cs" />
     <Compile Include="TestData\TestResources.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/PackageSigningStateServiceFacts.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Services.Validation;
+using Validation.PackageSigning.Core.Tests.Support;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignaturePartsExtractorFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignaturePartsExtractorFacts.cs
@@ -17,6 +17,7 @@ using NuGet.Packaging.Signing;
 using NuGet.Services.Validation;
 using Org.BouncyCastle.Cms;
 using Org.BouncyCastle.X509.Store;
+using Validation.PackageSigning.Core.Tests.Support;
 using Xunit;
 
 namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
@@ -42,16 +42,11 @@
     <Compile Include="SignaturePartsExtractorFacts.cs" />
     <Compile Include="SignatureValidatorFacts.cs" />
     <Compile Include="SignatureValidatorIntegrationTests.cs" />
-    <Compile Include="Support\TestDbAsyncEnumerable.cs" />
-    <Compile Include="Support\TestDbAsyncEnumerator.cs" />
-    <Compile Include="Support\TestDbAsyncQueryProvider.cs" />
-    <Compile Include="Support\DbSetMockFactory.cs" />
     <Compile Include="Support\EmbeddedResourceTestHandler.cs" />
     <Compile Include="PackageSigningStateServiceFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SignatureValidationMessageHandlerFacts.cs" />
     <Compile Include="Support\SubjectAndThumbprint.cs" />
-    <Compile Include="Support\XunitLoggerFactoryExtensions.cs" />
     <Compile Include="Support\TestResources.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -82,6 +77,10 @@
     <ProjectReference Include="..\..\src\Validation.PackageSigning.ExtractAndValidateSignature\Validation.PackageSigning.ExtractAndValidateSignature.csproj">
       <Project>{DD043977-6BCD-475A-BEE2-8C34309EC622}</Project>
       <Name>Validation.PackageSigning.ExtractAndValidateSignature</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Validation.PackageSigning.Core.Tests\Validation.PackageSigning.Core.Tests.csproj">
+      <Project>{b4b7564a-965b-447b-927f-6749e2c08880}</Project>
+      <Name>Validation.PackageSigning.Core.Tests</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.Helpers/Validation.PackageSigning.Helpers.csproj
+++ b/tests/Validation.PackageSigning.Helpers/Validation.PackageSigning.Helpers.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="moq">
-      <Version>4.5.23</Version>
+      <Version>4.7.145</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationMessageHandlerFacts.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationMessageHandlerFacts.cs
@@ -28,7 +28,7 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
                 // Arrange
                 _certificateValidationService
                     .Setup(s => s.FindCertificateValidationAsync(It.IsAny<CertificateValidationMessage>()))
-                    .ReturnsAsync(null);
+                    .ReturnsAsync((EndCertificateValidation)null);
 
                 // Act & Assert
                 Assert.False(await _target.HandleAsync(_message));

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
@@ -65,16 +65,16 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="moq">
-      <Version>4.5.23</Version>
+      <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.1.0</Version>
+      <Version>2.3.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.1.0</Version>
+      <Version>2.3.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Also, use package key instead of ID/version and add unit tests for `OtherRecentValidationSetForPackageExists`. This is important in the case of a hard-delete then recreate (the new content should be revalidated).

For now, I am not emitting the actual telemetry. A follow-up PR will be for the actual integration.

Progress on https://github.com/NuGet/NuGetGallery/issues/4652.