### PR TITLE
Add integration test for untrusted and unavailable revocation TSA certificates

### DIFF
--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -106,7 +106,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.7.0-preview1-4883</Version>
+      <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.12.0</Version>

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/ExtensionMethods.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/ExtensionMethods.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Test.Utility.Signing;
+
+namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests.Support
+{
+    public static class ExtensionMethods
+    {
+        public static DisposableList RegisterResponders(
+            this ISigningTestServer testServer,
+            CertificateAuthority ca,
+            bool addCa = true,
+            bool addOcsp = true)
+        {
+            var responders = new DisposableList();
+            var currentCa = ca;
+
+            while (currentCa != null)
+            {
+                if (addCa)
+                {
+                    responders.Add(testServer.RegisterResponder(currentCa));
+                }
+
+                if (addOcsp)
+                {
+                    responders.Add(testServer.RegisterResponder(currentCa.OcspResponder));
+                }
+
+                currentCa = currentCa.Parent;
+            }
+
+            return responders;
+        }
+
+        public static DisposableList RegisterResponders(
+            this ISigningTestServer testServer,
+            TimestampService timestampService,
+            bool addCa = true,
+            bool addOcsp = true,
+            bool addTimestamper = true)
+        {
+            var responders = testServer.RegisterResponders(
+                timestampService.CertificateAuthority,
+                addCa,
+                addOcsp);
+
+            if (addTimestamper)
+            {
+                responders.Add(testServer.RegisterResponder(timestampService));
+            }
+
+            return responders;
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestResources.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/TestResources.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Packaging.Signing;
 
 namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
@@ -14,16 +9,6 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
     public static class TestResources
     {
         private const string ResourceNamespace = "Validation.PackageSigning.ExtractAndValidateSignature.Tests.TestData";
-        private static readonly Lazy<Task<byte[]>> _lazyTestRootCertificate = new Lazy<Task<byte[]>>(async () =>
-        {
-            using (var package = SignedPackageLeaf1Reader)
-            {
-                var signature = await package.GetSignatureAsync(CancellationToken.None);
-                var certificates = SignatureUtility.GetPrimarySignatureCertificates(signature);
-                return certificates.Last().RawData;
-            }
-        });
-
         public const string SignedPackageLeaf1 = ResourceNamespace + ".TestSigned.leaf-1.1.0.0.nupkg";
         public const string SignedPackageLeaf2 = ResourceNamespace + ".TestSigned.leaf-2.2.0.0.nupkg";
         public const string UnsignedPackage = ResourceNamespace + ".TestUnsigned.1.0.0.nupkg";
@@ -51,12 +36,6 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 
         public static SignedPackageArchive SignedPackageLeaf1Reader => LoadPackage(SignedPackageLeaf1);
         public static SignedPackageArchive SignedPackageLeaf2Reader => LoadPackage(SignedPackageLeaf2);
-
-        public static async Task<X509Certificate2> GetTestRootCertificateAsync()
-        {
-            var bytes = await _lazyTestRootCertificate.Value;
-            return new X509Certificate2((byte[])bytes.Clone());
-        }
 
         /// <summary>
         /// Buffer the resource stream into memory so the caller doesn't have to dispose.

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
@@ -35,6 +35,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Support\ExtensionMethods.cs" />
     <Compile Include="Support\RecordingLogger.cs" />
     <Compile Include="Support\CertificateIntegrationTestCollection.cs" />
     <Compile Include="Support\CertificateIntegrationTestFixture.cs" />
@@ -60,7 +61,7 @@
       <Version>1.8.1.3</Version>
     </PackageReference>
     <PackageReference Include="Test.Utility">
-      <Version>4.7.0-preview1-4883</Version>
+      <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.3.1</Version>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/878

Also, switch to a signing certificate with a full chain instead of a trusted root which also does the signing (which is not a good simulation of what customers will be doing).