### PR TITLE
Extract gallery DB and packages container update logic

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/IPackageStatusProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IPackageStatusProcessor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    /// <summary>
+    /// This interface manages the state of gallery artifacts: gallery DB and packages container.
+    /// </summary>
+    public interface IPackageStatusProcessor
+    {
+        Task SetPackageStatusAsync(
+            Package package,
+            PackageValidationSet validationSet,
+            PackageStatus packageStatus);
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Configuration\EmailConfiguration.cs" />
     <Compile Include="Error.cs" />
     <Compile Include="IMessageService.cs" />
+    <Compile Include="IPackageStatusProcessor.cs" />
     <Compile Include="IValidationOutcomeProcessor.cs" />
     <Compile Include="IValidationPackageFileService.cs" />
     <Compile Include="IValidationSetProcessor.cs" />
@@ -70,6 +71,7 @@
     <Compile Include="PackageSigning\PackageSignatureVerificationEnqueuer.cs" />
     <Compile Include="PackageSigning\PackageSigningConfiguration.cs" />
     <Compile Include="PackageSigning\PackageSigningValidator.cs" />
+    <Compile Include="PackageStatusProcessor.cs" />
     <Compile Include="PackageValidationMessageDataSerializer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    public class PackageStatusProcessor : IPackageStatusProcessor
+    {
+        private readonly ICorePackageService _galleryPackageService;
+        private readonly IValidationPackageFileService _packageFileService;
+        private readonly ITelemetryService _telemetryService;
+        private readonly ILogger<PackageStatusProcessor> _logger;
+
+        public PackageStatusProcessor(
+            ICorePackageService galleryPackageService,
+            IValidationPackageFileService packageFileService,
+            ITelemetryService telemetryService,
+            ILogger<PackageStatusProcessor> logger)
+        {
+            _galleryPackageService = galleryPackageService ?? throw new ArgumentNullException(nameof(galleryPackageService));
+            _packageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task SetPackageStatusAsync(
+            Package package,
+            PackageValidationSet validationSet,
+            PackageStatus packageStatus)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (validationSet == null)
+            {
+                throw new ArgumentNullException(nameof(validationSet));
+            }
+
+            if (package.PackageStatusKey == PackageStatus.Deleted)
+            {
+                throw new ArgumentException(
+                    $"A package in the {nameof(PackageStatus.Deleted)} state cannot be processed.",
+                    nameof(package));
+            }
+
+            if (package.PackageStatusKey == PackageStatus.Available &&
+                packageStatus == PackageStatus.FailedValidation)
+            {
+                throw new ArgumentException(
+                    $"A package cannot transition from {nameof(PackageStatus.Available)} to {nameof(PackageStatus.FailedValidation)}.",
+                    nameof(packageStatus));
+            }
+
+            switch (packageStatus)
+            {
+                case PackageStatus.Available:
+                    return MakePackageAvailableAsync(package, validationSet);
+                case PackageStatus.FailedValidation:
+                    return MakePackageFailedValidationAsync(package, validationSet);
+                default:
+                    throw new ArgumentException(
+                        $"A package can only transition to the {nameof(PackageStatus.Available)} or " +
+                        $"{nameof(PackageStatus.FailedValidation)} states.", nameof(packageStatus));
+            }
+        }
+
+        private Task MakePackageFailedValidationAsync(Package package, PackageValidationSet validationSet)
+        {
+            return UpdatePackageStatusAsync(package, PackageStatus.FailedValidation);
+        }
+
+        private async Task MakePackageAvailableAsync(Package package, PackageValidationSet validationSet)
+        {
+            if (package.PackageStatusKey != PackageStatus.Available)
+            {
+                await MoveFileToPublicStorageAndMarkPackageAsAvailable(validationSet, package);
+            }
+            else
+            {
+                _logger.LogInformation("Package {PackageId} {PackageVersion} {ValidationSetId} was already available, not going to copy data and update DB",
+                    package.PackageRegistration.Id,
+                    package.NormalizedVersion,
+                    validationSet.ValidationTrackingId);
+
+                if (!await _packageFileService.DoesPackageFileExistAsync(package))
+                {
+                    var validationPackageAvailable = await _packageFileService.DoesValidationPackageFileExistAsync(package);
+
+                    _logger.LogWarning("Package {PackageId} {PackageVersion} is marked as available, but does not exist " +
+                        "in public container. Does package exist in validation container: {ExistsInValidation}",
+                        package.PackageRegistration.Id,
+                        package.NormalizedVersion,
+                        validationPackageAvailable);
+
+                    // Report missing package, don't try to fix up anything. This shouldn't happen and needs an investigation.
+                    _telemetryService.TrackMissingNupkgForAvailablePackage(
+                        validationSet.PackageId,
+                        validationSet.PackageNormalizedVersion,
+                        validationSet.ValidationTrackingId.ToString());
+                }
+            }
+        }
+
+        private async Task UpdatePackageStatusAsync(Package package, PackageStatus toStatus)
+        {
+            var fromStatus = package.PackageStatusKey;
+
+            await _galleryPackageService.UpdatePackageStatusAsync(package, toStatus, commitChanges: true);
+
+            if (fromStatus != toStatus)
+            {
+                _telemetryService.TrackPackageStatusChange(fromStatus, toStatus);
+            }
+        }
+
+        private async Task MoveFileToPublicStorageAndMarkPackageAsAvailable(PackageValidationSet validationSet, Package package)
+        {
+            _logger.LogInformation("Copying .nupkg to public storage for package {PackageId} {PackageVersion}, validation set {ValidationSetId}",
+                package.PackageRegistration.Id,
+                package.NormalizedVersion,
+                validationSet.ValidationTrackingId);
+
+            bool copied;
+            if (await _packageFileService.DoesValidationSetPackageExistAsync(validationSet))
+            {
+                copied = await CopyAsync(
+                    validationSet,
+                    package,
+                    x => _packageFileService.CopyValidationSetPackageToPackageFileAsync(x));
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "The package specific to the validation set does not exist. Falling back to the validation " +
+                    "container for package {PackageId} {PackageVersion}, validation set {ValidationSetId}",
+                    package.PackageRegistration.Id,
+                    package.NormalizedVersion,
+                    validationSet.ValidationTrackingId);
+
+                copied = await CopyAsync(
+                    validationSet,
+                    package,
+                    x => _packageFileService.CopyValidationPackageToPackageFileAsync(x.PackageId, x.PackageNormalizedVersion));
+            }
+
+            _logger.LogInformation("Marking package {PackageId} {PackageVersion}, validation set {ValidationSetId} as {PackageStatus} in DB",
+                package.PackageRegistration.Id,
+                package.NormalizedVersion,
+                validationSet.ValidationTrackingId,
+                PackageStatus.Available);
+
+            try
+            {
+                await UpdatePackageStatusAsync(package, PackageStatus.Available);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(
+                    Error.UpdatingPackageDbStatusFailed,
+                    e,
+                    "Failed to update package status in Gallery Db. Package {PackageId} {PackageVersion}, validation set {ValidationSetId}",
+                    package.PackageRegistration.Id,
+                    package.NormalizedVersion,
+                    validationSet.ValidationTrackingId);
+
+                // If this execution was not the one to copy the package, then don't delete the package on failure.
+                // This prevents the (unlikely) case where two actors attempt the DB update, one suceeds and one fails.
+                // We don't want an available package record with nothing in the packages container!
+                if (copied)
+                {
+                    await _packageFileService.DeletePackageFileAsync(package.PackageRegistration.Id, package.Version);
+                }
+
+                throw;
+            }
+            
+            _logger.LogInformation("Deleting from the source for package {PackageId} {PackageVersion}, validation set {ValidationSetId}",
+                package.PackageRegistration.Id,
+                package.NormalizedVersion,
+                validationSet.ValidationTrackingId);
+
+            await _packageFileService.DeleteValidationPackageFileAsync(package.PackageRegistration.Id, package.Version);
+        }
+
+        private async Task<bool> CopyAsync(PackageValidationSet validationSet, Package package, Func<PackageValidationSet, Task> copyAsync)
+        {
+            try
+            {
+                await copyAsync(validationSet);
+
+                return true;
+            }
+            catch (InvalidOperationException)
+            {
+                // The package already exists in the packages container. This can happen if the DB commit below fails
+                // and this flow is retried. We assume that the package content has not changed. Today there is no way
+                // for the content to change. Hard deletes (the one way a package ID and version can get different
+                // content) delete from both the packages and validating container so this can't be a mismatch.
+                _logger.LogInformation(
+                    "Package already exists in packages container for {PackageId} {PackageVersion}, validation set {ValidationSetId}",
+                    package.PackageRegistration.Id,
+                    package.NormalizedVersion,
+                    validationSet.ValidationTrackingId);
+
+                return false;
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="OrchestrationRunnerFacts.cs" />
     <Compile Include="PackageCertificates\PackageCertificatesValidatorFacts.cs" />
     <Compile Include="PackageSigning\PackageSigningValidatorFacts.cs" />
+    <Compile Include="PackageStatusProcessorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ValidationMessageHandlerFacts.cs" />
     <Compile Include="ValidationOutcomeProcessorFacts.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
@@ -1,0 +1,362 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+using NuGetGallery;
+using Xunit;
+
+namespace NuGet.Services.Validation.Orchestrator.Tests
+{
+    public class PackageStatusProcessorFacts
+    {
+        public class SetPackageStatusAsync : BaseFacts
+        {
+            [Theory]
+            [InlineData(PackageStatus.Deleted)]
+            [InlineData(PackageStatus.Validating)]
+            public async Task RejectsUnsupportedPackageStatus(PackageStatus packageStatus)
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => Target.SetPackageStatusAsync(Package, ValidationSet, packageStatus));
+
+                Assert.Equal("packageStatus", ex.ParamName);
+                Assert.Contains("A package can only transition to the Available or FailedValidation states.", ex.Message);
+            }
+
+            [Theory]
+            [InlineData(PackageStatus.Available)]
+            [InlineData(PackageStatus.FailedValidation)]
+            public async Task RejectsDeletedPackage(PackageStatus packageStatus)
+            {
+                Package.PackageStatusKey = PackageStatus.Deleted;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => Target.SetPackageStatusAsync(Package, ValidationSet, packageStatus));
+
+                Assert.Equal("package", ex.ParamName);
+                Assert.Contains("A package in the Deleted state cannot be processed.", ex.Message);
+            }
+
+            [Fact]
+            public async Task RejectsAvailableToFailedValidation()
+            {
+                Package.PackageStatusKey = PackageStatus.Available;
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(
+                    () => Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.FailedValidation));
+
+                Assert.Equal("packageStatus", ex.ParamName);
+                Assert.Contains("A package cannot transition from Available to FailedValidation.", ex.Message);
+            }
+
+            [Theory]
+            [InlineData(PackageStatus.Available, PackageStatus.Available)]
+            [InlineData(PackageStatus.Validating, PackageStatus.Available)]
+            [InlineData(PackageStatus.Validating, PackageStatus.FailedValidation)]
+            [InlineData(PackageStatus.FailedValidation, PackageStatus.Available)]
+            [InlineData(PackageStatus.FailedValidation, PackageStatus.FailedValidation)]
+            public async Task EmitsTelemetryOnStatusChange(PackageStatus fromStatus, PackageStatus toStatus)
+            {
+                Package.PackageStatusKey = fromStatus;
+
+                await Target.SetPackageStatusAsync(Package, ValidationSet, toStatus);
+
+                if (fromStatus != toStatus)
+                {
+                    TelemetryServiceMock.Verify(
+                        x => x.TrackPackageStatusChange(fromStatus, toStatus),
+                        Times.Once);
+                    TelemetryServiceMock.Verify(
+                        x => x.TrackPackageStatusChange(It.IsAny<PackageStatus>(), It.IsAny<PackageStatus>()),
+                        Times.Once);
+                }
+                else
+                {
+                    TelemetryServiceMock.Verify(
+                        x => x.TrackPackageStatusChange(It.IsAny<PackageStatus>(), It.IsAny<PackageStatus>()),
+                        Times.Never);
+                }
+            }
+        }
+
+        public class MakePackageAvailableAsync : BaseFacts
+        {
+            [Fact]
+            public async Task AllowsPackageAlreadyInPublicContainerWhenValidationSetPackageDoesNotExist()
+            {
+                PackageFileServiceMock
+                    .Setup(x => x.DoesValidationSetPackageExistAsync(It.IsAny<PackageValidationSet>()))
+                    .ReturnsAsync(false);
+                PackageFileServiceMock
+                    .Setup(x => x.CopyValidationPackageToPackageFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                    .Throws(new InvalidOperationException("Duplicate!"));
+                
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available);
+
+                PackageFileServiceMock.Verify(
+                    x => x.CopyValidationPackageToPackageFileAsync(Package.PackageRegistration.Id, Package.NormalizedVersion),
+                    Times.Once);
+                PackageServiceMock.Verify(
+                    x => x.UpdatePackageStatusAsync(Package, PackageStatus.Available, true),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task AllowsPackageAlreadyInPublicContainerWhenValidationSetPackageExists()
+            {
+                PackageFileServiceMock
+                    .Setup(x => x.DoesValidationSetPackageExistAsync(It.IsAny<PackageValidationSet>()))
+                    .ReturnsAsync(true);
+                PackageFileServiceMock
+                    .Setup(x => x.CopyValidationSetPackageToPackageFileAsync(It.IsAny<PackageValidationSet>()))
+                    .Throws(new InvalidOperationException("Duplicate!"));
+
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available);
+
+                PackageFileServiceMock.Verify(
+                    x => x.CopyValidationSetPackageToPackageFileAsync(ValidationSet),
+                    Times.Once);
+                PackageServiceMock.Verify(
+                    x => x.UpdatePackageStatusAsync(Package, PackageStatus.Available, true),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DoesNotCopyPackageIfItsAvailable()
+            {
+                Package.PackageStatusKey = PackageStatus.Available;
+                
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available);
+
+                PackageFileServiceMock.Verify(
+                    x => x.CopyValidationSetPackageToPackageFileAsync(It.IsAny<PackageValidationSet>()),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DeletesValidationPackageOnSuccess()
+            {
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available);
+
+                PackageFileServiceMock.Verify(
+                    x => x.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeleteValidationPackageFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DeletesPackageFromPublicStorageOnDbUpdateFailureIfCopied()
+            {
+                var expected = new Exception("Everything failed");
+                PackageServiceMock
+                    .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true))
+                    .Throws(expected);
+                
+                var actual = await Assert.ThrowsAsync<Exception>(
+                    () => Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available));
+
+                Assert.Same(expected, actual);
+                
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageFileAsync(Package.PackageRegistration.Id, Package.Version),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task DoesNotDeletePackageFromPublicStorageOnDbUpdateFailureIfNotCopied()
+            {
+                var expected = new Exception("Everything failed");
+                PackageServiceMock
+                    .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true))
+                    .Throws(expected);
+                PackageFileServiceMock
+                    .Setup(x => x.CopyValidationPackageToPackageFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                    .Throws(new InvalidOperationException("Duplicate!"));
+
+                var actual = await Assert.ThrowsAsync<Exception>(
+                    () => Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available));
+
+                Assert.Same(expected, actual);
+
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageFileAsync(It.IsAny<string>(), It.IsAny<string>()),
+                    Times.Never);
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task CopyDbUpdateDeleteInCorrectOrderWhenValidationSetPackageExists()
+            {
+                var operations = new List<string>();
+
+                PackageFileServiceMock
+                    .Setup(x => x.DoesValidationSetPackageExistAsync(ValidationSet))
+                    .ReturnsAsync(true)
+                    .Callback(() => operations.Add(nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync)));
+                PackageFileServiceMock
+                    .Setup(x => x.CopyValidationSetPackageToPackageFileAsync(ValidationSet))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() => operations.Add(nameof(IValidationPackageFileService.CopyValidationSetPackageToPackageFileAsync)));
+                PackageServiceMock
+                    .Setup(x => x.UpdatePackageStatusAsync(Package, PackageStatus.Available, true))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() => operations.Add(nameof(ICorePackageService.UpdatePackageStatusAsync)));
+                PackageFileServiceMock
+                    .Setup(x => x.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() => operations.Add(nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync)));
+                
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available);
+
+                var expectedOrder = new[]
+                {
+                    nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync),
+                    nameof(IValidationPackageFileService.CopyValidationSetPackageToPackageFileAsync),
+                    nameof(ICorePackageService.UpdatePackageStatusAsync),
+                    nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync),
+                };
+
+                Assert.Equal(expectedOrder, operations);
+            }
+
+            [Fact]
+            public async Task CopyDbUpdateDeleteInCorrectOrderWhenValidationSetPackageDoesNotExist()
+            {
+                var operations = new List<string>();
+
+                PackageFileServiceMock
+                    .Setup(x => x.DoesValidationSetPackageExistAsync(ValidationSet))
+                    .ReturnsAsync(false)
+                    .Callback(() => operations.Add(nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync)));
+                PackageFileServiceMock
+                    .Setup(x => x.CopyValidationPackageToPackageFileAsync(Package.PackageRegistration.Id, Package.NormalizedVersion))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() => operations.Add(nameof(IValidationPackageFileService.CopyValidationPackageToPackageFileAsync)));
+                PackageServiceMock
+                    .Setup(x => x.UpdatePackageStatusAsync(Package, PackageStatus.Available, true))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() => operations.Add(nameof(ICorePackageService.UpdatePackageStatusAsync)));
+                PackageFileServiceMock
+                    .Setup(x => x.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version))
+                    .Returns(Task.CompletedTask)
+                    .Callback(() => operations.Add(nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync)));
+                
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available);
+
+                var expectedOrder = new[]
+                {
+                    nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync),
+                    nameof(IValidationPackageFileService.CopyValidationPackageToPackageFileAsync),
+                    nameof(ICorePackageService.UpdatePackageStatusAsync),
+                    nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync),
+                };
+
+                Assert.Equal(expectedOrder, operations);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public async Task TracksMissingNupkgForAvailablePackage(bool validationFileExists)
+            {
+                Package.PackageStatusKey = PackageStatus.Available;
+                PackageFileServiceMock
+                    .Setup(pfs => pfs.DoesPackageFileExistAsync(Package))
+                    .ReturnsAsync(false);
+                PackageFileServiceMock
+                    .Setup(pfs => pfs.DoesValidationPackageFileExistAsync(Package))
+                    .ReturnsAsync(validationFileExists);
+
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available);
+
+                TelemetryServiceMock.Verify(
+                    x => x.TrackMissingNupkgForAvailablePackage(
+                        ValidationSet.PackageId,
+                        ValidationSet.PackageNormalizedVersion,
+                        ValidationSet.ValidationTrackingId.ToString()),
+                    Times.Once);
+            }
+        }
+
+        public class MakePackageFailedValidationAsync : BaseFacts
+        {
+            [Fact]
+            public async Task SetsPackageStatusToFailedValidation()
+            {
+                await Target.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.FailedValidation);
+
+                PackageServiceMock.Verify(
+                    x => x.UpdatePackageStatusAsync(Package, PackageStatus.FailedValidation, true),
+                    Times.Once);
+                PackageServiceMock.Verify(
+                    x => x.UpdatePackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), It.IsAny<bool>()),
+                    Times.Once);
+                TelemetryServiceMock.Verify(
+                    x => x.TrackPackageStatusChange(PackageStatus.Validating, PackageStatus.FailedValidation),
+                    Times.Once);
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Never);
+            }
+        }
+
+        public class BaseFacts
+        {
+            public BaseFacts()
+            {
+                Package = new Package
+                {
+                    PackageRegistration = new PackageRegistration(),
+                    PackageStatusKey = PackageStatus.Validating,
+                };
+                ValidationSet = new PackageValidationSet();
+
+                PackageServiceMock = new Mock<ICorePackageService>();
+                PackageFileServiceMock = new Mock<IValidationPackageFileService>();
+                TelemetryServiceMock = new Mock<ITelemetryService>();
+                LoggerMock = new Mock<ILogger<PackageStatusProcessor>>();
+
+                Target = new PackageStatusProcessor(
+                    PackageServiceMock.Object,
+                    PackageFileServiceMock.Object,
+                    TelemetryServiceMock.Object,
+                    LoggerMock.Object);
+            }
+
+            public Package Package { get; }
+            public PackageValidationSet ValidationSet { get; }
+            public Mock<ICorePackageService> PackageServiceMock { get; }
+            public Mock<IValidationPackageFileService> PackageFileServiceMock { get; }
+            public Mock<ITelemetryService> TelemetryServiceMock { get; }
+            public Mock<ILogger<PackageStatusProcessor>> LoggerMock { get; }
+            public PackageStatusProcessor Target { get; }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -22,41 +22,16 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         public async Task ProcessesFailedValidationAccordingToFailureBehavior(ValidationFailureBehavior failureBehavior, PackageStatus expectedPackageStatus)
         {
             AddValidation("validation1", ValidationStatus.Failed, failureBehavior);
-
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, expectedPackageStatus, true))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
+           
             var processor = CreateProcessor();
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
 
