### PR TITLE
Fix support requests notifications job sql query

### DIFF
--- a/src/NuGet.SupportRequests.Notifications/SqlQuery.cs
+++ b/src/NuGet.SupportRequests.Notifications/SqlQuery.cs
@@ -9,7 +9,7 @@ namespace NuGet.SupportRequests.Notifications
         {
             // If I.[CreatedBy] IS NULL, then the user data was deleted and the support request issue should be ignored.
             var query =
-                "SELECT I.[CreatedBy], I.[CreatedDate], I.[PackageId], I.[PackageVersion], I.[OwnerEmail], I.[Reason], I.[PackageRegistrationKey], ISNULL(A.[PagerDutyUsername], \'Unassigned\') AS \'AdminPagerDutyUsername\', ISNULL(A.[GalleryUsername], \'Unassigned\') AS \'AdminGalleryUsername\', I.[IssueStatusId] AS \'IssueStatus\' FROM [dbo].[Issues] AS I (NOLOCK) LEFT OUTER JOIN [dbo].[Admins] AS A (NOLOCK) ON I.[AssignedToId] = A.[Key] WHERE I.[IssueStatusId] <> 3 AND I.[CreatedBy] IS NOT NULL";
+                "SELECT I.[CreatedBy], I.[CreatedDate], I.[PackageId], I.[PackageVersion], I.[OwnerEmail], I.[Reason], I.[PackageRegistrationKey], ISNULL(A.[PagerDutyUsername], \'Unassigned\') AS \'AdminPagerDutyUsername\', ISNULL(A.[GalleryUsername], \'Unassigned\') AS \'AdminGalleryUsername\', I.[IssueStatusId] AS \'IssueStatus\' FROM [dbo].[Issues] AS I (NOLOCK) LEFT OUTER JOIN [dbo].[Admins] AS A (NOLOCK) ON I.[AssignedToId] = A.[Key] WHERE I.[IssueStatusId] <> 3 AND I.[CreatedBy] IS NOT NULL ";
 
             if (!string.IsNullOrEmpty(onCallPagerDutyUserName))
             {


### PR DESCRIPTION
Missed an important trailing whitespace character in the sql query that could break the query when concatenated.

Targeting `master` branch to be able to hotfix the job in a fresh deployment asap.