### PR TITLE
[Orchestrator] Add maximum retry count for missing packages

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -179,10 +179,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IValidationSetProvider, ValidationSetProvider>();
             services.AddTransient<IMessageHandler<PackageValidationMessageData>>(serviceProvider =>
             {
-                var configuration = serviceProvider.GetRequiredService<IOptionsSnapshot<ValidationConfiguration>>().Value;
-
-                int missingPackageRetryCount = configuration.MissingPackageRetryCount;
-
+                var configuration = serviceProvider.GetRequiredService<IOptionsSnapshot<ValidationConfiguration>>();
                 var galleryPackageService = serviceProvider.GetRequiredService<NuGetGallery.ICorePackageService>();
                 var validationSetProvider = serviceProvider.GetRequiredService<IValidationSetProvider>();
                 var validationSetProcessor = serviceProvider.GetRequiredService<IValidationSetProcessor>();
@@ -190,7 +187,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 var logger = serviceProvider.GetRequiredService<ILogger<ValidationMessageHandler>>();
 
                 return new ValidationMessageHandler(
-                    missingPackageRetryCount,
+                    configuration.Value,
                     galleryPackageService,
                     validationSetProvider,
                     validationSetProcessor,

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -177,25 +177,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IPackageValidationEnqueuer, PackageValidationEnqueuer>();
             services.AddTransient<IValidatorProvider, ValidatorProvider>();
             services.AddTransient<IValidationSetProvider, ValidationSetProvider>();
-            services.AddTransient<IMessageHandler<PackageValidationMessageData>>(serviceProvider =>
-            {
-                var configuration = serviceProvider.GetRequiredService<IOptionsSnapshot<ValidationConfiguration>>();
-                var galleryPackageService = serviceProvider.GetRequiredService<NuGetGallery.ICorePackageService>();
-                var validationSetProvider = serviceProvider.GetRequiredService<IValidationSetProvider>();
-                var validationSetProcessor = serviceProvider.GetRequiredService<IValidationSetProcessor>();
-                var validationOutcomeProcessor = serviceProvider.GetRequiredService<IValidationOutcomeProcessor>();
-                var telemetryService = serviceProvider.GetRequiredService<ITelemetryService>();
-                var logger = serviceProvider.GetRequiredService<ILogger<ValidationMessageHandler>>();
-
-                return new ValidationMessageHandler(
-                    configuration.Value,
-                    galleryPackageService,
-                    validationSetProvider,
-                    validationSetProcessor,
-                    validationOutcomeProcessor,
-                    telemetryService,
-                    logger);
-            });
+            services.AddTransient<IMessageHandler<PackageValidationMessageData>, ValidationMessageHandler>();
             services.AddTransient<IServiceBusMessageSerializer, ServiceBusMessageSerializer>();
             services.AddTransient<IBrokeredMessageSerializer<PackageValidationMessageData>, PackageValidationMessageDataSerializationAdapter>();
             services.AddTransient<IPackageCriteriaEvaluator, PackageCriteriaEvaluator>();

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -184,6 +184,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 var validationSetProvider = serviceProvider.GetRequiredService<IValidationSetProvider>();
                 var validationSetProcessor = serviceProvider.GetRequiredService<IValidationSetProcessor>();
                 var validationOutcomeProcessor = serviceProvider.GetRequiredService<IValidationOutcomeProcessor>();
+                var telemetryService = serviceProvider.GetRequiredService<ITelemetryService>();
                 var logger = serviceProvider.GetRequiredService<ILogger<ValidationMessageHandler>>();
 
                 return new ValidationMessageHandler(
@@ -192,6 +193,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     validationSetProvider,
                     validationSetProcessor,
                     validationOutcomeProcessor,
+                    telemetryService,
                     logger);
             });
             services.AddTransient<IServiceBusMessageSerializer, ServiceBusMessageSerializer>();

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -102,7 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.14.0</Version>
+      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -102,7 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
+      <Version>2.15.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/Program.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Program.cs
@@ -8,8 +8,6 @@ namespace NuGet.Services.Validation.Orchestrator
 {
     class Program
     {
-        private const string LoggingCategory = "Validation.Orchestrator";
-
         static int Main(string[] args)
         {
             if (!args.Contains(JobArgumentNames.Once))
@@ -17,7 +15,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 args = args.Concat(new[] { "-" + JobArgumentNames.Once }).ToArray();
             }
             var job = new Job();
-            JobRunner.Run(job, args).Wait();
+            JobRunner.Run(job, args).GetAwaiter().GetResult();
 
             // if configuration validation failed, return non-zero status so we can detect failures in automation
             return job.ConfigurationValidated ? 0 : 1;

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -80,6 +80,13 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         void TrackClientValidationIssue(string validatorType, string clientCode);
 
         /// <summary>
+        /// A counter metric emitted when the orchestrator is requested to validate a package,
+        /// but, the package does not exist in the Gallery database even after <see cref="ValidationConfiguration.MissingPackageRetryCount"/>
+        /// retries.
+        /// </summary>
+        void TrackMissingPackageForValidationMessage(string packageId, string normalizedVersion, string validationTrackingId);
+
+        /// <summary>
         /// A metric for the case when orchestrator sees a package marked as available, but the blob is missing
         /// in the public container.
         /// </summary>

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -21,6 +21,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string ValidatorDurationSeconds = Prefix + "ValidatorDurationSeconds";
         private const string ValidatorStarted = Prefix + "ValidatorStarted";
         private const string ClientValidationIssue = Prefix + "ClientValidationIssue";
+        private const string MissingPackageForValidationMessage = Prefix + "MissingPackageForValidationMessage";
         private const string MissingNupkgForAvailablePackage = Prefix + "MissingNupkgForAvailablePackage";
 
         private const string FromStatus = "FromStatus";
@@ -139,6 +140,17 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                     { ClientCode, clientCode },
                 });
         }