-            PackageServiceMock
-                .Verify(ps => ps.UpdatePackageStatusAsync(Package, expectedPackageStatus, true), Times.Once());
-            PackageServiceMock
-                .Verify(ps => ps.UpdatePackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), It.IsAny<bool>()), Times.Once());
-        }
-
-        [Fact]
-        public async Task DeleteValidationSetCopyOfPackageOnFailure()
-        {
-            AddValidation("validation1", ValidationStatus.Failed, ValidationFailureBehavior.MustSucceed);
-            AddValidation("validation2", ValidationStatus.Failed, ValidationFailureBehavior.MustSucceed);
-
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.FailedValidation, true))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            var processor = CreateProcessor();
-            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
+            PackageStateProcessorMock.Verify(
+                x => x.SetPackageStatusAsync(Package, ValidationSet, expectedPackageStatus),
+                Times.Once);
             PackageFileServiceMock.Verify(
-                x => x.DeletePackageForValidationSetAsync(ValidationSet), Times.Once);
-            PackageFileServiceMock.Verify(
-                x => x.DeletePackageFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-            PackageFileServiceMock.Verify(
-                x => x.DeleteValidationPackageFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+                x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                Times.Once);
         }
 
         [Theory]
@@ -71,11 +46,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationSet.PackageValidations.First().PackageValidationIssues = issueCodes
                 .Select(ic => new PackageValidationIssue { IssueCode = ic })
                 .ToList();
