### PR TITLE
Add job to verify the hash of the packages in packages container

### DIFF
--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -111,6 +111,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.PackageSigning.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Common.Job", "src\Validation.Common.Job\Validation.Common.Job.csproj", "{FA87D075-A934-4443-8D0B-5DB32640B6D7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageHash", "src\PackageHash\PackageHash.csproj", "{40843020-6F0A-48F0-AC28-42FFE3A5C21E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -283,6 +285,10 @@ Global
 		{FA87D075-A934-4443-8D0B-5DB32640B6D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FA87D075-A934-4443-8D0B-5DB32640B6D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FA87D075-A934-4443-8D0B-5DB32640B6D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40843020-6F0A-48F0-AC28-42FFE3A5C21E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40843020-6F0A-48F0-AC28-42FFE3A5C21E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40843020-6F0A-48F0-AC28-42FFE3A5C21E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40843020-6F0A-48F0-AC28-42FFE3A5C21E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -329,6 +335,7 @@ Global
 		{2C5BE067-ADFD-49E3-BA9F-13A74436E5DB} = {6A776396-02B1-475D-A104-26940ADB04AB}
 		{B4B7564A-965B-447B-927F-6749E2C08880} = {6A776396-02B1-475D-A104-26940ADB04AB}
 		{FA87D075-A934-4443-8D0B-5DB32640B6D7} = {678D7B14-F8BC-4193-99AF-2EE8AA390A02}
+		{40843020-6F0A-48F0-AC28-42FFE3A5C21E} = {FA5644B5-4F08-43F6-86B3-039374312A47}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {284A7AC3-FB43-4F1F-9C9C-2AF0E1F46C2B}

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -93,7 +93,9 @@
     <Compile Include="ValidatorProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -101,9 +103,6 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
       <Version>2.14.0</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Versioning">
-      <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/PackageHash/BatchProcessor.cs
+++ b/src/PackageHash/BatchProcessor.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Common;
+
+namespace NuGet.Services.PackageHash
+{
+    public class BatchProcessor : IBatchProcessor
+    {
+        private readonly IPackageHashCalculator _calculator;
+        private readonly IOptionsSnapshot<PackageHashConfiguration> _configuration;
+        private readonly ILogger<BatchProcessor> _logger;
+
+        public BatchProcessor(
+            IPackageHashCalculator calculator,
+            IOptionsSnapshot<PackageHashConfiguration> configuration,
+            ILogger<BatchProcessor> logger)
+        {
+            _calculator = calculator ?? throw new ArgumentNullException(nameof(configuration));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<IReadOnlyList<InvalidPackageHash>> ProcessBatchAsync(
+            IReadOnlyList<PackageHash> batch,
+            string hashAlgorithmId,
+            CancellationToken token)
+        {
+            // Build up a bag of work.
+            var remainingWork = new ConcurrentBag<Work>();
+            var failures = new ConcurrentBag<InvalidPackageHash>();
+            foreach (var source in _configuration.Value.Sources)
+            {
+                foreach (var package in batch)
+                {
+                    remainingWork.Add(new Work(source, package));
+                }
+            }
+
+            // Perform the work in parallel.
+            _logger.LogInformation(
+                "Starting to check hashes for {PackageCount} packages from {SourceCount} sources ({WorkCount} total" +
+                " checks, {DegreeOfParallelism} tasks).",
+                batch.Count,
+                _configuration.Value.Sources.Count,
+                remainingWork.Count,
+                _configuration.Value.DegreeOfParallelism);
+
+            var tasks = Enumerable
+                .Range(0, _configuration.Value.DegreeOfParallelism)
+                .Select(x => ProcessWorkAsync(remainingWork, failures, hashAlgorithmId, token))
+                .ToList();
+
+            await Task.WhenAll(tasks);
+
+            _logger.LogInformation(
+                "Completed the batch. {FailureResultCount} failure results were found.",
+                failures.Count);
+
+            return failures.ToList();
+        }
+
+        private async Task ProcessWorkAsync(
+            ConcurrentBag<Work> remainingWork,
+            ConcurrentBag<InvalidPackageHash> failures,
+            string hashAlgorithmId,
+            CancellationToken token)
+        {
+            while (remainingWork.TryTake(out var work) && !token.IsCancellationRequested)
+            {
+                var actualHash = await _calculator.GetPackageHashAsync(
+                    work.Source,
+                    work.Package.Identity,
+                    hashAlgorithmId,
+                    token);
+
+                if (work.Package.ExpectedHash != actualHash)
+                {
+                    failures.Add(new InvalidPackageHash(work.Source, work.Package, actualHash));
+                }
+            }
+        }
+
+        private class Work
+        {
+            public Work(PackageSource source, PackageHash package)
+            {
+                Source = source ?? throw new ArgumentNullException(nameof(source));
+                Package = package ?? throw new ArgumentNullException(nameof(package));
+            }
+
+            public PackageSource Source { get; }
+            public PackageHash Package { get; }
+        }
+    }
+}

--- a/src/PackageHash/ConsistentHash.cs
+++ b/src/PackageHash/ConsistentHash.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NuGet.Services.PackageHash
+{
+    public static class ConsistentHash
+    {
+        public static int DetermineBucket(string key, int bucketCount)
+        {
+            using (var hashAlgorithm = SHA256.Create())
+            {
+                var hashBytes = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(key));
+                var reducedHash = 0;
+                for (var i = 0; i < hashBytes.Length; i += sizeof(int))
+                {
+                    reducedHash ^= BitConverter.ToInt32(hashBytes, i);
+                }
+
+                return reducedHash % bucketCount;
+            }
+        }
+    }
+}

--- a/src/PackageHash/IBatchProcessor.cs
+++ b/src/PackageHash/IBatchProcessor.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.PackageHash
+{
+    public interface IBatchProcessor
+    {
+        Task<IReadOnlyList<InvalidPackageHash>> ProcessBatchAsync(
+            IReadOnlyList<PackageHash> batch,
+            string hashAlgorithm,
+            CancellationToken token);
+    }
+}

--- a/src/PackageHash/IPackageHashCalculator.cs
+++ b/src/PackageHash/IPackageHashCalculator.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Services.PackageHash
+{
+    public interface IPackageHashCalculator
+    {
+        Task<string> GetPackageHashAsync(
+            PackageSource source,
+            PackageIdentity package,
+            string hashAlgorithmId,
+            CancellationToken token);
+    }
+}

--- a/src/PackageHash/IPackageHashProcessor.cs
+++ b/src/PackageHash/IPackageHashProcessor.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.PackageHash
+{
+    public interface IPackageHashProcessor
+    {
+        Task ExecuteAsync(int bucketNumber, int bucketCount, CancellationToken token);
+    }
+}

--- a/src/PackageHash/IResultRecorder.cs
+++ b/src/PackageHash/IResultRecorder.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.PackageHash
+{
+    public interface IResultRecorder
+    {
+        Task RecordAsync(IReadOnlyList<InvalidPackageHash> results);
+    }
+}

--- a/src/PackageHash/InvalidPackageHash.cs
+++ b/src/PackageHash/InvalidPackageHash.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.PackageHash
+{
+    public class InvalidPackageHash
+    {
+        public InvalidPackageHash(PackageSource source, PackageHash package, string invalidHash)
+        {
+            Source = source;
+            Package = package;
+            InvalidHash = invalidHash;
+        }
+
+        public PackageSource Source { get; }
+        public PackageHash Package { get; }
+        public string InvalidHash { get; }
+    }
+}

--- a/src/PackageHash/Job.cs
+++ b/src/PackageHash/Job.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NuGet.Jobs.Validation;
+using NuGet.Services.Cursor;
+using NuGet.Services.Storage;
+using NuGetGallery;
+
+namespace NuGet.Services.PackageHash
+{
+    public class Job : JsonConfigurationJob
+    {
+        private const string PackageHashConfigurationSectionName = "PackageHash";
+
+        /// <summary>
+        /// This is the bucket number (bucket index + 1) to execute work for. In other words, if you want to run this
+        /// job on four different machines, you would set "-bucket-count" argument to "4" and execute this process four
+        /// times, with "-bucket-number" argument set to "1", "2", "3", and "4". This would effectively distribute the
+        /// work across four machines without any other coordination necessary.
+        /// </summary>
+        private const string BucketNumber = "bucket-number";
+
+        /// <summary>
+        /// This is the bucket count, which is the number of workers you want to be running in parallel.
+        /// </summary>
+        private const string BucketCount = "bucket-count";
+
+        private int _bucketNumber = 1;
+        private int _bucketCount = 1;
+
+        public override void Init(IDictionary<string, string> jobArgsDictionary)
+        {
+            if (jobArgsDictionary.TryGetValue(BucketCount, out var unparsedBucketCount))
+            {
+                if (int.TryParse(unparsedBucketCount, out var bucketCount))
+                {
+                    if (bucketCount > 0)
+                    {
+                        _bucketCount = bucketCount;
+                    }
+                    else
+                    {
+                        Logger.LogWarning(
+                            "The bucket count must be greater than zero. Defaulting to {DefaultValue}.",
+                            _bucketCount);
+                    }
+                }
+                else
+                {
+                    Logger.LogWarning(
+                        "Could not parse bucket count value {UnparsedBucketCount} as an integer. Defaulting to " +
+                        "{DefaultValue}",
+                        unparsedBucketCount,
+                        _bucketCount);
+                }
+            }
+
+            if (jobArgsDictionary.TryGetValue(BucketNumber, out var unparsedBucketNumber))
+            {
+                if (int.TryParse(unparsedBucketNumber, out var bucketNumber))
+                {
+                    if (bucketNumber > 0 && bucketNumber <= _bucketCount)
+                    {
+                        _bucketNumber = bucketNumber;
+                    }
+                    else
+                    {
+                        Logger.LogWarning(
+                            "The bucket number must be greater than zero and less than or equal to the bucket count " +
+                            "{BucketCount}. Defaulting to {DefaultValue}.",
+                            _bucketCount,
+                            _bucketNumber);
+                    }
+                }
+                else
+                {
+                    Logger.LogWarning(
+                        "Could not parse bucket number value {UnparsedBucketNumber} as an integer. Defaulting to " +
+                        "{DefaultValue}",
+                        unparsedBucketNumber,
+                        _bucketNumber);
+                }
+            }
+
+            if (_bucketNumber > _bucketCount)
+            {
+                throw new ArgumentException("The bucket number must be less or equal to the bucket count.");
+            }
+
+            base.Init(jobArgsDictionary);
+        }
+
+        public override async Task Run()
+        {
+            var processor = _serviceProvider.GetRequiredService<IPackageHashProcessor>();
+
+            await processor.ExecuteAsync(
+                _bucketNumber,
+                _bucketCount,
+                CancellationToken.None);
+        }
+
+        protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
+        {
+        }
+
+        protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
+        {
+            services.Configure<PackageHashConfiguration>(configurationRoot.GetSection(PackageHashConfigurationSectionName));
+
+            services.AddTransient<IEntityRepository<Package>, EntityRepository<Package>>();
+            services.AddTransient<IPackageHashCalculator, PackageHashCalculator>();
+            services.AddTransient<IBatchProcessor, BatchProcessor>();
+            services.AddTransient<IResultRecorder, ResultRecorder>();
+            services.AddTransient<IPackageHashProcessor, PackageHashProcessor>();
+            services.AddTransient(s =>
+            {
+                var address = new Uri("http://localhost");
+                var fileStorageFactory = new FileStorageFactory(
+                    address,
+                    Directory.GetCurrentDirectory(),
+                    s.GetRequiredService<ILogger<FileStorage>>());
+                return new DurableCursor(
+                    new Uri(address, $"cursor_{_bucketNumber}_of_{_bucketCount}.json"),
+                    fileStorageFactory.Create(),
+                    DateTimeOffset.MinValue);
+            });
+        }
+    }
+}

--- a/src/PackageHash/PackageHash.cs
+++ b/src/PackageHash/PackageHash.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Packaging.Core;
+
+namespace NuGet.Services.PackageHash
+{
+    public class PackageHash
+    {
+        public PackageHash(PackageIdentity identity, string expectedHash)
+        {
+            Identity = identity;
+            ExpectedHash = expectedHash;
+        }
+
+        public PackageIdentity Identity { get; }
+
+        /// <summary>
+        /// The expected, base64-encoded hash digest.
+        /// </summary>
+        public string ExpectedHash { get; }
+    }
+}

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -4,18 +4,17 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{DD043977-6BCD-475A-BEE2-8C34309EC622}</ProjectGuid>
+    <ProjectGuid>{40843020-6F0A-48F0-AC28-42FFE3A5C21E}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>NuGet.Jobs.Validation.PackageSigning</RootNamespace>
-    <AssemblyName>NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature</AssemblyName>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.Services.PackageHash</RootNamespace>
+    <AssemblyName>NuGet.Services.PackageHash</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,7 +24,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -33,57 +31,56 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Security" />
+    <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ExtractedCertificates.cs" />
-    <Compile Include="Hash.cs" />
-    <Compile Include="HashedCertificate.cs" />
-    <Compile Include="ISignaturePartsExtractor.cs" />
-    <Compile Include="ISignatureValidator.cs" />
-    <Compile Include="MinimalSignatureVerificationProvider.cs" />
-    <Compile Include="PackageSignatureVerifierFactory.cs" />
-    <Compile Include="SignaturePartsExtractor.cs" />
-    <Compile Include="SignatureValidator.cs" />
-    <Compile Include="Storage\PackageSigningStateService.cs" />
-    <Compile Include="Storage\IPackageSigningStateService.cs" />
+    <Compile Include="BatchProcessor.cs" />
+    <Compile Include="ConsistentHash.cs" />
+    <Compile Include="IBatchProcessor.cs" />
+    <Compile Include="InvalidPackageHash.cs" />
+    <Compile Include="IPackageHashCalculator.cs" />
+    <Compile Include="IPackageHashProcessor.cs" />
+    <Compile Include="IResultRecorder.cs" />
     <Compile Include="Job.cs" />
+    <Compile Include="PackageHash.cs" />
+    <Compile Include="PackageHashCalculator.cs" />
+    <Compile Include="PackageHashConfiguration.cs" />
+    <Compile Include="PackageHashProcessor.cs" />
+    <Compile Include="PackageSource.cs" />
+    <Compile Include="PackageSourceType.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SignatureValidationMessageHandler.cs" />
-    <Compile Include="SignatureValidatorResult.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="Scripts\*" />
-    <None Include="Settings\*" />
+    <Compile Include="ResultRecorder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
       <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
       <Name>NuGet.Jobs.Common</Name>
     </ProjectReference>
-    <ProjectReference Include="..\NuGet.Services.Validation.Orchestrator\NuGet.Services.Validation.Orchestrator.csproj">
-      <Project>{E6D094FB-9068-4578-B176-116F97E7506B}</Project>
-      <Name>NuGet.Services.Validation.Orchestrator</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Validation.Common.Job\Validation.Common.Job.csproj">
       <Project>{fa87d075-a934-4443-8d0b-5db32640b6d7}</Project>
       <Name>Validation.Common.Job</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Validation.Common\Validation.Common.csproj">
-      <Project>{2539DDF3-0CC5-4A03-B5F9-39B47744A7BD}</Project>
-      <Name>Validation.Common</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj">
-      <Project>{91c060da-736f-4da9-a57f-cb3ac0e6cb10}</Project>
-      <Name>Validation.PackageSigning.Core</Name>
-    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Settings\dev.json" />
+    <None Include="Settings\int.json" />
+    <None Include="Settings\prod.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>1.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Cursor">
+      <Version>2.14.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/PackageHash/PackageHashCalculator.cs
+++ b/src/PackageHash/PackageHashCalculator.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Jobs.Validation;
+using NuGet.Packaging.Core;
+using NuGetGallery;
+
+namespace NuGet.Services.PackageHash
+{
+    public class PackageHashCalculator : IPackageHashCalculator
+    {
+        private readonly IPackageDownloader _packageDownloader;
+
+        public PackageHashCalculator(IPackageDownloader packageDownloader)
+        {
+            _packageDownloader = packageDownloader ?? throw new ArgumentNullException(nameof(packageDownloader));
+        }
+
+        public async Task<string> GetPackageHashAsync(
+            PackageSource source,
+            PackageIdentity package,
+            string hashAlgorithmId,
+            CancellationToken token)
+        {
+            if (source.Type != PackageSourceType.PackagesContainer)
+            {
+                throw new NotSupportedException($"Only the package source type {PackageSourceType.PackagesContainer} is supported.");
+            }
+
+            var id = package.Id.ToLowerInvariant();
+            var version = package.Version.ToNormalizedString().ToLowerInvariant();
+            var packageUri = new Uri($"{source.Url.TrimEnd('/')}/{id}.{version}.nupkg");
+
+            using (var packageStream = await _packageDownloader.DownloadAsync(packageUri, token))
+            {
+                return CryptographyService.GenerateHash(packageStream, hashAlgorithmId);
+            }
+        }
+    }
+}

--- a/src/PackageHash/PackageHashConfiguration.cs
+++ b/src/PackageHash/PackageHashConfiguration.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Services.PackageHash
+{
+    public class PackageHashConfiguration
+    {
+        public int BatchSize { get; set; }
+        public int DegreeOfParallelism { get; set; }
+        public IReadOnlyList<PackageSource> Sources { get; set; }
+    }
+}

--- a/src/PackageHash/PackageHashProcessor.cs
+++ b/src/PackageHash/PackageHashProcessor.cs
@@ -1,0 +1,225 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Packaging.Core;
+using NuGet.Services.Cursor;
+using NuGet.Versioning;
+using NuGetGallery;
+
+namespace NuGet.Services.PackageHash
+{
+    public class PackageHashProcessor : IPackageHashProcessor
+    {
+        /// <summary>
+        /// If the cursor is close to the current time, look back a certain amount of time to catch any packages that
+        /// were updated out of order.
+        /// </summary>
+        private static readonly TimeSpan LookbackWindow = TimeSpan.FromHours(1);
+
+        private readonly IEntityRepository<Package> _packageRepository;
+        private readonly IBatchProcessor _batchProcessor;
+        private readonly IResultRecorder _resultRecorder;
+        private readonly IOptionsSnapshot<PackageHashConfiguration> _configuration;
+        private readonly DurableCursor _cursor;
+        private readonly ILogger<PackageHashProcessor> _logger;
+
+        public PackageHashProcessor(
+            IEntityRepository<Package> packageRepository,
+            IBatchProcessor batchProcessor,
+            IResultRecorder resultRecorder,
+            IOptionsSnapshot<PackageHashConfiguration> configuration,
+            DurableCursor cursor,
+            ILogger<PackageHashProcessor> logger)
+        {
+            _packageRepository = packageRepository ?? throw new ArgumentNullException(nameof(packageRepository));
+            _batchProcessor = batchProcessor ?? throw new ArgumentNullException(nameof(batchProcessor));
+            _resultRecorder = resultRecorder ?? throw new ArgumentNullException(nameof(resultRecorder));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _cursor = cursor ?? throw new ArgumentNullException(nameof(cursor));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task ExecuteAsync(
+            int bucketNumber,
+            int bucketCount,
+            CancellationToken token)
+        {
+            DateTimeOffset? newCursorValue;
+            do
+            {
+                await _cursor.Load(token);
+
+                newCursorValue = await ProcessBatchAsync(bucketNumber, bucketCount, token);
+
+                if (newCursorValue.HasValue)
+                {
+                    _cursor.Value = newCursorValue.Value;
+                    _logger.LogInformation(
+                        "Moving cursor {BucketNumber}/{BucketCount} forward to {NewCursorValue}.",
+                        bucketNumber,
+                        bucketCount,
+                        newCursorValue.Value);
+                    await _cursor.Save(token);
+                }
+            }
+            while (newCursorValue.HasValue);
+        }
+
+        private async Task<DateTimeOffset?> ProcessBatchAsync(
+            int bucketNumber,
+            int bucketCount,
+            CancellationToken token)
+        {
+            var cursorValue = _cursor.Value.UtcDateTime;
+            var lookbackTime = DateTime.UtcNow.Subtract(LookbackWindow);
+            var lookbackApplied = false;
+            if (cursorValue > lookbackTime)
+            {
+                _logger.LogInformation(
+                    "Since the cursor is close to the current time, the cursor value {CursorValue} will be used instead of {OriginalCursorValue}.",
+                    lookbackTime,
+                    cursorValue);
+                cursorValue = lookbackTime;
+                lookbackApplied = true;
+            }
+
+            _logger.LogInformation(
+                "Querying for up to {MaxBatchSize} packages with max timestamp after {CursorValue}.",
+                _configuration.Value.BatchSize,
+                cursorValue);
+
+            var fullBatch = await _packageRepository
+                .GetAll()
+                .Include(x => x.PackageRegistration)
+                .Where(p => p.PackageStatusKey == PackageStatus.Available
+                            && (p.Created > cursorValue
+                                || (p.LastEdited.HasValue && p.LastEdited.Value > cursorValue)))
+                .OrderBy(p => p.LastEdited.HasValue && p.LastEdited.Value > p.Created ? p.LastEdited.Value : p.Created)
+                .Take(_configuration.Value.BatchSize)
+                .ToListAsync();
+
+            if (!fullBatch.Any())
+            {
+                _logger.LogInformation("No more packages to process.");
+                return null;
+            }
+
+            _logger.LogInformation("Found {BatchSize} packages packages to process.", fullBatch.Count);
+
+            // Exclude packages sharing the same max timestamp. We do this since our cursor is exclusive and it's
+            // possible the current batch does not have all of the packages with the same max timestamp.
+            var maxTimestamp = fullBatch.Select(GetMaxTimestamp).Max();
+            var trimmedBatch = fullBatch
+                .Where(x => GetMaxTimestamp(x) < maxTimestamp)
+                .ToList();
+
+            if (!trimmedBatch.Any())
+            {
+                if (fullBatch.Count == _configuration.Value.BatchSize)
+                {
+                    _logger.LogError(
+                        "All of the packages in the batch have the same max timestamp of {MaxTimestamp}. " +
+                        "Consider increasing the batch size before continuing.",
+                        maxTimestamp);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "The reamining packages will be left unprocessed until a timestamp newer than " +
+                        "{MaxTimestamp} is encountered.",
+                        maxTimestamp);
+                }
+                                
+                return null;
+            }
+
+            var unexpectedHashAlgorithms = trimmedBatch
+                .Select(x => x.HashAlgorithm)
+                .Where(x => x != CoreConstants.Sha512HashAlgorithmId)
+                .Distinct()
+                .ToList();
+            if (unexpectedHashAlgorithms.Any())
+            {
+                _logger.LogError(
+                    "At least one package with an unexpected hash algorithms was found: {UnexpectedHashAlgorithms}",
+                    unexpectedHashAlgorithms);
+                return null;
+            }
+
+            var failureResults = await PartitionAndProcessAsync(bucketNumber, bucketCount, trimmedBatch, token);
+
+            if (failureResults.Any())
+            {
+                await _resultRecorder.RecordAsync(failureResults);
+            }
+
+            if (lookbackApplied)
+            {
+                return null;
+            }
+
+            return new DateTimeOffset(trimmedBatch.Select(GetMaxTimestamp).Max(), TimeSpan.Zero);
+        }
+
+        private async Task<IReadOnlyList<InvalidPackageHash>> PartitionAndProcessAsync(
+            int bucketNumber,
+            int bucketCount,
+            IReadOnlyList<Package> batch,
+            CancellationToken token)
+        {
+            var packages = batch
+                .Select(x => new PackageHash(
+                    new PackageIdentity(
+                        x.PackageRegistration.Id,
+                        NuGetVersion.Parse(x.NormalizedVersion)),
+                    x.Hash))
+                .Where(x => MatchesBucket(bucketNumber, bucketCount, x))
+                .ToList();
+
+            _logger.LogInformation(
+                "{PackageCount} packages are in bucket {BucketNumber}/{BucketCount} from a batch of size {BatchSize}.",
+                packages.Count,
+                bucketNumber,
+                bucketCount,
+                batch.Count);
+
+            return await _batchProcessor.ProcessBatchAsync(
+                packages,
+                CoreConstants.Sha512HashAlgorithmId,
+                token);
+        }
+
+        private bool MatchesBucket(int bucketNumber, int bucketCount, PackageHash x)
+        {
+            if (bucketCount == 1)
+            {
+                return true;
+            }
+
+            var key = $"{x.Identity.Id}/{x.Identity.Version.ToNormalizedString()}".ToLowerInvariant();
+
+            var bucketIndex = ConsistentHash.DetermineBucket(key, bucketCount);
+
+            // Bucket index is zero-based. Bucket number is one-based.
+            return bucketIndex == bucketNumber - 1;
+        }
+
+        private DateTime GetMaxTimestamp(Package package)
+        {
+            return new[]
+            {
+                package.Created,
+                package.LastEdited ?? DateTime.MinValue,
+            }.Max();
+        }
+    }
+}

--- a/src/PackageHash/PackageSource.cs
+++ b/src/PackageHash/PackageSource.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.PackageHash
+{
+    public class PackageSource
+    {
+        public string Url { get; set; }
+        public PackageSourceType Type { get; set; }
+    }
+}

--- a/src/PackageHash/PackageSourceType.cs
+++ b/src/PackageHash/PackageSourceType.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.PackageHash
+{
+    public enum PackageSourceType
+    {
+        PackagesContainer,
+    }
+}

--- a/src/PackageHash/Program.cs
+++ b/src/PackageHash/Program.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Jobs;
+
+namespace NuGet.Services.PackageHash
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var job = new Job();
+            JobRunner.Run(job, args).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/PackageHash/Properties/AssemblyInfo.cs
+++ b/src/PackageHash/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NuGet.Services.PackageHash")]
+[assembly: AssemblyDescription("Verify that a package matches the hash in the database.")]
+[assembly: ComVisible(false)]
+[assembly: Guid("40843020-6f0a-48f0-ac28-42ffe3a5c21e")]

--- a/src/PackageHash/ResultRecorder.cs
+++ b/src/PackageHash/ResultRecorder.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace NuGet.Services.PackageHash
+{
+    public class ResultRecorder : IResultRecorder
+    {
+        private readonly ILogger<ResultRecorder> _logger;
+
+        public ResultRecorder(ILogger<ResultRecorder> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task RecordAsync(IReadOnlyList<InvalidPackageHash> results)
+        {
+            using (var fileStream = new FileStream("results.csv", FileMode.Append))
+            using (var writer = new StreamWriter(fileStream))
+            {
+                if (fileStream.Position == 0)
+                {
+                    await writer.WriteLineAsync("Type,URL,ID,Version,ExpectedHash,ActualHash");
+                }
+
+                foreach (var result in results)
+                {
+                    _logger.LogError(
+                        "Inconsistent hash found for {PackageId} {PackageVersion} on {SourceUrl} ({SourceType}). " +
+                        "Expected {ExpectedHash}, found {ActualHash}.",
+                        result.Package.Identity.Id,
+                        result.Package.Identity.Version.ToNormalizedString(),
+                        result.Source.Url,
+                        result.Source.Type,
+                        result.Package.ExpectedHash,
+                        result.InvalidHash);
+
+                    var pieces = new object[]
+                    {
+                        result.Source.Type,
+                        result.Source.Url,
+                        result.Package.Identity.Id,
+                        result.Package.Identity.Version.ToNormalizedString(),
+                        result.Package.ExpectedHash,
+                        result.InvalidHash,
+                    };
+
+                    await writer.WriteLineAsync(string.Join(",", pieces));
+                }
+            }
+        }
+    }
+}

--- a/src/PackageHash/Settings/dev.json
+++ b/src/PackageHash/Settings/dev.json
@@ -1,0 +1,24 @@
+﻿{
+  "GalleryDb": {
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
+  },
+  "PackageHash": {
+    "BatchSize": 1000,
+    "DegreeOfParallelism": 16,
+    "Sources": [
+      {
+        "Type": "PackagesContainer",
+        "Url": "https://nugetdevlegacy.blob.core.windows.net/packages/"
+      }
+    ]
+  },
+
+  "PackageDownloadTimeout": "10:00",
+
+  "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
+  "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
+  "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",
+  "KeyVault_ValidateCertificate": false,
+  "KeyVault_StoreName": "My",
+  "KeyVault_StoreLocation": "LocalMachine"
+}

--- a/src/PackageHash/Settings/int.json
+++ b/src/PackageHash/Settings/int.json
@@ -1,0 +1,24 @@
+﻿{
+  "GalleryDb": {
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;Integrated Security=False;User ID=$$Int-GalleryDBReadonly-UserName$$;Password=$$Int-GalleryDBReadonly-Password$$;Connect Timeout=30;Encrypt=True"
+  },
+  "PackageHash": {
+    "BatchSize": 1000,
+    "DegreeOfParallelism": 16,
+    "Sources": [
+      {
+        "Type": "PackagesContainer",
+        "Url": "https://nugetint0.blob.core.windows.net/packages/"
+      }
+    ]
+  },
+
+  "PackageDownloadTimeout": "10:00",
+
+  "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
+  "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
+  "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",
+  "KeyVault_ValidateCertificate": false,
+  "KeyVault_StoreName": "My",
+  "KeyVault_StoreLocation": "LocalMachine"
+}

--- a/src/PackageHash/Settings/prod.json
+++ b/src/PackageHash/Settings/prod.json
@@ -1,0 +1,24 @@
+﻿{
+  "GalleryDb": {
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;Integrated Security=False;User ID=$$Prod-GalleryDBReadonly-UserName$$;Password=$$Prod-GalleryDBReadonly-Password$$;Connect Timeout=30;Encrypt=True"
+  },
+  "PackageHash": {
+    "BatchSize": 1000,
+    "DegreeOfParallelism": 16,
+    "Sources": [
+      {
+        "Type": "PackagesContainer",
+        "Url": "https://nugetgallery.blob.core.windows.net/packages/"
+      }
+    ]
+  },
+
+  "PackageDownloadTimeout": "10:00",
+
+  "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
+  "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
+  "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",
+  "KeyVault_ValidateCertificate": false,
+  "KeyVault_StoreName": "My",
+  "KeyVault_StoreLocation": "LocalMachine"
+}

--- a/src/Validation.Common.Job/Error.cs
+++ b/src/Validation.Common.Job/Error.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace NuGet.Jobs.Validation.PackageSigning
+namespace NuGet.Jobs.Validation
 {
     public static class Error
     {
@@ -12,6 +12,6 @@ namespace NuGet.Jobs.Validation.PackageSigning
         public static EventId LoadedCertificateThumbprintDoesNotMatch = new EventId(1002, "Certificate thumbprint mismatch");
         public static EventId LoadCertificateFromStorageFailed = new EventId(1003, "Certificate loading from storage failed");
 
-        public static EventId ValidateSignatureFailedToDownloadPackageStatus = new EventId(1100, "Failed to download package");
+        public static EventId FailedToDownloadPackage = new EventId(1100, "Failed to download package");
     }
 }

--- a/src/Validation.Common.Job/IPackageDownloader.cs
+++ b/src/Validation.Common.Job/IPackageDownloader.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs.Validation
+{
+    public interface IPackageDownloader
+    {
+        Task<Stream> DownloadAsync(Uri packageUri, CancellationToken cancellationToken);
+    }
+}

--- a/src/Validation.Common.Job/JsonConfigurationJob.cs
+++ b/src/Validation.Common.Job/JsonConfigurationJob.cs
@@ -22,7 +22,7 @@ using NuGetGallery;
 
 namespace NuGet.Jobs.Validation
 {
-    public abstract class ValidationJob : JobBase
+    public abstract class JsonConfigurationJob : JobBase
     {
         private const string GalleryDbConfigurationSectionName = "GalleryDb";
         private const string ValidationDbConfigurationSectionName = "ValidationDb";
@@ -104,6 +104,8 @@ namespace NuGet.Jobs.Validation
             services.Configure<GalleryDbConfiguration>(configurationRoot.GetSection(GalleryDbConfigurationSectionName));
             services.Configure<ValidationDbConfiguration>(configurationRoot.GetSection(ValidationDbConfigurationSectionName));
             services.Configure<ServiceBusConfiguration>(configurationRoot.GetSection(ServiceBusConfigurationSectionName));
+
+            services.AddTransient<IPackageDownloader, PackageDownloader>();
 
             services.AddScoped<IValidationEntitiesContext>(p =>
             {

--- a/src/Validation.Common.Job/PackageDownloader.cs
+++ b/src/Validation.Common.Job/PackageDownloader.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace NuGet.Jobs.Validation
+{
+    public class PackageDownloader : IPackageDownloader
+    {
+        private const int BufferSize = 8192;
+
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<PackageDownloader> _logger;
+
+        public PackageDownloader(HttpClient httpClient, ILogger<PackageDownloader> logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<Stream> DownloadAsync(Uri packageUri, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Attempting to download package from {PackageUri}...", packageUri);
+
+            Stream packageStream = null;
+            var stopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                // Download the package from the network to a temporary file.
+                using (var response = await _httpClient.GetAsync(packageUri, HttpCompletionOption.ResponseHeadersRead))
+                {
+                    _logger.LogInformation(
+                        "Received response {StatusCode}: {ReasonPhrase} of type {ContentType} for request {PackageUri}",
+                        response.StatusCode,
+                        response.ReasonPhrase,
+                        response.Content.Headers.ContentType,
+                        packageUri);
+
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        throw new InvalidOperationException($"Expected status code {HttpStatusCode.OK} for package download, actual: {response.StatusCode}");
+                    }
+
+                    using (var networkStream = await response.Content.ReadAsStreamAsync())
+                    {
+                        packageStream = new FileStream(
+                                            Path.GetTempFileName(),
+                                            FileMode.Create,
+                                            FileAccess.ReadWrite,
+                                            FileShare.None,
+                                            BufferSize,
+                                            FileOptions.DeleteOnClose | FileOptions.Asynchronous);
+
+                        await networkStream.CopyToAsync(packageStream, BufferSize, cancellationToken);
+                    }
+                }
+
+                packageStream.Position = 0;
+
+                _logger.LogInformation(
+                    "Downloaded {PackageSizeInBytes} bytes in {DownloadElapsedTime} seconds for request {PackageUri}",
+                    packageStream.Length,
+                    stopwatch.Elapsed.TotalSeconds,
+                    packageUri);
+
+                return packageStream;
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(
+                    Error.FailedToDownloadPackage,
+                    e,
+                    "Exception thrown when trying to download package from {PackageUri}",
+                    packageUri);
+
+                packageStream?.Dispose();
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/Validation.Common.Job/SubcriptionProcessorJob.cs
+++ b/src/Validation.Common.Job/SubcriptionProcessorJob.cs
@@ -9,7 +9,7 @@ using NuGet.Services.ServiceBus;
 
 namespace NuGet.Jobs.Validation
 {
-    public abstract class SubcriptionProcessorJob<T> : ValidationJob
+    public abstract class SubcriptionProcessorJob<T> : JsonConfigurationJob
     {
         /// <summary>
         /// The maximum amount of time that graceful shutdown can take before the job will

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -38,6 +38,8 @@
   <ItemGroup>
     <Compile Include="Error.cs" />
     <Compile Include="ExceptionExtensions.cs" />
+    <Compile Include="IPackageDownloader.cs" />
+    <Compile Include="PackageDownloader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\AddStatusResult.cs" />
     <Compile Include="Storage\IValidatorStateService.cs" />
@@ -46,7 +48,7 @@
     <Compile Include="Storage\ValidatorStateService.cs" />
     <Compile Include="Storage\ValidatorStatusExtensions.cs" />
     <Compile Include="SubcriptionProcessorJob.cs" />
-    <Compile Include="ValidationJob.cs" />
+    <Compile Include="JsonConfigurationJob.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac">
@@ -64,6 +66,9 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
       <Version>1.1.2</Version>
     </PackageReference>
+    <PackageReference Include="NuGet.Packaging">
+      <Version>4.7.0-preview1-4886</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.14.0</Version>
     </PackageReference>
@@ -77,7 +82,7 @@
       <Version>2.14.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.4-dev-19677</Version>
+      <Version>4.4.4-dev-23300</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>


### PR DESCRIPTION
This tool:

1. Downloads a package from packages container
1. Hashes it with SHA-512
1. Compares the hash against the gallery DB value.

Other things:

1. The tool has a cursor, currently persisted to disk.
1. Discrepancies are written to disk in a CSV file.
1. Partitioning feature allowing the job to be run on multiple machines, consistent hash on ID+version.
1. I go directly against packages container to avoid accidental download counts. This also will work better in the future when we want to scan China's flat container.
1. I moved the package download logic from E&V to a common place.

This tool is not meant to be deployed by I wrote the lower level components so they could be reused later.

I plan on writing unit tests as a follow-up PR. Since this is big already.

If this PR is too big as-is, let me know and I can try to split it in two.