### PR TITLE
[Package Signing] Add logic on how to update signatures after certificate status changes

### DIFF
--- a/src/Validation.PackageSigning.ValidateCertificate/App.config
+++ b/src/Validation.PackageSigning.ValidateCertificate/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/src/Validation.PackageSigning.ValidateCertificate/CertificateVerificationResult.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/CertificateVerificationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Security.Cryptography.X509Certificates;
 using NuGet.Services.Validation;
 
 namespace Validation.PackageSigning.ValidateCertificate
@@ -13,39 +14,26 @@ namespace Validation.PackageSigning.ValidateCertificate
     public class CertificateVerificationResult
     {
         /// <summary>
-        /// Create a new non-revoked certificate verification result.
+        /// The status of the end <see cref="X509Certificate2"/>.
         /// </summary>
-        /// <param name="status">The status of the <see cref="X509Certificate2"/></param>
-        /// <param name="revocationTime">The time of </param>
-        public CertificateVerificationResult(EndCertificateStatus status)
-        {
-            if (status == EndCertificateStatus.Revoked)
-            {
-                throw new ArgumentException("Provide a revocation date for a revoked certificate result.", nameof(status));
-            }
-
-            Status = status;
-        }
+        public EndCertificateStatus Status { get; set; }
 
         /// <summary>
-        /// Create a new revoked certificate verification result.
+        /// The flattened flags for the <see cref="X509Certificate2"/> and its entire chain.
         /// </summary>
-        /// <param name="revocationTime">The start of the certificate's invalidity period.</param>
-        public CertificateVerificationResult(DateTime revocationTime)
-        {
-            Status = EndCertificateStatus.Revoked;
-            RevocationTime = revocationTime;
-        }
+        public X509ChainStatusFlags StatusFlags { get; set; }
 
         /// <summary>
-        /// The status of the <see cref="X509Certificate2"/>.
+        /// The time that the end <see cref="X509Certificate2"/>'s status was last updated, according to the
+        /// Certificate Authority. If <see cref="Status"/> is <see cref="EndCertificateStatus.Revoked"/>
+        /// or <see cref="EndCertificateStatus.Unknown"/>, this will have a value of <c>null</c>.
         /// </summary>
-        public EndCertificateStatus Status { get; }
+        public DateTime? StatusUpdateTime { get; set; }
 
         /// <summary>
-        /// The time at which the <see cref="X509Certificate2"/> was revoked. Null unless
-        /// <see cref="Status"/> is <see cref="CertificateStatus.Revoked"/>.
+        /// The time at which the end <see cref="X509Certificate2"/> was revoked. If <see cref="Status"/>
+        /// is not <see cref="CertificateStatus.Revoked"/>, this will have a value of <c>null</c>.
         /// </summary>
-        public DateTime? RevocationTime { get; }
+        public DateTime? RevocationTime { get; set; }
     }
 }