-
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.FailedValidation, true))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
 
             var processor = CreateProcessor();
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
@@ -95,11 +65,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationSet.PackageValidations.First().PackageValidationIssues = issueCodes
                 .Select(ic => new PackageValidationIssue { IssueCode = ic })
                 .ToList();
-
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.FailedValidation, true))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
 
             var processor = CreateProcessor();
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
@@ -130,8 +95,15 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             ValidationEnqueuerMock
                 .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Once());
-            PackageFileServiceMock
-                .Verify(x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Never);
+
+            PackageStateProcessorMock.Verify(
+                x => x.SetPackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageValidationSet>(), It.IsAny<PackageStatus>()),
+                Times.Never);
+
+            PackageFileServiceMock.Verify(
+                x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()),
+                Times.Never);
+
             Assert.NotNull(messageData);
             Assert.Equal(ValidationSet.ValidationTrackingId, messageData.ValidationTrackingId);
             Assert.Equal(ValidationSet.PackageId, messageData.PackageId);
@@ -140,100 +112,40 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Fact]
-        public async Task CopiesPackageToPublicStorageAndSendsEmailUponSuccess()
-        {
-            AddValidation("validation1", ValidationStatus.Succeeded);
-            Package.PackageStatusKey = PackageStatus.Validating;
-
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DoesValidationSetPackageExistAsync(ValidationSet))
-                .ReturnsAsync(true)
-                .Verifiable();
-            PackageFileServiceMock
-                .Setup(pfs => pfs.CopyValidationSetPackageToPackageFileAsync(ValidationSet))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            var processor = CreateProcessor();
-            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
-            PackageFileServiceMock
-                .Verify(pfs => pfs.CopyValidationSetPackageToPackageFileAsync(ValidationSet), Times.Once());
-            PackageFileServiceMock
-                .Verify(pfs => pfs.CopyValidationSetPackageToPackageFileAsync(It.IsAny<PackageValidationSet>()), Times.Once());
-
-            MessageServiceMock
-                .Verify(ms => ms.SendPackagePublishedMessage(Package), Times.Once());
-            MessageServiceMock
-                .Verify(ms => ms.SendPackagePublishedMessage(It.IsAny<Package>()), Times.Once());
-
-            PackageFileServiceMock
-                .Verify(x => x.DeletePackageForValidationSetAsync(ValidationSet), Times.Once);
-        }
-
-        [Fact]
-        public async Task AllowsPackageAlreadyInPublicContainerWhenValidationSetPackageDoesNotExist()
-        {
-            AddValidation("validation1", ValidationStatus.Succeeded);
-            Package.PackageStatusKey = PackageStatus.Validating;
-
-            PackageFileServiceMock
-                .Setup(x => x.DoesValidationSetPackageExistAsync(It.IsAny<PackageValidationSet>()))
-                .ReturnsAsync(false);
-            PackageFileServiceMock
-                .Setup(x => x.CopyValidationPackageToPackageFileAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Throws(new InvalidOperationException("Duplicate!"));
-
-            var processor = CreateProcessor();
-            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
-            PackageFileServiceMock
-                .Verify(pfs => pfs.CopyValidationPackageToPackageFileAsync(Package.PackageRegistration.Id, Package.NormalizedVersion), Times.Once);
-            PackageServiceMock
-                .Verify(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true), Times.Once);
-            PackageFileServiceMock
-                .Verify(pfs => pfs.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version), Times.Once);
-            MessageServiceMock
-                .Verify(ms => ms.SendPackagePublishedMessage(Package), Times.Once);
-        }
-
-        [Fact]
-        public async Task AllowsPackageAlreadyInPublicContainerWhenValidationSetPackageExists()
-        {
-            AddValidation("validation1", ValidationStatus.Succeeded);
-            Package.PackageStatusKey = PackageStatus.Validating;
-
-            PackageFileServiceMock
-                .Setup(x => x.DoesValidationSetPackageExistAsync(It.IsAny<PackageValidationSet>()))
-                .ReturnsAsync(true);
-            PackageFileServiceMock
-                .Setup(x => x.CopyValidationSetPackageToPackageFileAsync(It.IsAny<PackageValidationSet>()))
-                .Throws(new InvalidOperationException("Duplicate!"));
-
-            var processor = CreateProcessor();
-            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
-            PackageFileServiceMock
-                .Verify(pfs => pfs.CopyValidationSetPackageToPackageFileAsync(ValidationSet), Times.Once);
-            PackageServiceMock
-                .Verify(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true), Times.Once);
-            PackageFileServiceMock
-                .Verify(pfs => pfs.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version), Times.Once);
-            MessageServiceMock
-                .Verify(ms => ms.SendPackagePublishedMessage(Package), Times.Once);
-        }
-
-        [Fact]
-        public async Task DoesNotCopyPackageIfItsAvailable()
+        public async Task DoesNotSendSuccessEmailIfPackageIsAlreadyAvailable()
         {
             AddValidation("validation1", ValidationStatus.Succeeded);
             Package.PackageStatusKey = PackageStatus.Available;
 
             var processor = CreateProcessor();
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+           
+            MessageServiceMock.Verify(
+                x => x.SendPackagePublishedMessage(It.IsAny<Package>()),
+                Times.Never);
+        }
 
