### PR TITLE
[Package Signing] Add Trusted Timestamp Status

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -133,25 +133,25 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>4.3.0</Version>

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -133,25 +133,25 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>4.3.0</Version>

--- a/src/Validation.Callback.Vcs/Web.config
+++ b/src/Validation.Callback.Vcs/Web.config
@@ -70,7 +70,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.12.0.0" newVersion="2.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.13.0.0" newVersion="2.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/src/Validation.Common/Validation.Common.csproj
+++ b/src/Validation.Common/Validation.Common.csproj
@@ -106,10 +106,10 @@
       <HintPath>..\..\packages\NuGet.ApplicationInsights.Owin.4.1.0\lib\net452\NuGet.ApplicationInsights.Owin.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.KeyVault, Version=2.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.13.0-loshar-tmstp-status-22169\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.13.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.Logging, Version=2.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Logging.2.13.0-loshar-tmstp-status-22169\lib\net452\NuGet.Services.Logging.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Logging.2.13.0\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.VirusScanning.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.VirusScanning.Vcs.3.2.0\lib\net452\NuGet.Services.VirusScanning.Core.dll</HintPath>

--- a/src/Validation.Common/Validation.Common.csproj
+++ b/src/Validation.Common/Validation.Common.csproj
@@ -105,11 +105,11 @@
     <Reference Include="NuGet.ApplicationInsights.Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.ApplicationInsights.Owin.4.1.0\lib\net452\NuGet.ApplicationInsights.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.KeyVault, Version=2.12.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.12.0\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
+    <Reference Include="NuGet.Services.KeyVault, Version=2.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.KeyVault.2.13.0-loshar-tmstp-status-22169\lib\net45\NuGet.Services.KeyVault.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Logging, Version=2.12.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NuGet.Services.Logging.2.12.0\lib\net452\NuGet.Services.Logging.dll</HintPath>
+    <Reference Include="NuGet.Services.Logging, Version=2.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Services.Logging.2.13.0-loshar-tmstp-status-22169\lib\net452\NuGet.Services.Logging.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.VirusScanning.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Services.VirusScanning.Vcs.3.2.0\lib\net452\NuGet.Services.VirusScanning.Core.dll</HintPath>

--- a/src/Validation.Common/app.config
+++ b/src/Validation.Common/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.Logging" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.12.0.0" newVersion="2.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.13.0.0" newVersion="2.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -40,7 +40,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.12.0.0" newVersion="2.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.13.0.0" newVersion="2.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/src/Validation.Common/packages.config
+++ b/src/Validation.Common/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.ApplicationInsights.Owin" version="4.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="2.12.0" targetFramework="net452" />
-  <package id="NuGet.Services.Logging" version="2.12.0" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="2.13.0-loshar-tmstp-status-22169" targetFramework="net452" />
+  <package id="NuGet.Services.Logging" version="2.13.0-loshar-tmstp-status-22169" targetFramework="net452" />
   <package id="NuGet.Services.VirusScanning.Vcs" version="3.2.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Serilog" version="2.0.0" targetFramework="net452" />

--- a/src/Validation.Common/packages.config
+++ b/src/Validation.Common/packages.config
@@ -22,8 +22,8 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.ApplicationInsights.Owin" version="4.1.0" targetFramework="net452" />
-  <package id="NuGet.Services.KeyVault" version="2.13.0-loshar-tmstp-status-22169" targetFramework="net452" />
-  <package id="NuGet.Services.Logging" version="2.13.0-loshar-tmstp-status-22169" targetFramework="net452" />
+  <package id="NuGet.Services.KeyVault" version="2.13.0" targetFramework="net452" />
+  <package id="NuGet.Services.Logging" version="2.13.0" targetFramework="net452" />
   <package id="NuGet.Services.VirusScanning.Vcs" version="3.2.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Serilog" version="2.0.0" targetFramework="net452" />

--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -39,13 +39,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>

--- a/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
+++ b/src/Validation.PackageSigning.Core/Validation.PackageSigning.Core.csproj
@@ -39,13 +39,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>7.1.2</Version>

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignaturePartsExtractor.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignaturePartsExtractor.cs
@@ -225,6 +225,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
                     PackageSignatureKey = packageSignature.Key,
                     EndCertificate = thumbprintToEndCertificate[timestampEndCertificate.Thumbprint],
                     Value = value,
+                    Status = TrustedTimestampStatus.Valid,
                 };
                 trustedTimestamp.EndCertificateKey = trustedTimestamp.EndCertificate.Key;
                 packageSignature.TrustedTimestamps.Add(trustedTimestamp);

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -109,22 +109,22 @@
       <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-19677</Version>

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/Validation.PackageSigning.ExtractAndValidateSignature.csproj
@@ -109,22 +109,22 @@
       <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-19677</Version>

--- a/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
+++ b/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
@@ -105,16 +105,16 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
+++ b/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
@@ -105,16 +105,16 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Contracts">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/Validation.Runner/App.config
+++ b/src/Validation.Runner/App.config
@@ -47,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Services.KeyVault" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.12.0.0" newVersion="2.12.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.13.0.0" newVersion="2.13.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -69,7 +69,7 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.12.0</Version>
+      <Version>2.13.0-loshar-tmstp-status-22169</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -69,7 +69,7 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.13.0-loshar-tmstp-status-22169</Version>
+      <Version>2.13.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignaturePartsExtractorFacts.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/SignaturePartsExtractorFacts.cs
@@ -638,6 +638,7 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
                 Assert.Equal(expected.TimestampEndCertificate.Thumbprint, trustedTimestamp.EndCertificate.Thumbprint);
                 Assert.Same(timestampEndCertificate, trustedTimestamp.EndCertificate);
                 Assert.Equal(timestampValue, trustedTimestamp.Value);
+                Assert.Equal(TrustedTimestampStatus.Valid, trustedTimestamp.Status);
             }
         }
 


### PR DESCRIPTION
Updates `NuGet.Services.*` dependencies to add the `Status` property to `TrustedTimestamp` entities. Also modified the Extract & Validate job to properly initialize timestamp's status as `Valid`.

Depends on https://github.com/NuGet/ServerCommon/pull/135