### PR TITLE
Give each validation set its own copy of the package using server-side copy

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    public interface IValidationPackageFileService : ICorePackageFileService
+    {
+        /// <summary>
+        /// Copy a package from the validation container to a location specific for the validation set. This allows the
+        /// validation set to have its own copy of the package to mutate (via <see cref="IProcessor"/>) and validate.
+        /// </summary>
+        /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
+        Task CopyValidationPackageForValidationSetAsync(PackageValidationSet validationSet);
+
+        /// <summary>
+        /// Copy a package from the packages container to a location specific for the validation set. This allows the
+        /// validation set to have its own copy of the package to mutate (via <see cref="IProcessor"/>) and validate.
+        /// </summary>
+        /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
+        Task CopyPackageFileForValidationSetAsync(PackageValidationSet validationSet);
+
+        /// <summary>
+        /// Copy a package from a location specific for the validation set to the packages container.
+        /// </summary>
+        /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
+        Task CopyValidationSetPackageToPackageFileAsync(PackageValidationSet validationSet);
+
+        /// <summary>
+        /// Copy a package from the validation container to the packages container.
+        /// </summary>
+        /// <param name="id">The package ID.</param>
+        /// <param name="normalizedVersion">The normalized package version.</param>
+        Task CopyValidationPackageToPackageFileAsync(string id, string normalizedVersion);
+
+        /// <summary>
+        /// Delete a package from a location specific for the validation set.
+        /// </summary>
+        /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
+        Task DeletePackageForValidationSetAsync(PackageValidationSet validationSet);
+
+        /// <summary>
+        /// Generates the URI for the specified validating package, which can be used to download it.
+        /// </summary>
+        /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
+        /// <param name="endOfAccess">The timestamp that limits the URI usage period.</param>
+        /// <returns>Time limited (if implementation supports) URI for the package.</returns>
+        Task<Uri> GetPackageForValidationSetReadUriAsync(PackageValidationSet validationSet, DateTimeOffset endOfAccess);
+
+        /// <summary>
+        /// Checks whether the validation set's package file exists.
+        /// </summary>
+        /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
+        /// <returns>True if file exists, false otherwise</returns>
+        Task<bool> DoesValidationSetPackageExistAsync(PackageValidationSet validationSet);
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -287,7 +287,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     parameterKey: ValidationStorageBindingKey);
 
             containerBuilder