-            PackageFileServiceMock
-                .Verify(pfs => pfs.CopyValidationSetPackageToPackageFileAsync(It.IsAny<PackageValidationSet>()), Times.Never);
+        [Fact]
+        public async Task MakesPackageAvailableAndSendsEmailUponSuccess()
+        {
+            AddValidation("validation1", ValidationStatus.Succeeded);
+            Package.PackageStatusKey = PackageStatus.Validating;
+
+            var processor = CreateProcessor();
+            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+
+            PackageStateProcessorMock.Verify(
+                x => x.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available),
+                Times.Once);
+
+            PackageFileServiceMock.Verify(
+                x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                Times.Once);
+
+            MessageServiceMock
+                .Verify(ms => ms.SendPackagePublishedMessage(Package), Times.Once());
+            MessageServiceMock
+                .Verify(ms => ms.SendPackagePublishedMessage(It.IsAny<Package>()), Times.Once());
         }
 
         [Theory]
@@ -248,11 +160,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             AddValidation("validation1", validation);
             Package.PackageStatusKey = fromStatus;
 
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, toStatus, true))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
             TimeSpan duration = default(TimeSpan);
             TelemetryServiceMock
                 .Setup(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()))
@@ -263,163 +170,29 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             var before = DateTime.UtcNow;
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
             var after = DateTime.UtcNow;
