### PR TITLE
[Package Signing] Add Missing Dependency Injection

### DIFF
--- a/src/Validation.PackageSigning.ValidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/Job.cs
@@ -148,6 +148,7 @@ namespace Validation.PackageSigning.ValidateCertificate
                 return new CertificateStore(storage, LoggerFactory.CreateLogger<CertificateStore>());
             });
 
+            services.AddTransient<ICertificateVerifier, OnlineCertificateVerifier>();
             services.AddTransient<ICertificateValidationService, CertificateValidationService>();
             services.AddTransient<ITelemetryService, TelemetryService>();
         }


### PR DESCRIPTION
A `ICertificateVerifier` type wasn't registered for the Validate Certificate job, causing it to fail to initialize. 