### PR TITLE
Fix for NPE in Orchestrator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
@@ -137,12 +137,13 @@ namespace NuGet.Services.Validation.Orchestrator
                packageValidation.Type,
                isSuccess);
 
+            var issues = (packageValidation?.PackageValidationIssues ?? Enumerable.Empty<PackageValidationIssue>()).ToList();
             _telemetryService.TrackValidationIssueCount(
-                packageValidation.PackageValidationIssues.Count,
+                issues.Count,
                 packageValidation.Type,
                 isSuccess);
 
-            foreach (var issue in packageValidation?.PackageValidationIssues ?? Enumerable.Empty<PackageValidationIssue>())
+            foreach (var issue in issues)
             {
                 _telemetryService.TrackValidationIssue(packageValidation.Type, issue.IssueCode);
 

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
@@ -137,7 +137,7 @@ namespace NuGet.Services.Validation.Orchestrator
                packageValidation.Type,
                isSuccess);
 
-            var issues = (packageValidation?.PackageValidationIssues ?? Enumerable.Empty<PackageValidationIssue>()).ToList();
+            var issues = (packageValidation.PackageValidationIssues ?? Enumerable.Empty<PackageValidationIssue>()).ToList();
             _telemetryService.TrackValidationIssueCount(
                 issues.Count,
                 packageValidation.Type,

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
@@ -250,6 +250,23 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 // Assert
                 _telemetryService.VerifyAll();
             }
+
+            [Theory]
+            [InlineData(ValidationStatus.Failed)]
+            [InlineData(ValidationStatus.Incomplete)]
+            [InlineData(ValidationStatus.Succeeded)]
+            public async Task DoesNotThrowWhenPackageValidationIssuesIsNull(ValidationStatus validationStatus)
+            {
+                // Arrange
+                _packageValidation.PackageValidationIssues = null;
+                var validationResult = new ValidationResult(validationStatus);
+
+                // Act
+                var ex = await Record.ExceptionAsync(async() => await ExecuteAsync(validationResult));
+
+                // Assert
+                Assert.Null(ex);
+            }
         }
 
         public abstract class Facts


### PR DESCRIPTION
Currently if `PackageValidation.PackageValidationIssues` is null when `ValidationStorageService.TrackValidationStatus` is called and `PackageValidation.ValidationStatus` is `Succeded` or `Failed` it throws.