-            
+
             if (fromStatus != toStatus)
             {
-                PackageServiceMock
-                    .Verify(ps => ps.UpdatePackageStatusAsync(Package, toStatus, true), Times.Once);
-                PackageServiceMock
-                    .Verify(ps => ps.UpdatePackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), It.IsAny<bool>()), Times.Once);
-                TelemetryServiceMock
-                    .Verify(ts => ts.TrackPackageStatusChange(fromStatus, toStatus), Times.Once);
+                PackageStateProcessorMock.Verify(
+                    x => x.SetPackageStatusAsync(Package, ValidationSet, toStatus),
+                    Times.Once);
+                PackageStateProcessorMock.Verify(
+                    x => x.SetPackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageValidationSet>(), It.IsAny<PackageStatus>()),
+                    Times.Once);
             }
             else
             {
-                PackageServiceMock
-                    .Verify(ps => ps.UpdatePackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), It.IsAny<bool>()), Times.Never);
-                TelemetryServiceMock
-                    .Verify(ts => ts.TrackPackageStatusChange(It.IsAny<PackageStatus>(), It.IsAny<PackageStatus>()), Times.Never);
+                PackageStateProcessorMock.Verify(
+                    x => x.SetPackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageValidationSet>(), It.IsAny<PackageStatus>()),
+                    Times.Never);
             }
 