+
+        public void TrackMissingPackageForValidationMessage(string packageId, string normalizedVersion, string validationTrackingId)
+            => _telemetryClient.TrackMetric(
+                    MissingPackageForValidationMessage,
+                    1,
+                    new Dictionary<string, string>
+                    {
+                        { PackageId, packageId },
+                        { NormalizedVersion, normalizedVersion },
+                        { ValidationTrackingId, validationTrackingId },
+                    });
 
         public void TrackMissingNupkgForAvailablePackage(string packageId, string normalizedVersion, string validationTrackingId)
             => _telemetryClient.TrackMetric(

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationConfiguration.cs
@@ -22,6 +22,12 @@ namespace NuGet.Services.Validation.Orchestrator
         public string ValidationStorageConnectionString { get; set; }
 
         /// <summary>
+        /// How many times the Orchestrator should retry to validate a package
+        /// that is missing from the Gallery database.
+        /// </summary>
+        public int MissingPackageRetryCount { get; set; }
+
+        /// <summary>
         /// Time to wait between checking the state of a certain validation.
         /// </summary>
         public TimeSpan ValidationMessageRecheckPeriod { get; set; }

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationMessageHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.ServiceBus;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
 using NuGetGallery;
 
 namespace NuGet.Services.Validation.Orchestrator
@@ -16,6 +17,7 @@ namespace NuGet.Services.Validation.Orchestrator
         private readonly IValidationSetProvider _validationSetProvider;
         private readonly IValidationSetProcessor _validationSetProcessor;
         private readonly IValidationOutcomeProcessor _validationOutcomeProcessor;
+        private readonly ITelemetryService _telemetryService;
         private readonly ILogger<ValidationMessageHandler> _logger;
 
         public ValidationMessageHandler(
@@ -24,6 +26,7 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidationSetProvider validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
             IValidationOutcomeProcessor validationOutcomeProcessor,
+            ITelemetryService telemetryService,
             ILogger<ValidationMessageHandler> logger)
         {
             if (configs == null)
@@ -43,6 +46,7 @@ namespace NuGet.Services.Validation.Orchestrator
             _validationSetProvider = validationSetProvider ?? throw new ArgumentNullException(nameof(validationSetProvider));
             _validationSetProcessor = validationSetProcessor ?? throw new ArgumentNullException(nameof(validationSetProcessor));
             _validationOutcomeProcessor = validationOutcomeProcessor ?? throw new ArgumentNullException(nameof(validationOutcomeProcessor));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -69,6 +73,11 @@ namespace NuGet.Services.Validation.Orchestrator
                             message.PackageId,
                             message.PackageVersion,
                             message.DeliveryCount);
+
+                        _telemetryService.TrackMissingPackageForValidationMessage(
+                            message.PackageId,
+                            message.PackageVersion,
+                            message.ValidationTrackingId.ToString());
 
                         return true;
                     }

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -10,9 +10,9 @@
       }
     ],
     "ValidationStorageConnectionString": "",
-    "MissingPackageRetryCount":  2,
+    "MissingPackageRetryCount":  15,
     "ValidationMessageRecheckPeriod": "00:01:00",
-    "NewValidationRequestDeduplicationWindow": "00:10:00"
+    "NewValidationRequestDeduplicationWindow": "00:20:00"
   },
   "Vcs": {
     "ContainerName": "validation",

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -10,6 +10,7 @@
       }
     ],
     "ValidationStorageConnectionString": "",
+    "MissingPackageRetryCount":  2,
     "ValidationMessageRecheckPeriod": "00:01:00",
     "NewValidationRequestDeduplicationWindow": "00:10:00"
   },

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -79,7 +79,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
+      <Version>2.15.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -79,7 +79,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.14.0</Version>
+      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -70,16 +70,16 @@
       <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.14.0</Version>
+      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.14.0</Version>
+      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.14.0</Version>
+      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.14.0</Version>
+      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-23300</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -70,16 +70,16 @@
       <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
