### PR TITLE
Using SmtpUri to process SMTP credentials consistent with other jobs

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/SmtpConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/SmtpConfiguration.cs
@@ -5,10 +5,6 @@ namespace NuGet.Services.Validation.Orchestrator
 {
     public class SmtpConfiguration
     {
-        public string SmtpHost { get; set; }
-        public int SmtpPort { get; set; }
-        public bool EnableSsl { get; set; }
-        public string Username { get; set; }
-        public string Password { get; set; }
+        public string SmtpUri { get; set; }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -197,7 +197,9 @@ namespace NuGet.Services.Validation.Orchestrator
                     Port = smtpConfiguration.SmtpPort,
                     EnableSsl = smtpConfiguration.EnableSsl,
                     UseDefaultCredentials = false,
-                    Credentials = new NetworkCredential(smtpConfiguration.Username, smtpConfiguration.Password)
+                    Credentials = new NetworkCredential(
+                        WebUtility.UrlDecode(smtpConfiguration.Username),
+                        WebUtility.UrlDecode(smtpConfiguration.Password))
                 };
             });
             services.AddTransient<IMailSender>(serviceProvider =>

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -190,16 +190,21 @@ namespace NuGet.Services.Validation.Orchestrator
             {
                 var smtpConfigurationAccessor = serviceProvider.GetRequiredService<IOptionsSnapshot<SmtpConfiguration>>();
                 var smtpConfiguration = smtpConfigurationAccessor.Value;
+                if (string.IsNullOrWhiteSpace(smtpConfiguration.SmtpUri))
+                {
+                    return new MailSenderConfiguration();
+                }
+                var smtpUri = new SmtpUri(new Uri(smtpConfiguration.SmtpUri));
                 return new MailSenderConfiguration
                 {
                     DeliveryMethod = System.Net.Mail.SmtpDeliveryMethod.Network,
-                    Host = smtpConfiguration.SmtpHost,
-                    Port = smtpConfiguration.SmtpPort,
-                    EnableSsl = smtpConfiguration.EnableSsl,
+                    Host = smtpUri.Host,
+                    Port = smtpUri.Port,
+                    EnableSsl = smtpUri.Secure,
                     UseDefaultCredentials = false,
                     Credentials = new NetworkCredential(
-                        WebUtility.UrlDecode(smtpConfiguration.Username),
-                        WebUtility.UrlDecode(smtpConfiguration.Password))
+                        smtpUri.UserName,
+                        smtpUri.Password)
                 };
             });
             services.AddTransient<IMailSender>(serviceProvider =>

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -71,6 +71,7 @@
     "SubscriptionName": ""
   },
   "Smtp": {
+    "SmtpUri": "",
     "SmtpHost": "",
     "SmtpPort": "587",
     "EnableSsl": "true",

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -71,12 +71,7 @@
     "SubscriptionName": ""
   },
   "Smtp": {
-    "SmtpUri": "",
-    "SmtpHost": "",
-    "SmtpPort": "587",
-    "EnableSsl": "true",
-    "Username": "",
-    "Password": ""
+    "SmtpUri": ""
   },
   "Email": {
     "GalleryOwner": "NuGet Gallery <support@nuget.org>",


### PR DESCRIPTION
Didn't notice initially that we had a copy of `SmtpUri` class in the `NuGet.Jobs.Common` from the Gallery. Fixing to make it consistent with other jobs.

Addresses https://github.com/NuGet/Engineering/issues/1220

[X] Needs deployment configuration update.