+            PackageFileServiceMock.Verify(
+                x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                Times.Once);
             TelemetryServiceMock
                 .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
             Assert.InRange(duration, before - ValidationSet.Created, after - ValidationSet.Created);
-        }
-
-        [Fact]
-        public async Task DeletesValidationPackageOnSuccess()
-        {
-            AddValidation("validation1", ValidationStatus.Succeeded);
-            Package.PackageStatusKey = PackageStatus.Validating;
-
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            var procecssor = CreateProcessor();
-            await procecssor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
-            PackageFileServiceMock
-                .Verify(pfs => pfs.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version), Times.Once());
-            PackageFileServiceMock
-                .Verify(pfs => pfs.DeleteValidationPackageFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once());
-        }
-
-        [Fact]
-        public async Task DeletesPackageFromPublicStorageOnDbUpdateFailure()
-        {
-            AddValidation("validation1", ValidationStatus.Succeeded);
-            Package.PackageStatusKey = PackageStatus.Validating;
-
-            const string exceptionText = "Everything failed";
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true))
-                .Throws(new Exception(exceptionText))
-                .Verifiable();
-
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DeletePackageFileAsync(Package.PackageRegistration.Id, Package.Version))
-                .Returns(Task.FromResult(0))
-                .Verifiable();
-
-            var processor = CreateProcessor();
-            var exception = await Assert.ThrowsAsync<Exception>(() => processor.ProcessValidationOutcomeAsync(ValidationSet, Package));
-
-            PackageFileServiceMock
-                .Verify(pfs => pfs.DeletePackageFileAsync(Package.PackageRegistration.Id, Package.Version), Times.AtLeastOnce());
-            Assert.Equal(exceptionText, exception.Message);
-
-            PackageFileServiceMock
-                .Verify(pfs => pfs.DeletePackageForValidationSetAsync(ValidationSet), Times.Never);
-        }
-
-        [Fact]
-        public async Task CopyDbUpdateDeleteInCorrectOrderWhenValidationSetPackageExists()
-        {
-            AddValidation("validation1", ValidationStatus.Succeeded);
-            Package.PackageStatusKey = PackageStatus.Validating;
-
-            var operations = new List<string>();
-
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DoesValidationSetPackageExistAsync(ValidationSet))
-                .ReturnsAsync(true)
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync)));
-            PackageFileServiceMock
-                .Setup(pfs => pfs.CopyValidationSetPackageToPackageFileAsync(ValidationSet))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.CopyValidationSetPackageToPackageFileAsync)));
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(ICorePackageService.UpdatePackageStatusAsync)));
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync)));
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DeletePackageForValidationSetAsync(ValidationSet))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.DeletePackageForValidationSetAsync)));
-
-            var procecssor = CreateProcessor();
-            await procecssor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
-            var expectedOrder = new[]
-            {
-                nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync),
-                nameof(IValidationPackageFileService.CopyValidationSetPackageToPackageFileAsync),
-                nameof(ICorePackageService.UpdatePackageStatusAsync),
-                nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync),
-                nameof(IValidationPackageFileService.DeletePackageForValidationSetAsync),
-            };
-
-            Assert.Equal(expectedOrder, operations);
-        }
-
-        [Fact]
-        public async Task CopyDbUpdateDeleteInCorrectOrderWhenValidationSetPackageDoesNotExist()
-        {
-            AddValidation("validation1", ValidationStatus.Succeeded);
-            Package.PackageStatusKey = PackageStatus.Validating;
-
-            var operations = new List<string>();
-
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DoesValidationSetPackageExistAsync(ValidationSet))
-                .ReturnsAsync(false)
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync)));
-            PackageFileServiceMock
-                .Setup(pfs => pfs.CopyValidationPackageToPackageFileAsync(Package.PackageRegistration.Id, Package.NormalizedVersion))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.CopyValidationPackageToPackageFileAsync)));
-            PackageServiceMock
-                .Setup(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(ICorePackageService.UpdatePackageStatusAsync)));
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DeleteValidationPackageFileAsync(Package.PackageRegistration.Id, Package.Version))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync)));
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DeletePackageForValidationSetAsync(ValidationSet))
-                .Returns(Task.FromResult(0))
-                .Callback(() => operations.Add(nameof(IValidationPackageFileService.DeletePackageForValidationSetAsync)));
-
-            var procecssor = CreateProcessor();
-            await procecssor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
-            var expectedOrder = new[]
-            {
-                nameof(IValidationPackageFileService.DoesValidationSetPackageExistAsync),
-                nameof(IValidationPackageFileService.CopyValidationPackageToPackageFileAsync),
-                nameof(ICorePackageService.UpdatePackageStatusAsync),
-                nameof(IValidationPackageFileService.DeleteValidationPackageFileAsync),
-                nameof(IValidationPackageFileService.DeletePackageForValidationSetAsync),
-            };
-
-            Assert.Equal(expectedOrder, operations);
         }
 
         [Fact]