+      <Version>2.15.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
+      <Version>2.15.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
+      <Version>2.15.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
+      <Version>2.15.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-23300</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -69,7 +69,7 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.14.0</Version>
+      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -69,7 +69,7 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.15.0-loshar-orc-deliverycount-23388</Version>
+      <Version>2.15.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -177,7 +177,10 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
     public class ValidationMessageHandlerFactsBase
     {
-        protected const int MissingPackageRetryCount = 2;
+        protected static readonly ValidationConfiguration Configuration = new ValidationConfiguration
+        {
+            MissingPackageRetryCount = 2,
+        };
 
         protected Mock<ICorePackageService> CorePackageServiceMock { get; }
         protected Mock<IValidationSetProvider> ValidationSetProviderMock { get; }
@@ -197,7 +200,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         public ValidationMessageHandler CreateHandler()
         {
             return new ValidationMessageHandler(
-                MissingPackageRetryCount,
+                Configuration,
                 CorePackageServiceMock.Object,
                 ValidationSetProviderMock.Object,
                 ValidationSetProcessorMock.Object,

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -122,6 +122,9 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             public IDictionary<string, object> Properties => _inner.Properties;
 
             public DateTimeOffset ScheduledEnqueueTimeUtc { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public DateTimeOffset ExpiresAtUtc => throw new NotImplementedException();
+            public DateTimeOffset EnqueuedTimeUtc => throw new NotImplementedException();
+
             public Task AbandonAsync() => throw new NotImplementedException();
             public IBrokeredMessage Clone() => throw new NotImplementedException();
             public Task CompleteAsync() => throw new NotImplementedException();

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
@@ -188,6 +189,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             MissingPackageRetryCount = 2,
         };
 
+        protected Mock<IOptionsSnapshot<ValidationConfiguration>> ConfigurationAccessorMock { get; }
         protected Mock<ICorePackageService> CorePackageServiceMock { get; }
         protected Mock<IValidationSetProvider> ValidationSetProviderMock { get; }
         protected Mock<IValidationSetProcessor> ValidationSetProcessorMock { get; }
@@ -197,18 +199,23 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
         public ValidationMessageHandlerFactsBase(MockBehavior mockBehavior)
         {
+            ConfigurationAccessorMock = new Mock<IOptionsSnapshot<ValidationConfiguration>>();
             CorePackageServiceMock = new Mock<ICorePackageService>(mockBehavior);
             ValidationSetProviderMock = new Mock<IValidationSetProvider>(mockBehavior);
             ValidationSetProcessorMock = new Mock<IValidationSetProcessor>(mockBehavior);
             ValidationOutcomeProcessorMock = new Mock<IValidationOutcomeProcessor>(mockBehavior);
             TelemetryServiceMock = new Mock<ITelemetryService>(mockBehavior);
             LoggerMock = new Mock<ILogger<ValidationMessageHandler>>(); // we generally don't care about how logger is called, so it's loose all the time
+
+            ConfigurationAccessorMock
+                .SetupGet(ca => ca.Value)
+                .Returns(Configuration);
         }
 
         public ValidationMessageHandler CreateHandler()
         {
             return new ValidationMessageHandler(
-                Configuration,
+                ConfigurationAccessorMock.Object,
                 CorePackageServiceMock.Object,
                 ValidationSetProviderMock.Object,
                 ValidationSetProcessorMock.Object,


### PR DESCRIPTION
## Intro 

The Gallery requests validations before it persists packages to the Gallery database. This means that if the database commit fails, the Orchestrator will a message to validate an nonexistent package. This change adds a maximum retry count for packages that are missing from the Gallery database. 

Progress on https://github.com/NuGet/Engineering/issues/1100
Depends on https://github.com/NuGet/ServerCommon/pull/137

## Supporting Data

I ran the following Application Insights query:

```
traces
| where message contains "Starting Enqueuing asynchronous package validation"
| join (requests | where name == "POST Packages/VerifyPackage" or name == "PUT Api/PushPackageApi" | project requestTimestamp = timestamp, duration, operation_Id) on operation_Id 
| project requestTimestamp, validationTimestamp = timestamp, duration
| extend timeToEnqueue = ((validationTimestamp - requestTimestamp)/ time(1ms))
| extend timeAfterEnqueue = duration - timeToEnqueue
| summarize percentiles(timeAfterEnqueue, 99, 99.9, 99.99), max(timeAfterEnqueue)
```

This `timeAfterEnqueue` is the time upload requests spend after the validation message has been enqueued. This includes both the database commit and the package upload to the validation container. The breakdown for `timeAfterEnqueue` for ALL requests (including failed ones) since December 1st is:

99% | 99.9% | 99.99% | Max
--- | --- | --- | ---
38s (38,687ms) | 2.5m (152,961ms) | 6.7m (399,178ms) | 13.9m (831,157ms)

From this, it seems that the maximum validation time for the Orchestrator should be raised to 20 minutes and there should be 15 retries of missing packages.

