### PR TITLE
[Package Signing] Certificate Validation Testing Infrastructure

### DIFF
--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+using Test.Utility.Signing;
+using Xunit;
+using GeneralName = Org.BouncyCastle.Asn1.X509.GeneralName;
+
+namespace Validation.PackageSigning.Core.Tests.Support
+{
+    /// <summary>
+    /// This test fixture trusts the root certificate of checked in signed packages. This handles adding and removing
+    /// the root certificate from the local machine trusted roots. Any tests with this fixture require admin elevation.
+    /// </summary>
+    public class CertificateIntegrationTestFixture : IDisposable
+    {
+        private readonly Lazy<Task<SigningTestServer>> _testServer;
+        private readonly Lazy<Task<CertificateAuthority>> _certificateAuthority;
+        private readonly Lazy<Task<TimestampService>> _timestampService;
+        private readonly Lazy<Task<Uri>> _timestampServiceUrl;
+        private readonly Lazy<Task<X509Certificate2>> _signingCertificate;
+        private readonly Lazy<Task<string>> _signingCertificateThumbprint;
+        private TrustedTestCert<X509Certificate2> _trustedRoot;
+        private readonly DisposableList _responders;
+
+        public CertificateIntegrationTestFixture()
+        {
+            Assert.True(
+                IsAdministrator(),
+                "This test must be executing with administrator privileges since it installs a trusted root.");
+
+            _testServer = new Lazy<Task<SigningTestServer>>(SigningTestServer.CreateAsync);
+            _certificateAuthority = new Lazy<Task<CertificateAuthority>>(CreateDefaultTrustedCertificateAuthorityAsync);
+            _timestampService = new Lazy<Task<TimestampService>>(CreateDefaultTrustedTimestampServiceAsync);
+            _timestampServiceUrl = new Lazy<Task<Uri>>(CreateDefaultTrustedTimestampServiceUrlAsync);
+            _signingCertificate = new Lazy<Task<X509Certificate2>>(CreateDefaultTrustedSigningCertificateAsync);
+            _signingCertificateThumbprint = new Lazy<Task<string>>(GetDefaultTrustedSigningCertificateThumbprintAsync);
+            _responders = new DisposableList();
+        }
+
+        public Task<SigningTestServer> GetTestServerAsync() => _testServer.Value;
+        public Task<Uri> GetTimestampServiceUrlAsync() => _timestampServiceUrl.Value;
+        public Task<X509Certificate2> GetSigningCertificateAsync() => _signingCertificate.Value;
+        public Task<string> GetSigningCertificateThumbprintAsync() => _signingCertificateThumbprint.Value;
+
+        public void Dispose()
+        {
+            _trustedRoot?.Dispose();
+            _responders.Dispose();
+
+            if (_testServer.IsValueCreated)
+            {
+                _testServer.Value.Result.Dispose();
+            }
+        }
+
+        private async Task<CertificateAuthority> CreateDefaultTrustedCertificateAuthorityAsync()
+        {
+            var testServer = await GetTestServerAsync();
+            var rootCa = CertificateAuthority.Create(testServer.Url);
+            var intermediateCa = rootCa.CreateIntermediateCertificateAuthority();
+            var rootCertificate = new X509Certificate2(rootCa.Certificate.GetEncoded());
+
+            _trustedRoot = new TrustedTestCert<X509Certificate2>(
+                rootCertificate,
+                certificate => certificate,
+                StoreName.Root,
+                StoreLocation.LocalMachine);
+
+            _responders.AddRange(testServer.RegisterResponders(intermediateCa));
+
+            return intermediateCa;
+        }
+
+        private async Task<TimestampService> CreateDefaultTrustedTimestampServiceAsync()
+        {
+            var testServer = await GetTestServerAsync();
+            var ca = await _certificateAuthority.Value;
+            var timestampService = TimestampService.Create(ca);
+
+            _responders.Add(testServer.RegisterResponder(timestampService));
+
+            return timestampService;
+        }
+
+        private async Task<Uri> CreateDefaultTrustedTimestampServiceUrlAsync()
+        {
+            var timestampService = await _timestampService.Value;
+            return timestampService.Url;
+        }
+
+        private async Task<X509Certificate2> CreateDefaultTrustedSigningCertificateAsync()
+        {
+            var ca = await _certificateAuthority.Value;
+            return CreateSigningCertificate(ca);
+        }
+
+        public X509Certificate2 CreateSigningCertificate(CertificateAuthority ca)
+        {
+            var keyPair = SigningTestUtility.GenerateKeyPair(publicKeyLength: 2048);
+            var publicCertificate = ca.IssueCertificate(
+                keyPair.Public,
+                new X509Name($"C=US,ST=WA,L=Redmond,O=NuGet,CN=NuGet Test Signing Certificate ({Guid.NewGuid()})"),
+                generator =>
+                {
+                    SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert(generator);
+
+                    generator.AddExtension(
+                        X509Extensions.AuthorityInfoAccess,
+                        critical: false,
+                        extensionValue: new DerSequence(
+                            new AccessDescription(AccessDescription.IdADOcsp,
+                                new GeneralName(GeneralName.UniformResourceIdentifier, ca.OcspResponderUri.OriginalString)),
+                            new AccessDescription(AccessDescription.IdADCAIssuers,
+                                new GeneralName(GeneralName.UniformResourceIdentifier, ca.CertificateUri.OriginalString))));
+                },
+                notBefore: DateTime.UtcNow.AddSeconds(-10));
+
+            var certificate = new X509Certificate2(publicCertificate.GetEncoded());
+            certificate.PrivateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
+
+            return certificate;
+        }
+
+        private async Task<string> GetDefaultTrustedSigningCertificateThumbprintAsync()
+        {
+            var certificate = await GetSigningCertificateAsync();
+            return certificate.ComputeSHA256Thumbprint();
+        }
+
+        /// <summary>
+        /// Source: https://stackoverflow.com/a/11660205
+        /// </summary>
+        private static bool IsAdministrator()
+        {
+            var identity = WindowsIdentity.GetCurrent();
+            var principal = new WindowsPrincipal(identity);
+            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.Core.Tests/Support/ExtensionMethods.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/ExtensionMethods.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Test.Utility.Signing;
+
+namespace Validation.PackageSigning.Core.Tests.Support
+{
+    public static class ExtensionMethods
+    {
+        public static DisposableList RegisterResponders(
+            this ISigningTestServer testServer,
+            CertificateAuthority ca,
+            bool addCa = true,
+            bool addOcsp = true)
+        {
+            var responders = new DisposableList();
+            var currentCa = ca;
+
+            while (currentCa != null)
+            {
+                if (addCa)
+                {
+                    responders.Add(testServer.RegisterResponder(currentCa));
+                }
+
+                if (addOcsp)
+                {
+                    responders.Add(testServer.RegisterResponder(currentCa.OcspResponder));
+                }
+
+                currentCa = currentCa.Parent;
+            }
+
+            return responders;
+        }
+
+        public static DisposableList RegisterResponders(
+            this ISigningTestServer testServer,
+            TimestampService timestampService,
+            bool addCa = true,
+            bool addOcsp = true,
+            bool addTimestamper = true)
+        {
+            var responders = testServer.RegisterResponders(
+                timestampService.CertificateAuthority,
+                addCa,
+                addOcsp);
+
+            if (addTimestamper)
+            {
+                responders.Add(testServer.RegisterResponder(timestampService));
+            }
+
+            return responders;
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -38,7 +38,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\CertificateStoreTests.cs" />
     <Compile Include="Storage\ValidatorStatusExtensionsFacts.cs" />
+    <Compile Include="Support\CertificateIntegrationTestFixture.cs" />
     <Compile Include="Support\DbSetMockFactory.cs" />
+    <Compile Include="Support\ExtensionMethods.cs" />
     <Compile Include="Support\TestDbAsyncEnumerable.cs" />
     <Compile Include="Support\TestDbAsyncEnumerator.cs" />
     <Compile Include="Support\TestDbAsyncQueryProvider.cs" />
@@ -56,6 +58,12 @@
   <ItemGroup>
     <PackageReference Include="Moq">
       <Version>4.7.145</Version>
+    </PackageReference>
+    <PackageReference Include="Portable.BouncyCastle">
+      <Version>1.8.1.3</Version>
+    </PackageReference>
+    <PackageReference Include="Test.Utility">
+      <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.3.1</Version>

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -4,56 +4,25 @@
 using System;
 using System.IO;
 using System.Security.Cryptography.X509Certificates;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Signing;
 using NuGet.Test.Utility;
-using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.X509;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Security;
-using Test.Utility.Signing;
-using Validation.PackageSigning.ExtractAndValidateSignature.Tests.Support;
-using Xunit;
 using Xunit.Abstractions;
-using GeneralName = Org.BouncyCastle.Asn1.X509.GeneralName;
 
 namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
 {
+    using CoreCertificateIntegrationTestFixture = Core.Tests.Support.CertificateIntegrationTestFixture;
+
     /// <summary>
     /// This test fixture trusts the root certificate of checked in signed packages. This handles adding and removing
     /// the root certificate from the local machine trusted roots. Any tests with this fixture require admin elevation.
     /// </summary>
-    public class CertificateIntegrationTestFixture : IDisposable
+    public class CertificateIntegrationTestFixture : CoreCertificateIntegrationTestFixture
     {
-        private readonly Lazy<Task<SigningTestServer>> _testServer;
-        private readonly Lazy<Task<CertificateAuthority>> _certificateAuthority;
-        private readonly Lazy<Task<TimestampService>> _timestampService;
-        private readonly Lazy<Task<Uri>> _timestampServiceUrl;
-        private readonly Lazy<Task<X509Certificate2>> _signingCertificate;
-        private readonly Lazy<Task<string>> _signingCertificateThumbprint;
-        private TrustedTestCert<X509Certificate2> _trustedRoot;
-        private readonly DisposableList _responders;
-
         private readonly SemaphoreSlim _lock = new SemaphoreSlim(1);
         private byte[] _signedPackageBytes1;
-
-        public CertificateIntegrationTestFixture()
-        {
-            Assert.True(
-                IsAdministrator(),
-                "This test must be executing with administrator privileges since it installs a trusted root.");
-
-            _testServer = new Lazy<Task<SigningTestServer>>(SigningTestServer.CreateAsync);
-            _certificateAuthority = new Lazy<Task<CertificateAuthority>>(CreateDefaultTrustedCertificateAuthorityAsync);
-            _timestampService = new Lazy<Task<TimestampService>>(CreateDefaultTrustedTimestampServiceAsync);
-            _timestampServiceUrl = new Lazy<Task<Uri>>(CreateDefaultTrustedTimestampServiceUrlAsync);
-            _signingCertificate = new Lazy<Task<X509Certificate2>>(CreateDefaultTrustedSigningCertificateAsync);
-            _signingCertificateThumbprint = new Lazy<Task<string>>(GetDefaultTrustedSigningCertificateThumbprintAsync);
-            _responders = new DisposableList();
-        }
 
         public async Task<SignedPackageArchive> GetSignedPackage1Async(ITestOutputHelper output) => await GetSignedPackageAsync(
             new Reference<byte[]>(
@@ -69,106 +38,6 @@ namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
             TestResources.SignedPackageLeaf1,
             await GetSigningCertificateAsync(),
             output);
-
-        public Task<SigningTestServer> GetTestServerAsync() => _testServer.Value;
-        public Task<Uri> GetTimestampServiceUrlAsync() => _timestampServiceUrl.Value;
-        public Task<X509Certificate2> GetSigningCertificateAsync() => _signingCertificate.Value;
-        public Task<string> GetSigningCertificateThumbprintAsync() => _signingCertificateThumbprint.Value;
-
-        public void Dispose()
-        {
-            _trustedRoot?.Dispose();
-            _responders.Dispose();
-
-            if (_testServer.IsValueCreated)
-            {
-                _testServer.Value.Result.Dispose();
-            }
-        }
-
-        private async Task<CertificateAuthority> CreateDefaultTrustedCertificateAuthorityAsync()
-        {
-            var testServer = await GetTestServerAsync();
-            var rootCa = CertificateAuthority.Create(testServer.Url);
-            var intermediateCa = rootCa.CreateIntermediateCertificateAuthority();
-            var rootCertificate = new X509Certificate2(rootCa.Certificate.GetEncoded());
-
-            _trustedRoot = new TrustedTestCert<X509Certificate2>(
-                rootCertificate,
-                certificate => certificate,
-                StoreName.Root,
-                StoreLocation.LocalMachine);
-
-            _responders.AddRange(testServer.RegisterResponders(intermediateCa));
-
-            return intermediateCa;
-        }
-
-        private async Task<TimestampService> CreateDefaultTrustedTimestampServiceAsync()
-        {
-            var testServer = await GetTestServerAsync();
-            var ca = await _certificateAuthority.Value;
-            var timestampService = TimestampService.Create(ca);
-
-            _responders.Add(testServer.RegisterResponder(timestampService));
-
-            return timestampService;
-        }
-
-        private async Task<Uri> CreateDefaultTrustedTimestampServiceUrlAsync()
-        {
-            var timestampService = await _timestampService.Value;
-            return timestampService.Url;
-        }
-
-        private async Task<X509Certificate2> CreateDefaultTrustedSigningCertificateAsync()
-        {
-            var ca = await _certificateAuthority.Value;
-            return CreateSigningCertificate(ca);
-        }
-
-        public X509Certificate2 CreateSigningCertificate(CertificateAuthority ca)
-        {
-            var keyPair = SigningTestUtility.GenerateKeyPair(publicKeyLength: 2048);
-            var publicCertificate = ca.IssueCertificate(
-                keyPair.Public,
-                new X509Name($"C=US,ST=WA,L=Redmond,O=NuGet,CN=NuGet Test Signing Certificate ({Guid.NewGuid()})"),
-                generator =>
-                {
-                    SigningTestUtility.CertificateModificationGeneratorForCodeSigningEkuCert(generator);
-
-                    generator.AddExtension(
-                        X509Extensions.AuthorityInfoAccess,
-                        critical: false,
-                        extensionValue: new DerSequence(
-                            new AccessDescription(AccessDescription.IdADOcsp,
-                                new GeneralName(GeneralName.UniformResourceIdentifier, ca.OcspResponderUri.OriginalString)),
-                            new AccessDescription(AccessDescription.IdADCAIssuers,
-                                new GeneralName(GeneralName.UniformResourceIdentifier, ca.CertificateUri.OriginalString))));
-                },
-                notBefore: DateTime.UtcNow.AddSeconds(-10));
-
-            var certificate = new X509Certificate2(publicCertificate.GetEncoded());
-            certificate.PrivateKey = DotNetUtilities.ToRSA(keyPair.Private as RsaPrivateCrtKeyParameters);
-
-            return certificate;
-        }
-
-        private async Task<string> GetDefaultTrustedSigningCertificateThumbprintAsync()
-        {
-            var certificate = await GetSigningCertificateAsync();
-            return certificate.ComputeSHA256Thumbprint();
-        }
-
-        /// <summary>
-        /// Source: https://stackoverflow.com/a/11660205
-        /// </summary>
-        private static bool IsAdministrator()
-        {
-            var identity = WindowsIdentity.GetCurrent();
-            var principal = new WindowsPrincipal(identity);
-            return principal.IsInRole(WindowsBuiltInRole.Administrator);
-        }
 
         private async Task<MemoryStream> GetSignedPackageStreamAsync(
             Reference<byte[]> reference,

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/OnlineCertificateVerifierIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/OnlineCertificateVerifierIntegrationTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using NuGet.Services.Validation;
+using Validation.PackageSigning.Core.Tests.Support;
+using Validation.PackageSigning.ValidateCertificate.Tests.Support;
+using Xunit;
+
+namespace Validation.PackageSigning.ValidateCertificate.Tests
+{
+    [Collection(CertificateIntegrationTestCollection.Name)]
+    public class OnlineCertificateVerifierIntegrationTests
+    {
+        private readonly CertificateIntegrationTestFixture _fixture;
+        private readonly OnlineCertificateVerifier _target;
+
+        public OnlineCertificateVerifierIntegrationTests(CertificateIntegrationTestFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+
+            _target = new OnlineCertificateVerifier();
+        }
+
+        [Fact]
+        public async Task ValidCodeSigningCertificate()
+        {
+            // Arrange
+            var certificate = await _fixture.GetSigningCertificateAsync();
+
+            // Act & assert
+            var result = _target.VerifyCodeSigningCertificate(certificate, new X509Certificate2[0]);
+
+            Assert.Equal(EndCertificateStatus.Good, result.Status);
+            Assert.Equal(X509ChainStatusFlags.NoError, result.StatusFlags);
+            Assert.NotNull(result.StatusUpdateTime);
+            Assert.Null(result.RevocationTime);
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/OnlineCertificateVerifierIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/OnlineCertificateVerifierIntegrationTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using NuGet.Services.Validation;

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Support/CertificateIntegrationTestCollection.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Support/CertificateIntegrationTestCollection.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Validation.PackageSigning.Core.Tests.Support;
+using Xunit;
+
+namespace Validation.PackageSigning.ValidateCertificate.Tests.Support
+{
+    [CollectionDefinition(Name)]
+    public class CertificateIntegrationTestCollection : ICollectionFixture<CertificateIntegrationTestFixture>
+    {
+        public const string Name = "Certificate integration test collection";
+    }
+}

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
@@ -45,8 +45,10 @@
     <Compile Include="CertificateValidationMessageHandlerFacts.cs" />
     <Compile Include="CertificateValidationServiceFacts.cs" />
     <Compile Include="CertificateVerificationResultFacts.cs" />
+    <Compile Include="OnlineCertificateVerifierIntegrationTests.cs" />
     <Compile Include="SignatureDeciderFactoryFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Support\CertificateIntegrationTestCollection.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj">
@@ -56,6 +58,10 @@
     <ProjectReference Include="..\..\src\Validation.PackageSigning.ValidateCertificate\Validation.PackageSigning.ValidateCertificate.csproj">
       <Project>{a245e448-8ae0-452b-9338-8c0e0b637d72}</Project>
       <Name>Validation.PackageSigning.ValidateCertificate</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Validation.PackageSigning.Core.Tests\Validation.PackageSigning.Core.Tests.csproj">
+      <Project>{B4B7564A-965B-447B-927F-6749E2C08880}</Project>
+      <Name>Validation.PackageSigning.Core.Tests</Name>
     </ProjectReference>
     <ProjectReference Include="..\Validation.PackageSigning.Helpers\Validation.PackageSigning.Helpers.csproj">
       <Project>{2c5be067-adfd-49e3-ba9f-13a74436e5db}</Project>


### PR DESCRIPTION
The focus of this change is to prepare the Validate Certificate job's test project for integration testing:

* Moves common integration testing infrastructure from E&V's test project to the common project
* Adds a basic integration test to verify a valid codesigning certificate

Progress on https://github.com/NuGet/Engineering/issues/878