@@ -428,11 +201,24 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             AddValidation("validation1", ValidationStatus.Failed);
             Package.PackageStatusKey = PackageStatus.Available;
 
-            var procecssor = CreateProcessor();
-            await procecssor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+            var processor = CreateProcessor();
+            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
 
-            PackageServiceMock
-                .Verify(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.FailedValidation, It.IsAny<bool>()), Times.Never());
+            PackageFileServiceMock.Verify(
+                x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                Times.Once);
+            PackageStateProcessorMock.Verify(
+                x => x.SetPackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageValidationSet>(), It.IsAny<PackageStatus>()),
+                Times.Never);
+            MessageServiceMock.Verify(
+                x => x.SendPackageSignedValidationFailedMessage(It.IsAny<Package>()),
+                Times.Never);
+            MessageServiceMock.Verify(
+                x => x.SendPackageValidationFailedMessage(It.IsAny<Package>()),
+                Times.Never);
+            MessageServiceMock.Verify(
+                x => x.SendPackagePublishedMessage(It.IsAny<Package>()),
+                Times.Never);
         }
 
         [Theory]
@@ -476,44 +262,23 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             if (expectedStatus != PackageStatus.Validating)
             {
-                PackageServiceMock
-                    .Verify(ps => ps.UpdatePackageStatusAsync(Package, expectedStatus, true), Times.Once());
-                PackageServiceMock
-                    .Verify(ps => ps.UpdatePackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), It.IsAny<bool>()), Times.Once());
+                PackageStateProcessorMock.Verify(
+                    x => x.SetPackageStatusAsync(Package, ValidationSet, expectedStatus),
+                    Times.Once);
+                PackageStateProcessorMock.Verify(
+                    x => x.SetPackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageValidationSet>(), expectedStatus),
+                    Times.Once);
             }
             else
             {
-                PackageServiceMock
-                    .Verify(ps => ps.UpdatePackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), It.IsAny<bool>()), Times.Never());
+                PackageStateProcessorMock.Verify(
+                    x => x.SetPackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageValidationSet>(), It.IsAny<PackageStatus>()),
+                    Times.Never);
             }
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TracksMissingNupkgForAvailablePackage(bool validationFileExists)
-        {
-            Package.PackageStatusKey = PackageStatus.Available;
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DoesPackageFileExistAsync(Package))
-                .ReturnsAsync(false);
-            PackageFileServiceMock
-                .Setup(pfs => pfs.DoesValidationPackageFileExistAsync(Package))
-                .ReturnsAsync(validationFileExists);
-
-            var processor = CreateProcessor();
-            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
-
-            TelemetryServiceMock
-                .Verify(ts => ts.TrackMissingNupkgForAvailablePackage(
-                    ValidationSet.PackageId,
-                    ValidationSet.PackageNormalizedVersion,
-                    ValidationSet.ValidationTrackingId.ToString()),
-                Times.Once());
-        }
-
         [Fact]