--- a/src/Validation.PackageSigning.ValidateCertificate/ITelemetryService.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/ITelemetryService.cs
@@ -8,7 +8,18 @@ namespace Validation.PackageSigning.ValidateCertificate
     public interface ITelemetryService
     {
         /// <summary>
+        /// The event that tracks when a signature may be invalid and should be manually inspected.
+        /// Unlike <see cref="TrackPackageSignatureShouldBeInvalidatedEvent(PackageSignature)"/>, this
+        /// package MAY be found to still be valid!
+        /// </summary>
+        /// <param name="signature">The signature that should be invalidated.</param>
+        /// <returns>A task that returns when the event has been recorded.</returns>
+        void TrackPackageSignatureMayBeInvalidatedEvent(PackageSignature signature);
+
+        /// <summary>
         /// The event that tracks when a signature should be manually invalidated.
+        /// Unlike <see cref="TrackPackageSignatureMayBeInvalidatedEvent(PackageSignature)"/>, this
+        /// package SHOULD be invalidated.
         /// </summary>
         /// <param name="signature">The signature that should be invalidated.</param>
         /// <returns>A task that returns when the event has been recorded.</returns>

--- a/src/Validation.PackageSigning.ValidateCertificate/SignatureDeciderFactory.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/SignatureDeciderFactory.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Services.Validation;
+
+namespace Validation.PackageSigning.ValidateCertificate
+{
+    /// <summary>
+    /// Deciders are created from a given <see cref="CertificateVerificationResult"/> to decide
+    /// how each of the certificate's dependent <see cref="PackageSignature"/>s should be affected.
+    /// </summary>
+    /// <param name="signature">A signature that depends on the <see cref="EndCertificate"/> that was verified.</param>
+    /// <returns>How the signature should be handled.</returns>
+    public delegate SignatureDecision SignatureDecider(PackageSignature signature);
+
+    /// <summary>
+    /// Creates functions that decide how <see cref="PackageSignature"/>s should be affected by
+    /// <see cref="EndCertificate.Status"/> changes.
+    /// </summary>
+    public class SignatureDeciderFactory
+    {
+        /// <summary>
+        /// Create a function to decide how signatures should be affected by a revoked certificate.
+        /// </summary>
+        /// <param name="certificate">The certificate that was revoked.</param>
+        /// <param name="result">The verification result that describes when the certificate was revoked.</param>
+        /// <returns>The function that describes how dependent signatures should be affected by the certificate status change.</returns>
+        public SignatureDecider MakeDeciderForRevokedCertificate(EndCertificate certificate, CertificateVerificationResult result)
+        {
+            switch (certificate.Use)
+            {
+                case EndCertificateUse.Timestamping:
+                    return RejectSignaturesAtIngestionOtherwiseWarnDecider;
+
+                case EndCertificateUse.CodeSigning:
+                    return MakeDeciderForRevokedCodeSigningCertificate(result.RevocationTime);
+
+                default:
+                    throw new InvalidOperationException($"Revoked certificate has unknown use: {certificate.Use}");
+            }
+        }
+
+        /// <summary>
+        /// Create a function to decide how signatures should be affected by an invalidated certificate.
+        /// </summary>
+        /// <param name="certificate">The certificate that was invalidated.</param>
+        /// <param name="result">The verification result that describes why the certificate was invalidated.</param>
+        /// <returns>The function that describes how dependent signatures should be affected by the certificate status change.</returns>
+        public SignatureDecider MakeDeciderForInvalidatedCertificate(EndCertificate certificate, CertificateVerificationResult result)
+        {
+            if (result.Status != EndCertificateStatus.Invalid)
+            {
+                throw new ArgumentException($"Result must have a status of {nameof(EndCertificateStatus.Invalid)}", nameof(result));
+            }
+
+            if (result.StatusFlags == X509ChainStatusFlags.NoError ||
+                (result.StatusFlags & (X509ChainStatusFlags.OfflineRevocation | X509ChainStatusFlags.RevocationStatusUnknown)) != 0)
+            {
+                throw new ArgumentException($"Invalid flags on invalid verification result: {result.StatusFlags}!", nameof(result));
+            }
+
+            // If a certificate used for the primary signature is revoked, all dependent signatures should be invalidated.
+            // Note that in this case the revoked certificate is a parent of the end certificate - NOT the end certificate.
+            if (certificate.Use == EndCertificateUse.CodeSigning && (result.StatusFlags & X509ChainStatusFlags.Revoked) != 0)
+            {
+                return RejectAllSignaturesDecider;
+            }
+
+            // NotTimeValid and HasWeakSignature fail packages only at ingestion.
+            else if (ResultHasOnlyFlags(result, X509ChainStatusFlags.NotTimeValid | X509ChainStatusFlags.HasWeakSignature))
+            {
+                return RejectSignaturesAtIngestionDecider;
+            }
+
+            // NotTimeNested does not affect signatures and should be ignored.
+            else if (ResultHasOnlyFlags(result, X509ChainStatusFlags.NotTimeNested))
+            {
+                return NoActionDecider;
+            }
+
+            // In all other cases, reject signatures at ingestion and warn on all other signatures.
+            else
+            {
+                return RejectSignaturesAtIngestionOtherwiseWarnDecider;
+            }
+        }
+
+        private SignatureDecider MakeDeciderForRevokedCodeSigningCertificate(DateTime? revocationTime)
+        {
+            // If the time the certificate was revoked is unknown, assume the worst and reject all dependent signatures.
+            if (!revocationTime.HasValue)
+            {
+                return RejectAllSignaturesDecider;
+            }
+
+            return (PackageSignature signature) =>
+            {
+                // The revoked code signing certificate invalidates signatures with no valid timestamps.
+                // TODO: This should skip trusted timestamps with invalid/revoked certs. This requires:
+                //          * Getting trusted timestamps' certificates and their statuses.
+                if (!signature.TrustedTimestamps.Any())
+                {
+                    return SignatureDecision.Reject;
+                }
+
+                // The revoked code signing certificate invalidates signatures with at least one trusted
+                // timestamp before the revocation date.
+                if (signature.TrustedTimestamps.Any(t => revocationTime.Value <= t.Value))
+                {
+                    return SignatureDecision.Reject;
+                }
+
+                // This signature lives to see another day.
+                return SignatureDecision.Ignore;
+            };
+        }
+
+        private SignatureDecision NoActionDecider(PackageSignature signature) => SignatureDecision.Ignore;
+
+        private SignatureDecision RejectAllSignaturesDecider(PackageSignature signature) => SignatureDecision.Reject;
+
+        private SignatureDecision RejectSignaturesAtIngestionDecider(PackageSignature signature)
+        {
+            return (signature.Status == PackageSignatureStatus.Unknown)
+                        ? SignatureDecision.Reject
+                        : SignatureDecision.Ignore;
+        }
+
+        private SignatureDecision RejectSignaturesAtIngestionOtherwiseWarnDecider(PackageSignature signature)
+        {
+            return (signature.Status == PackageSignatureStatus.Unknown)
+                    ? SignatureDecision.Reject
+                    : SignatureDecision.Warn;
+        }
+
+        private bool ResultHasOnlyFlags(CertificateVerificationResult result, X509ChainStatusFlags flags)
+        {
+            if (result.StatusFlags == X509ChainStatusFlags.NoError)
+            {
+                return flags == X509ChainStatusFlags.NoError;
+            }
+
+            return (result.StatusFlags & flags) == result.StatusFlags;
+        }
+    }
+}

--- a/src/Validation.PackageSigning.ValidateCertificate/SignatureDecision.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/SignatureDecision.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Validation;
+
+namespace Validation.PackageSigning.ValidateCertificate
+{
+    /// <summary>
+    /// The ways an <see cref="EndCertificate"/>'s dependent <see cref="PackageSignature"/> may be affected by
+    /// a change in the certificate's status.
+    /// </summary>
+    public enum SignatureDecision
+    {
+        /// <summary>
+        /// The <see cref="PackageSignature"/> is unaffected by the status change of the <see cref="EndCertificate"/>.
+        /// </summary>
+        Ignore,
+
+        /// <summary>
+        /// The <see cref="PackageSignature"/> may be affected by the status change of the <see cref="EndCertificate"/>.
+        /// The NuGet client may no longer accept this signature, however, the package does not necessarily need to be
+        /// deleted from the server. This decision will only happen for packages whose status is currently
+        /// <see cref="PackageSignatureStatus.Valid"/>.
+        /// </summary>
+        Warn,
+
+        /// <summary>
+        /// The <see cref="PackageSignature"/> is affected by the status change of the <see cref="EndCertificate"/>.
+        /// The package should be deleted by an administrator.
+        /// </summary>
+        Reject,
+    }
+}

--- a/src/Validation.PackageSigning.ValidateCertificate/TelemetryService.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/TelemetryService.cs
@@ -8,6 +8,12 @@ namespace Validation.PackageSigning.ValidateCertificate
 {
     public class TelemetryService : ITelemetryService
     {
+        public void TrackPackageSignatureMayBeInvalidatedEvent(PackageSignature signature)
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
         public void TrackPackageSignatureShouldBeInvalidatedEvent(PackageSignature signature)
         {
             // TODO

--- a/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
+++ b/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Validation.PackageSigning.ValidateCertificate</RootNamespace>
     <AssemblyName>Validation.PackageSigning.ValidateCertificate</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -42,6 +42,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SignatureDeciderFactory.cs" />
+    <Compile Include="SignatureDecision.cs" />
     <Compile Include="TelemetryService.cs" />
     <Compile Include="CertificateValidationMessageHandler.cs" />
     <Compile Include="CertificateValidationService.cs" />

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationMessageHandlerFacts.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationMessageHandlerFacts.cs
@@ -105,11 +105,11 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
 
             public static IEnumerable<object[]> MessageIsConsumedIfValidationEndsGracefullyData()
             {
-                yield return new[] { new CertificateVerificationResult(EndCertificateStatus.Good) };
+                yield return new[] { new CertificateVerificationResult() { Status = EndCertificateStatus.Good } };
 
-                yield return new[] { new CertificateVerificationResult(EndCertificateStatus.Invalid) };
+                yield return new[] { new CertificateVerificationResult() { Status = EndCertificateStatus.Invalid } };
 
-                yield return new[] { new CertificateVerificationResult(revocationTime: DateTime.UtcNow) };
+                yield return new[] { new CertificateVerificationResult() { Status = EndCertificateStatus.Revoked, RevocationTime = DateTime.UtcNow } };
             }
 
             [Theory]
@@ -182,7 +182,7 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
 
                 _certificateValidationService
                     .Setup(s => s.VerifyAsync(It.IsAny<X509Certificate2>()))
-                    .ReturnsAsync(new CertificateVerificationResult(EndCertificateStatus.Unknown));
+                    .ReturnsAsync(new CertificateVerificationResult() { Status = EndCertificateStatus.Unknown });
 
                 _certificateValidationService
                     .Setup(

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/SignatureDeciderFactoryFacts.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/SignatureDeciderFactoryFacts.cs
@@ -1,0 +1,326 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using NuGet.Services.Validation;
+using Xunit;
+
+namespace Validation.PackageSigning.ValidateCertificate.Tests
+{
+    public class SignatureDeciderFactoryFacts
+    {
+        public class TheMakeDeciderForRevokedCertificateMethod : FactsBase
+        {
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public void RevokedTimestampingCertificateInvalidatesSignatures(bool nullRevocationTime)
+            {
+                // Arrange - only signatures at ingestion should be rejected, all other signatures should
+                // raise a warning. The revocation time should not matter.
+                var revocationTime = nullRevocationTime ? (DateTime?)null : DateTime.Now;
+                var certificate = new EndCertificate { Use = EndCertificateUse.Timestamping };
+                var result = new CertificateVerificationResult { RevocationTime = revocationTime };
+
+                var signatureAtIngestion = new PackageSignature { Status = PackageSignatureStatus.Unknown };
+                var signatureAtGracePeriod = new PackageSignature { Status = PackageSignatureStatus.InGracePeriod };
+                var signatureAfterGracePeriod = new PackageSignature { Status = PackageSignatureStatus.Valid };
+
+                // Act & Assert
+                var decider = _target.MakeDeciderForRevokedCertificate(certificate, result);
+
+                Assert.Equal(SignatureDecision.Reject, decider(signatureAtIngestion));
+                Assert.Equal(SignatureDecision.Warn, decider(signatureAtGracePeriod));
+                Assert.Equal(SignatureDecision.Warn, decider(signatureAfterGracePeriod));
+            }
+
+            [Fact]
+            public void RevokedCodeSigningCertificateWithoutRevocationDateInvalidatesAllSignatures()
+            {
+                var certificate = new EndCertificate { Use = EndCertificateUse.CodeSigning };
+
+                var result = new CertificateVerificationResult
+                {
+                    Status = EndCertificateStatus.Revoked,
+                    RevocationTime = null
+                };
+
+                var signatureAtIngestion = new PackageSignature { Status = PackageSignatureStatus.Unknown };
+                var signatureAtGracePeriod = new PackageSignature { Status = PackageSignatureStatus.InGracePeriod };
+                var signatureAfterGracePeriod = new PackageSignature { Status = PackageSignatureStatus.Valid };
+
+                // Act & Assert
+                var decider = _target.MakeDeciderForRevokedCertificate(certificate, result);
+
+                Assert.Equal(SignatureDecision.Reject, decider(signatureAtIngestion));
+                Assert.Equal(SignatureDecision.Reject, decider(signatureAtGracePeriod));
+                Assert.Equal(SignatureDecision.Reject, decider(signatureAfterGracePeriod));
+            }
+
+            [Theory]
+            [MemberData(nameof(RevokedCodeSigningCertificateWithRevocationDateInvalidatesSignaturesData))]
+            public void RevokedCodeSigningCertificateWithRevocationDateInvalidatesSignatures(
+                TimeSpan signatureTimeDeltaToRevocationTime,
+                SignatureDecision ingestionDecision,
+                SignatureDecision gracePeriodDecision,
+                SignatureDecision afterGracePeriodDecision)
+            {
+                // Arrange - only signatures that were created after the revocation date should
+                // be rejected.
+                var revocationTime = DateTime.UtcNow;
+                var certificate = new EndCertificate { Use = EndCertificateUse.CodeSigning };
+                var timestamp = new TrustedTimestamp { Value = revocationTime + signatureTimeDeltaToRevocationTime };
+
+                var result = new CertificateVerificationResult
+                {
+                    Status = EndCertificateStatus.Revoked,
+                    RevocationTime = revocationTime
+                };
+
+                var signatureAtIngestion = new PackageSignature { Status = PackageSignatureStatus.Unknown };
+                var signatureAtGracePeriod = new PackageSignature { Status = PackageSignatureStatus.InGracePeriod };
+                var signatureAfterGracePeriod = new PackageSignature { Status = PackageSignatureStatus.Valid };
+
+                signatureAtIngestion.TrustedTimestamps = new[] { timestamp };
+                signatureAtGracePeriod.TrustedTimestamps = new[] { timestamp };
+                signatureAfterGracePeriod.TrustedTimestamps = new[] { timestamp };
+
+                // Act & Assert
+                var decider = _target.MakeDeciderForRevokedCertificate(certificate, result);
+
+                Assert.Equal(ingestionDecision, decider(signatureAtIngestion));
+                Assert.Equal(gracePeriodDecision, decider(signatureAtGracePeriod));
+                Assert.Equal(afterGracePeriodDecision, decider(signatureAfterGracePeriod));
+            }
+
+            public static IEnumerable<object[]> RevokedCodeSigningCertificateWithRevocationDateInvalidatesSignaturesData()
+            {
+                yield return new object[]
+                {
+                    TimeSpan.FromDays(-1), SignatureDecision.Ignore, SignatureDecision.Ignore, SignatureDecision.Ignore
+                };
+
+                yield return new object[]
+                {
+                    TimeSpan.FromDays(0), SignatureDecision.Reject, SignatureDecision.Reject, SignatureDecision.Reject
+                };
+
+                yield return new object[]
+                {
+                    TimeSpan.FromDays(1), SignatureDecision.Reject, SignatureDecision.Reject, SignatureDecision.Reject
+                };
+            }
+        }
+
+        public class MakeDeciderForInvalidatedCertificate : FactsBase
+        {
+            [Theory]
+            [InlineData(X509ChainStatusFlags.NoError)]
+            [InlineData(X509ChainStatusFlags.OfflineRevocation)]
+            [InlineData(X509ChainStatusFlags.RevocationStatusUnknown)]
+            public void ThrowsIfStatusIsOfflineOrUnknown(X509ChainStatusFlags flags)
+            {
+                // Arrange
+                var certificate = new EndCertificate();
+
+                var result = new CertificateVerificationResult
+                {
+                    Status = EndCertificateStatus.Invalid,
+                    StatusFlags = flags
+                };
+
+                // Act & Assert
+                Assert.Throws<ArgumentException>(() => _target.MakeDeciderForInvalidatedCertificate(certificate, result));
+            }
+
+            [Theory]
+            [MemberData(nameof(InvalidCertificateInvalidatesSignaturesData))]
+            public void InvalidCertificateInvalidatesSignatures(
+                EndCertificateUse use,
+                X509ChainStatusFlags flags,
+                SignatureDecision ingestionDecision,
+                SignatureDecision gracePeriodDecision,
+                SignatureDecision afterGracePeriodDecision)
+            {
+                // Arrange
+                var certificate = new EndCertificate { Use = use };
+
+                var result = new CertificateVerificationResult
+                {
+                    Status = EndCertificateStatus.Invalid,
+                    StatusFlags = flags,
+                };
+
+                var signatureAtIngestion = new PackageSignature { Status = PackageSignatureStatus.Unknown };
+                var signatureAtGracePeriod = new PackageSignature { Status = PackageSignatureStatus.InGracePeriod };
+                var signatureAfterGracePeriod = new PackageSignature { Status = PackageSignatureStatus.Valid };
+
+                // Act & Assert
+                var decider = _target.MakeDeciderForInvalidatedCertificate(certificate, result);
+
+                Assert.Equal(ingestionDecision, decider(signatureAtIngestion));
+                Assert.Equal(gracePeriodDecision, decider(signatureAtGracePeriod));
+                Assert.Equal(afterGracePeriodDecision, decider(signatureAfterGracePeriod));
+            }
+
+            public static IEnumerable<object[]> InvalidCertificateInvalidatesSignaturesData()
+            {
+                // NotTimeValid and HasWeakSignature only reject packages at ingestion (as these are time dependent).
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.CodeSigning,
+                    /* flags: */ X509ChainStatusFlags.NotTimeValid | X509ChainStatusFlags.HasWeakSignature,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Ignore,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Ignore,
+                };
+
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.Timestamping,
+                    /* flags: */ X509ChainStatusFlags.NotTimeValid | X509ChainStatusFlags.HasWeakSignature,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Ignore,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Ignore,
+                };
+
+                // NotTimeNested certificates do not affect dependent signatures.
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.CodeSigning,
+                    /* flags: */ X509ChainStatusFlags.NotTimeNested,
+                    /* ingestionDecision: */ SignatureDecision.Ignore,
+                    /* gracePeriodDecision: */ SignatureDecision.Ignore,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Ignore,
+                };
+
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.Timestamping,
+                    /* flags: */ X509ChainStatusFlags.NotTimeNested,
+                    /* ingestionDecision: */ SignatureDecision.Ignore,
+                    /* gracePeriodDecision: */ SignatureDecision.Ignore,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Ignore,
+                };
+
+                // Revoked codesigning certificates invalidate all dependent signatures.
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.CodeSigning,
+                    /* flags: */ X509ChainStatusFlags.Revoked,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Reject,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Reject,
+                };
+
+                // Revoked timestamping certificates reject signatures at injection, otherwise warn.
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.Timestamping,
+                    /* flags: */ X509ChainStatusFlags.Revoked,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Warn,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Warn,
+                };
+
+                // Ensure the following flags are rejected at ingestion but otherwise just warned.
+                foreach (var flags in FlagsThatAreRejectedAtIngestionOtherwiseWarn)
+                {
+                    yield return new object[]
+                    {
+                        /* use: */ EndCertificateUse.CodeSigning,
+                        /* flags: */ flags,
+                        /* ingestionDecision: */ SignatureDecision.Reject,
+                        /* gracePeriodDecision: */ SignatureDecision.Warn,
+                        /* afterGracePeriodDecision: */ SignatureDecision.Warn,
+                    };
+
+                    yield return new object[]
+                    {
+                        /* use: */ EndCertificateUse.Timestamping,
+                        /* flags: */ flags,
+                        /* ingestionDecision: */ SignatureDecision.Reject,
+                        /* gracePeriodDecision: */ SignatureDecision.Warn,
+                        /* afterGracePeriodDecision: */ SignatureDecision.Warn,
+                    };
+                }
+
+                // Ensure the most "drastic" case is always picked from the previous cases.
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.CodeSigning,
+                    /* flags: */ X509ChainStatusFlags.NotTimeValid | X509ChainStatusFlags.HasWeakSignature | X509ChainStatusFlags.Revoked,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Reject,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Reject,
+                };
+
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.CodeSigning,
+                    /* flags: */ X509ChainStatusFlags.NotTimeNested | X509ChainStatusFlags.Revoked,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Reject,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Reject,
+                };
+
+                var allFlagsThatAreRejectedAtIngestionOtherwiseWarn = FlagsThatAreRejectedAtIngestionOtherwiseWarn
+                                                                        .Aggregate(X509ChainStatusFlags.NoError, (result, next) => result |= next);
+
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.CodeSigning,
+                    /* flags: */ allFlagsThatAreRejectedAtIngestionOtherwiseWarn,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Warn,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Warn,
+                };
+
+                yield return new object[]
+                {
+                    /* use: */ EndCertificateUse.CodeSigning,
+                    /* flags: */ allFlagsThatAreRejectedAtIngestionOtherwiseWarn | X509ChainStatusFlags.Revoked,
+                    /* ingestionDecision: */ SignatureDecision.Reject,
+                    /* gracePeriodDecision: */ SignatureDecision.Reject,
+                    /* afterGracePeriodDecision: */ SignatureDecision.Reject,
+                };
+            }
+        }
+
+        private static X509ChainStatusFlags[] FlagsThatAreRejectedAtIngestionOtherwiseWarn = new[]
+        {
+            X509ChainStatusFlags.NotSignatureValid,
+            X509ChainStatusFlags.NotValidForUsage,
+            X509ChainStatusFlags.UntrustedRoot,
+            X509ChainStatusFlags.Cyclic,
+            X509ChainStatusFlags.InvalidExtension,
+            X509ChainStatusFlags.InvalidPolicyConstraints,
+            X509ChainStatusFlags.InvalidBasicConstraints,
+            X509ChainStatusFlags.InvalidNameConstraints,
+            X509ChainStatusFlags.HasNotSupportedNameConstraint,
+            X509ChainStatusFlags.HasNotDefinedNameConstraint,
+            X509ChainStatusFlags.HasNotPermittedNameConstraint,
+            X509ChainStatusFlags.HasExcludedNameConstraint,
+            X509ChainStatusFlags.PartialChain,
+            X509ChainStatusFlags.CtlNotTimeValid,
+            X509ChainStatusFlags.CtlNotSignatureValid,
+            X509ChainStatusFlags.CtlNotValidForUsage,
+            X509ChainStatusFlags.NoIssuanceChainPolicy,
+            X509ChainStatusFlags.ExplicitDistrust,
+            X509ChainStatusFlags.HasNotSupportedCriticalExtension,
+        };
+    }
+
+    public class FactsBase
+    {
+        protected readonly SignatureDeciderFactory _target;
+
+        public FactsBase()
+        {
+            _target = new SignatureDeciderFactory();
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Validation.PackageSigning.ValidateCertificate.Tests</RootNamespace>
     <AssemblyName>Validation.PackageSigning.ValidateCertificate.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="CertificateValidationMessageHandlerFacts.cs" />
     <Compile Include="CertificateValidationServiceFacts.cs" />
+    <Compile Include="SignatureDeciderFactoryFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This adds the logic on how to handle online certificate verification results. For more information, see the ["Package Signing Scenario Matrix" document](https://microsoft.sharepoint.com/:x:/t/NuGet/Eb5bYKB5_JhPtb5CFzm_NzsBxC1G_sYspGo78IFAEKwrKA?e=8hx7p8).

This will be used by https://github.com/NuGet/NuGet.Jobs/pull/309 

