### PR TITLE
Update the package hash and length in DB after blob copy

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ConfigurationValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ConfigurationValidator.cs
@@ -102,9 +102,7 @@ namespace NuGet.Services.Validation.Orchestrator
         {
             foreach (var validatorItem in _configuration.Validations)
             {
-                // This method will throw if the validator does not exist.
-                var validatorType = _validatorProvider.GetValidatorType(validatorItem.Name);
-                if (validatorType == null)
+                if (!_validatorProvider.IsValidator(validatorItem.Name))
                 {
                     throw new ConfigurationErrorsException("Validator implementation not found for " + validatorItem.Name);
                 }
@@ -142,7 +140,7 @@ namespace NuGet.Services.Validation.Orchestrator
             var processorNames = _configuration
                 .Validations
                 .Select(x => x.Name)
-                .Where(x => typeof(IProcessor).IsAssignableFrom(_validatorProvider.GetValidatorType(x)))
+                .Where(x => _validatorProvider.IsProcessor(x))
                 .ToList();
 
             TopologicalSort.Validate(_configuration.Validations, processorNames);

--- a/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using NuGetGallery;
 
@@ -9,6 +10,13 @@ namespace NuGet.Services.Validation.Orchestrator
 {
     public interface IValidationPackageFileService : ICorePackageFileService
     {
+        /// <summary>
+        /// Download the package content from the packages container to a temporary location on disk.
+        /// </summary>
+        /// <param name="package">The package metadata.</param>
+        /// <returns>The package stream.</returns>
+        Task<Stream> DownloadPackageFileToDiskAsync(Package package);
+
         /// <summary>
         /// Copy a package from the validation container to a location specific for the validation set. This allows the
         /// validation set to have its own copy of the package to mutate (via <see cref="IProcessor"/>) and validate.

--- a/src/NuGet.Services.Validation.Orchestrator/IValidatorProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidatorProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace NuGet.Services.Validation.Orchestrator
 {
     /// <summary>
@@ -10,7 +8,8 @@ namespace NuGet.Services.Validation.Orchestrator
     /// </summary>
     public interface IValidatorProvider
     {
-        Type GetValidatorType(string validatorName);
+        bool IsValidator(string validatorName);
+        bool IsProcessor(string validatorName);
         IValidator GetValidator(string validatorName);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 using NuGetGallery;
+using NuGetGallery.Packaging;
 
 namespace NuGet.Services.Validation.Orchestrator
 {
@@ -13,17 +16,20 @@ namespace NuGet.Services.Validation.Orchestrator
     {
         private readonly ICorePackageService _galleryPackageService;
         private readonly IValidationPackageFileService _packageFileService;
+        private readonly IValidatorProvider _validatorProvider;
         private readonly ITelemetryService _telemetryService;
         private readonly ILogger<PackageStatusProcessor> _logger;
 
         public PackageStatusProcessor(
             ICorePackageService galleryPackageService,
             IValidationPackageFileService packageFileService,
+            IValidatorProvider validatorProvider,
             ITelemetryService telemetryService,
             ILogger<PackageStatusProcessor> logger)
         {
             _galleryPackageService = galleryPackageService ?? throw new ArgumentNullException(nameof(galleryPackageService));
             _packageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
+            _validatorProvider = validatorProvider ?? throw new ArgumentNullException(nameof(validatorProvider));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -127,8 +133,15 @@ namespace NuGet.Services.Validation.Orchestrator
                 package.NormalizedVersion,
                 validationSet.ValidationTrackingId);
 
+            // If the validation set contains any processors, we must use the copy of the package that is specific to
+            // this validation set. We can't use the original validation package because it does not have any of the
+            // changes that the processors made. If the validation set package does not exist for some reason and there
+            // are processors in the validation set, this indicates a bug and an exception will be thrown by the copy
+            // operation below. This will cause the validation queue message to eventually dead-letter at which point
+            // the on-call person should investigate.
             bool copied;
-            if (await _packageFileService.DoesValidationSetPackageExistAsync(validationSet))
+            if (validationSet.PackageValidations.Any(x => _validatorProvider.IsProcessor(x.Type)) ||
+                await _packageFileService.DoesValidationSetPackageExistAsync(validationSet))
             {
                 copied = await CopyAsync(
                     validationSet,
@@ -150,6 +163,39 @@ namespace NuGet.Services.Validation.Orchestrator
                     x => _packageFileService.CopyValidationPackageToPackageFileAsync(x.PackageId, x.PackageNormalizedVersion));
             }
 
+            // Use whatever package made it into the packages container. This is what customers will consume so the DB
+            // record must match.
+            using (var packageStream = await _packageFileService.DownloadPackageFileToDiskAsync(package))
+            {
+                var stopwatch = Stopwatch.StartNew();
+                var hash = CryptographyService.GenerateHash(packageStream, CoreConstants.Sha512HashAlgorithmId);
+                _telemetryService.TrackDurationToHashPackage(
+                    stopwatch.Elapsed,
+                    package.PackageRegistration.Id,
+                    package.NormalizedVersion,
+                    CoreConstants.Sha512HashAlgorithmId,
+                    packageStream.GetType().FullName);
+
+                var streamMetadata = new PackageStreamMetadata
+                {
+                    Size = packageStream.Length,
+                    Hash = hash,
+                    HashAlgorithm = CoreConstants.Sha512HashAlgorithmId,
+                };
+
+                // We don't immediately commit here. Later, we will commit these changes as well as the new package
+                // status as part of the same transaction.
+                if (streamMetadata.Size != package.PackageFileSize
+                    || streamMetadata.Hash != package.Hash
+                    || streamMetadata.HashAlgorithm != package.HashAlgorithm)
+                {
+                    await _galleryPackageService.UpdatePackageStreamMetadataAsync(
+                        package,
+                        streamMetadata,
+                        commitChanges: false);
+                }
+            }
+
             _logger.LogInformation("Marking package {PackageId} {PackageVersion}, validation set {ValidationSetId} as {PackageStatus} in DB",
                 package.PackageRegistration.Id,
                 package.NormalizedVersion,
@@ -158,6 +204,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
             try
             {
+                // Make the package available and commit any other pending changes (e.g. updated hash).
                 await UpdatePackageStatusAsync(package, PackageStatus.Available);
             }
             catch (Exception e)
@@ -171,8 +218,9 @@ namespace NuGet.Services.Validation.Orchestrator
                     validationSet.ValidationTrackingId);
 
                 // If this execution was not the one to copy the package, then don't delete the package on failure.
-                // This prevents the (unlikely) case where two actors attempt the DB update, one suceeds and one fails.
-                // We don't want an available package record with nothing in the packages container!
+                // This prevents a missing passing in the (unlikely) case where two actors attempt the DB update, one
+                // succeeds and one fails. We don't want an available package record with nothing in the packages
+                // container!
                 if (copied)
                 {
                     await _packageFileService.DeletePackageFileAsync(package.PackageRegistration.Id, package.Version);
@@ -200,9 +248,10 @@ namespace NuGet.Services.Validation.Orchestrator
             catch (InvalidOperationException)
             {
                 // The package already exists in the packages container. This can happen if the DB commit below fails
-                // and this flow is retried. We assume that the package content has not changed. Today there is no way
-                // for the content to change. Hard deletes (the one way a package ID and version can get different
-                // content) delete from both the packages and validating container so this can't be a mismatch.
+                // and this flow is retried or another validation set for the package completed first. Either way, we
+                // will later attempt to use the hash from the package in the packages container (the destination).
+                // In other words, we don't care which copy wins, but the DB record must match the package that ends
+                // up in the packages container.
                 _logger.LogInformation(
                     "Package already exists in packages container for {PackageId} {PackageVersion}, validation set {ValidationSetId}",
                     package.PackageRegistration.Id,

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -91,5 +91,10 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// in the public container.
         /// </summary>
         void TrackMissingNupkgForAvailablePackage(string packageId, string normalizedVersion, string validationTrackingId);
+
+        /// <summary>
+        /// A metric to of how long it took to hash a package.
+        /// </summary>
+        void TrackDurationToHashPackage(TimeSpan duration, string packageId, string normalizedVersion, string hashAlgorithm, string streamType);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -23,6 +23,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string ClientValidationIssue = Prefix + "ClientValidationIssue";
         private const string MissingPackageForValidationMessage = Prefix + "MissingPackageForValidationMessage";
         private const string MissingNupkgForAvailablePackage = Prefix + "MissingNupkgForAvailablePackage";
+        private const string DurationToHashPackageSeconds = Prefix + "DurationToHashPackageSeconds";
 
         private const string FromStatus = "FromStatus";
         private const string ToStatus = "ToStatus";
@@ -33,12 +34,30 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string PackageId = "PackageId";
         private const string NormalizedVersion = "NormalizedVersion";
         private const string ValidationTrackingId = "ValidationTrackingId";
+        private const string PackageSize = "PackageSize";
+        private const string HashAlgorithm = "HashAlgorithm";
+        private const string StreamType = "StreamType";
 
         private readonly TelemetryClient _telemetryClient;
 
         public TelemetryService(TelemetryClient telemetryClient)
         {
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public void TrackDurationToHashPackage(TimeSpan duration, string packageId, string normalizedVersion, string hashAlgorithm, string streamType)
+        {
+            _telemetryClient.TrackMetric(
+                DurationToHashPackageSeconds,
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { PackageSize, PackageSize.ToString() },
+                    { HashAlgorithm, hashAlgorithm },
+                    { StreamType, streamType },
+                });
         }
 
         public void TrackDurationToValidationSetCreation(TimeSpan duration)

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -24,7 +24,7 @@
       }
     ],
     "ValidationStorageConnectionString": "",
-    "MissingPackageRetryCount":  15,
+    "MissingPackageRetryCount": 15,
     "ValidationMessageRecheckPeriod": "00:01:00",
     "NewValidationRequestDeduplicationWindow": "00:20:00"
   },
@@ -82,6 +82,7 @@
     "AnnouncementsUrl": "https://github.com/NuGet/Announcements/issues",
     "TwitterUrl": "https://twitter.com/nuget"
   },
+  "PackageDownloadTimeout": "00:10:00",
   "KeyVault_VaultName": "",
   "KeyVault_ClientId": "",
   "KeyVault_CertificateThumbprint": "",

--- a/src/Validation.Common.Job/CommonTelemetryService.cs
+++ b/src/Validation.Common.Job/CommonTelemetryService.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights;
+
+namespace NuGet.Jobs.Validation
+{
+    public class CommonTelemetryService : ICommonTelemetryService
+    {
+        private const string PackageDownloadedSeconds = "PackageDownloadedSeconds";
+        private const string PackageUri = "PackageUri";
+        private const string PackageSize = "PackageSize";
+
+        private readonly TelemetryClient _telemetryClient;
+
+        public CommonTelemetryService(TelemetryClient telemetryClient)
+        {
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public void TrackPackageDownloaded(Uri packageUri, TimeSpan duration, long size)
+        {
+            // Remove the query string from the package URI, since this could contain a SAS token.
+            var uriBuilder = new UriBuilder(packageUri);
+            uriBuilder.Query = null;
+            var absoluteUri = uriBuilder.Uri.AbsoluteUri;
+
+            _telemetryClient.TrackMetric(
+                PackageDownloadedSeconds,
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { PackageUri, absoluteUri },
+                    { PackageSize, size.ToString() },
+                });
+        }
+    }
+}

--- a/src/Validation.Common.Job/ICommonTelemetryService.cs
+++ b/src/Validation.Common.Job/ICommonTelemetryService.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Jobs.Validation
+{
+    public interface ICommonTelemetryService
+    {
+        void TrackPackageDownloaded(Uri packageUri, TimeSpan duration, long size);
+    }
+}

--- a/src/Validation.Common.Job/JsonConfigurationJob.cs
+++ b/src/Validation.Common.Job/JsonConfigurationJob.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Reflection;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -105,6 +106,8 @@ namespace NuGet.Jobs.Validation
             services.Configure<ValidationDbConfiguration>(configurationRoot.GetSection(ValidationDbConfigurationSectionName));
             services.Configure<ServiceBusConfiguration>(configurationRoot.GetSection(ServiceBusConfigurationSectionName));
 
+            services.AddSingleton(new TelemetryClient());
+            services.AddTransient<ICommonTelemetryService, CommonTelemetryService>();
             services.AddTransient<IPackageDownloader, PackageDownloader>();
 
             services.AddScoped<IValidationEntitiesContext>(p =>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -36,8 +36,10 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CommonTelemetryService.cs" />
     <Compile Include="Error.cs" />
     <Compile Include="ExceptionExtensions.cs" />
+    <Compile Include="ICommonTelemetryService.cs" />
     <Compile Include="IPackageDownloader.cs" />
     <Compile Include="PackageDownloader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace NuGet.Services.Validation.Orchestrator.Tests
 {
-    public class ConfigurationFacts
+    public class ConfigurationValidatorFacts
     {
         [Fact]
         public void ConfigurationValidatorSmokeTest()
@@ -148,11 +148,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             var validatorProvider = new Mock<IValidatorProvider>();
             validatorProvider
-                .Setup(x => x.GetValidatorType(It.Is<string>(n => n == validationName1 || n == validationName2)))
-                .Returns(() => new Mock<IValidator>().Object.GetType());
+                .Setup(x => x.IsValidator(It.Is<string>(n => n == validationName1
+                                                          || n == validationName2
+                                                          || n == processorName1)))
+                .Returns(true);
             validatorProvider
-                .Setup(x => x.GetValidatorType(processorName1))
-                .Returns(() => new Mock<IProcessor>().Object.GetType());
+                .Setup(x => x.IsProcessor(processorName1))
+                .Returns(true);
 
             var ex = Record.Exception(() => Validate(validatorProvider.Object, configuration));
 
@@ -195,11 +197,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             var validatorProvider = new Mock<IValidatorProvider>();
             validatorProvider
-                .Setup(x => x.GetValidatorType(It.Is<string>(n => n == validationName1 || n == validationName2)))
-                .Returns(() => new Mock<IValidator>().Object.GetType());
+                .Setup(x => x.IsValidator(It.Is<string>(n => n == validationName1
+                                                          || n == validationName2
+                                                          || n == processorName1)))
+                .Returns(true);
             validatorProvider
-                .Setup(x => x.GetValidatorType(processorName1))
-                .Returns(() => new Mock<IProcessor>().Object.GetType());
+                .Setup(x => x.IsProcessor(processorName1))
+                .Returns(true);
 
             var ex = Record.Exception(() => Validate(validatorProvider.Object, configuration));
 
@@ -601,8 +605,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             var validatorProvider = new Mock<IValidatorProvider>();
             validatorProvider
-                .Setup(x => x.GetValidatorType(It.IsAny<string>()))
-                .Returns(() => new Mock<IValidator>().Object.GetType());
+                .Setup(x => x.IsValidator(It.IsAny<string>()))
+                .Returns(true);
 
             Validate(validatorProvider.Object, configuration);
         }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -41,7 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Configuration\ConfigurationFacts.cs" />
+    <Compile Include="Configuration\ConfigurationValidatorFacts.cs" />
     <Compile Include="Configuration\CoreMessageServiceConfigurationFacts.cs" />
     <Compile Include="Configuration\TopologicalSortFacts.cs" />
     <Compile Include="MessageServiceFacts.cs" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1190.
Depends on https://github.com/NuGet/NuGet.Jobs/pull/362.
Depends on https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment/pullrequest/345?_a=files.

After copying the package to the packages container, download the package to recalculate the package hash. Also, update `ValidatorProvider` to better abstract away `Type` operations.