-                .RegisterKeyedTypeWithKeyedParameter<NuGetGallery.ICorePackageFileService, NuGetGallery.CorePackageFileService, NuGetGallery.ICoreFileStorageService>(
+                .RegisterKeyedTypeWithKeyedParameter<IValidationPackageFileService, ValidationPackageFileService, NuGetGallery.ICoreFileStorageService>(
                     typeKey: ValidationStorageBindingKey,
                     parameterKey: ValidationStorageBindingKey);
 
@@ -295,13 +295,19 @@ namespace NuGet.Services.Validation.Orchestrator
                 .RegisterTypeWithKeyedParameter<
                     IValidationOutcomeProcessor,
                     ValidationOutcomeProcessor,
-                    NuGetGallery.ICorePackageFileService>(ValidationStorageBindingKey);
+                    IValidationPackageFileService>(ValidationStorageBindingKey);
+
+            containerBuilder
+                .RegisterTypeWithKeyedParameter<
+                    IValidationSetProvider,
+                    ValidationSetProvider,
+                    IValidationPackageFileService>(ValidationStorageBindingKey);
 
             containerBuilder
                 .RegisterTypeWithKeyedParameter<
                     IValidationSetProcessor,
                     ValidationSetProcessor,
-                    NuGetGallery.ICorePackageFileService>(ValidationStorageBindingKey);
+                    IValidationPackageFileService>(ValidationStorageBindingKey);
 
             containerBuilder
                 .RegisterType<ScopedMessageHandler<PackageValidationMessageData>>()

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Error.cs" />
     <Compile Include="IMessageService.cs" />
     <Compile Include="IValidationOutcomeProcessor.cs" />
+    <Compile Include="IValidationPackageFileService.cs" />
     <Compile Include="IValidationSetProcessor.cs" />
     <Compile Include="IValidationSetProvider.cs" />
     <Compile Include="IValidationStorageService.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="Configuration\ValidationConfiguration.cs" />
     <Compile Include="Configuration\ValidationConfigurationItem.cs" />
     <Compile Include="ValidationFailureBehavior.cs" />
+    <Compile Include="ValidationPackageFileService.cs" />
     <Compile Include="Vcs\IPackageCriteria.cs" />
     <Compile Include="Vcs\IPackageCriteriaEvaluator.cs" />
     <Compile Include="Vcs\PackageCriteriaEvaluator.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    public class ValidationPackageFileService : CorePackageFileService, IValidationPackageFileService
+    {
+        private readonly ICoreFileStorageService _fileStorageService;
+        private readonly ILogger<ValidationPackageFileService> _logger;
+
+        public ValidationPackageFileService(
+            ICoreFileStorageService fileStorageService,
+            ILogger<ValidationPackageFileService> logger) : base(fileStorageService)
+        {
+            _fileStorageService = fileStorageService ?? throw new ArgumentNullException(nameof(fileStorageService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task CopyValidationPackageForValidationSetAsync(PackageValidationSet validationSet)
+        {
+            var srcFileName = BuildFileName(
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+
+            return CopyFileAsync(
+                CoreConstants.ValidationFolderName,
+                srcFileName,
+                CoreConstants.ValidationFolderName,
+                BuildValidationSetPackageFileName(validationSet));
+        }
+
+        public Task CopyPackageFileForValidationSetAsync(PackageValidationSet validationSet)
+        {
+            var srcFileName = BuildFileName(
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+
+            return CopyFileAsync(
+                CoreConstants.PackagesFolderName,
+                srcFileName,
+                CoreConstants.ValidationFolderName,
+                BuildValidationSetPackageFileName(validationSet));
+        }
+
+        public Task CopyValidationPackageToPackageFileAsync(string id, string normalizedVersion)
+        {
+            var fileName = BuildFileName(
+                id,
+                normalizedVersion,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+
+            return CopyFileAsync(
+                CoreConstants.ValidationFolderName,
+                fileName,
+                CoreConstants.PackagesFolderName,
+                fileName);
+        }
+
+        public Task CopyValidationSetPackageToPackageFileAsync(PackageValidationSet validationSet)
+        {
+            var srcFileName = BuildValidationSetPackageFileName(validationSet);
+
+            var destFileName = BuildFileName(
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion,
+                CoreConstants.PackageFileSavePathTemplate,
+                CoreConstants.NuGetPackageFileExtension);
+
+            return CopyFileAsync(
+                CoreConstants.ValidationFolderName,
+                srcFileName,
+                CoreConstants.PackagesFolderName,
+                destFileName);
+        }
+
+        public Task<bool> DoesValidationSetPackageExistAsync(PackageValidationSet validationSet)
+        {
+            var fileName = BuildValidationSetPackageFileName(validationSet);
+            
+            return _fileStorageService.FileExistsAsync(CoreConstants.ValidationFolderName, fileName);
+        }
+
+        public Task DeletePackageForValidationSetAsync(PackageValidationSet validationSet)
+        {
+            var fileName = BuildValidationSetPackageFileName(validationSet);
+
+            _logger.LogInformation(
+                "Deleting package for validation set {ValidationTrackingId} from {FolderName}/{FileName}.",
+                validationSet.ValidationTrackingId,
+                CoreConstants.ValidationFolderName,
+                fileName);
+
+            return _fileStorageService.DeleteFileAsync(CoreConstants.ValidationFolderName, fileName);
+        }
+
+        public Task<Uri> GetPackageForValidationSetReadUriAsync(PackageValidationSet validationSet, DateTimeOffset endOfAccess)
+        {
+            var fileName = BuildValidationSetPackageFileName(validationSet);
+
+            return _fileStorageService.GetFileReadUriAsync(CoreConstants.ValidationFolderName, fileName, endOfAccess);
+        }
+
+        private Task CopyFileAsync(string srcFolderName, string srcFileName, string destFolderName, string destFileName)
+        {
+            _logger.LogInformation(
+                "Copying file {SrcFolderName}/{SrcFileName} to {DestFolderName}/{DestFileName}.",
+                srcFolderName,
+                srcFileName,
+                destFolderName,
+                destFileName);
+
+            return _fileStorageService.CopyFileAsync(
+                srcFolderName,
+                srcFileName,
+                destFolderName,
+                destFileName);
+        }
+
+        private static string BuildValidationSetPackageFileName(PackageValidationSet validationSet)
+        {
+            return $"validation-sets/{validationSet.ValidationTrackingId}/" +
+                $"{validationSet.PackageId.ToLowerInvariant()}." +
+                $"{validationSet.PackageNormalizedVersion.ToLowerInvariant()}" +
+                CoreConstants.NuGetPackageFileExtension;
+        }
+    }
+}

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -82,7 +82,7 @@
       <Version>2.17.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.4-dev-23300</Version>
+      <Version>4.4.4-dev-25129</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ValidationMessageHandlerFacts.cs" />
     <Compile Include="ValidationOutcomeProcessorFacts.cs" />
+    <Compile Include="ValidationPackageFileServiceFacts.cs" />
     <Compile Include="ValidationProviderFacts.cs" />
     <Compile Include="ValidationSetProcessorFacts.cs" />
     <Compile Include="ValidationSetProviderFacts.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGetGallery;
+using Xunit;
+
+namespace NuGet.Services.Validation.Orchestrator.Tests
+{
+    public class ValidationPackageFileServiceFacts
+    {
+        private readonly PackageValidationSet _validationSet;
+        private readonly string _validationContainerName;
+        private readonly string _packagesContainerName;
+        private readonly string _packageFileName;
+        private readonly string _validationSetPackageFileName;
+        private readonly Mock<ICoreFileStorageService> _fileStorageService;
+        private readonly Mock<ILogger<ValidationPackageFileService>> _logger;
+        private readonly ValidationPackageFileService _target;
+
+        public ValidationPackageFileServiceFacts()
+        {
+            _validationSet = new PackageValidationSet
+            {
+                ValidationTrackingId = new Guid("0b44d53f-0689-4f82-9530-f25f26b321aa"),
+                PackageId = "NuGet.Versioning",
+                PackageNormalizedVersion = "4.5.0-ALPHA",
+            };
+
+            _packagesContainerName = "packages";
+            _validationContainerName = "validation";
+            _packageFileName = "nuget.versioning.4.5.0-alpha.nupkg";
+            _validationSetPackageFileName = "validation-sets/0b44d53f-0689-4f82-9530-f25f26b321aa/nuget.versioning.4.5.0-alpha.nupkg";
+
+            _fileStorageService = new Mock<ICoreFileStorageService>(MockBehavior.Strict);
+            _logger = new Mock<ILogger<ValidationPackageFileService>>();
+            _target = new ValidationPackageFileService(_fileStorageService.Object, _logger.Object);
+        }
+
+        [Fact]
+        public async Task CopyValidationPackageForValidationSetAsync()
+        {
+            _fileStorageService
+                .Setup(x => x.CopyFileAsync(
+                    _validationContainerName,
+                    _packageFileName,
+                    _validationContainerName,
+                    _validationSetPackageFileName))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            await _target.CopyValidationPackageForValidationSetAsync(_validationSet);
+
+            _fileStorageService.Verify();
+        }
+
+        [Fact]
+        public async Task CopyPackageFileForValidationSetAsync()
+        {
+            _fileStorageService
+                .Setup(x => x.CopyFileAsync(
+                    _packagesContainerName,
+                    _packageFileName,
+                    _validationContainerName,
+                    _validationSetPackageFileName))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            await _target.CopyPackageFileForValidationSetAsync(_validationSet);
+
+            _fileStorageService.Verify();
+        }
+
+        [Fact]
+        public async Task CopyValidationPackageToPackageFileAsync()
+        {
+            _fileStorageService
+                .Setup(x => x.CopyFileAsync(
+                    _validationContainerName,
+                    _packageFileName,
+                    _packagesContainerName,
+                    _packageFileName))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            await _target.CopyValidationPackageToPackageFileAsync(_validationSet.PackageId, _validationSet.PackageNormalizedVersion);
+
+            _fileStorageService.Verify();
+        }
+
+        [Fact]
+        public async Task DoesValidationSetPackageExistAsync()
+        {
+            _fileStorageService
+                .Setup(x => x.FileExistsAsync(
+                    _validationContainerName,
+                    _validationSetPackageFileName))
+                .ReturnsAsync(true)
+                .Verifiable();
+
+            var exists = await _target.DoesValidationSetPackageExistAsync(_validationSet);
+
+            Assert.True(exists);
+            _fileStorageService.Verify();
+        }
+
+        [Fact]
+        public async Task CopyValidationSetPackageToPackageFileAsync()
+        {
+            _fileStorageService
+                .Setup(x => x.CopyFileAsync(
+                    _validationContainerName,
+                    _validationSetPackageFileName,
+                    _packagesContainerName,
+                    _packageFileName))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            await _target.CopyValidationSetPackageToPackageFileAsync(_validationSet);
+            
+            _fileStorageService.Verify();
+        }
+
+        [Fact]
+        public async Task DeletePackageForValidationSetAsync()
+        {
+            _fileStorageService
+                .Setup(x => x.DeleteFileAsync(
+                    _validationContainerName,
+                    _validationSetPackageFileName))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            await _target.DeletePackageForValidationSetAsync(_validationSet);
+
+            _fileStorageService.Verify();
+        }
+
+        [Fact]
+        public async Task GetPackageForValidationSetReadUriAsync()
+        {
+            var endOfAccess = new DateTimeOffset(2018, 1, 3, 8, 30, 0, TimeSpan.Zero);
+            var expected = new Uri("http://example.com/nupkg.nupkg");
+            _fileStorageService
+                .Setup(x => x.GetFileReadUriAsync(
+                    _validationContainerName,
+                    _validationSetPackageFileName,
+                    endOfAccess))
+                .ReturnsAsync(expected)
+                .Verifiable();
+
+            var actual = await _target.GetPackageForValidationSetReadUriAsync(_validationSet, endOfAccess);
+
+            Assert.Equal(expected, actual);
+            _fileStorageService.Verify();
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1190
Address https://github.com/NuGet/Engineering/issues/1030

Each validation set gets its own copy of the package. This means that concurrent validation sets cannot step on each others toes when mutating packages. As an added bonus, this fixes a pre-existing bug where on validation set moving a package to Available would cause another to fail since the `validation` container URL is no longer valid).