-        public async Task PublishedNotificationSendFailureDoesNotCausePackageToBeDeleted()
+        public async Task PackageStillBecomesAvailableIfPublishedMessageFails()
         {
             var exception = new Exception("Something baaad happened");
 
@@ -524,21 +289,23 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             Package.PackageStatusKey = PackageStatus.Validating;
 
             var processor = CreateProcessor();
-            var thrownException = await Record.ExceptionAsync(async () => await processor.ProcessValidationOutcomeAsync(ValidationSet, Package));
+            var thrownException = await Record.ExceptionAsync(
+                async () => await processor.ProcessValidationOutcomeAsync(ValidationSet, Package));
 
             Assert.NotNull(thrownException);
-            PackageServiceMock
-                .Verify(ps => ps.UpdatePackageStatusAsync(Package, PackageStatus.Available, true),
-                    Times.Once());
-            PackageFileServiceMock
-                .Verify(pfs => pfs.DeletePackageFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            PackageStateProcessorMock.Verify(
+                x => x.SetPackageStatusAsync(Package, ValidationSet, PackageStatus.Available),
+                Times.Once);
+            PackageFileServiceMock.Verify(
+                x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()),
+                Times.Never);
         }
 
         public ValidationOutcomeProcessorFacts()
         {
-            PackageServiceMock = new Mock<ICorePackageService>();
-            PackageFileServiceMock = new Mock<IValidationPackageFileService>();
             ValidationEnqueuerMock = new Mock<IPackageValidationEnqueuer>();
+            PackageStateProcessorMock = new Mock<IPackageStatusProcessor>();
+            PackageFileServiceMock = new Mock<IValidationPackageFileService>();
             ConfigurationAccessorMock = new Mock<IOptionsSnapshot<ValidationConfiguration>>();
             MessageServiceMock = new Mock<IMessageService>();
             TelemetryServiceMock = new Mock<ITelemetryService>();
@@ -571,16 +338,16 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         protected ValidationOutcomeProcessor CreateProcessor()
         {
             return new ValidationOutcomeProcessor(
-                PackageServiceMock.Object,
-                PackageFileServiceMock.Object,
                 ValidationEnqueuerMock.Object,
+                PackageStateProcessorMock.Object,
+                PackageFileServiceMock.Object,
                 ConfigurationAccessorMock.Object,
                 MessageServiceMock.Object,
                 TelemetryServiceMock.Object,
                 LoggerMock.Object);
         }
 
-        protected Mock<ICorePackageService> PackageServiceMock { get; }
+        protected Mock<IPackageStatusProcessor> PackageStateProcessorMock { get; }
         protected Mock<IValidationPackageFileService> PackageFileServiceMock { get; }
         protected Mock<IPackageValidationEnqueuer> ValidationEnqueuerMock { get; }
         protected Mock<IOptionsSnapshot<ValidationConfiguration>> ConfigurationAccessorMock { get; }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1190.
Depends on https://github.com/NuGet/NuGet.Jobs/pull/361.

This logic will get a lot more complex with `IProcessor` since we now need to update the package hash in the gallery DB. This also needs to be synchronized since multiple validation sets could complete at once for the same package.

To ease this added complexity, I have extracted the gallery DB and packages container logic to its own class: `IPackageStatusProcessor`. This made the unit tests a lot clearer too 😄.