### PR TITLE
Process the package state change even when the package is already available

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
@@ -29,13 +29,19 @@ namespace NuGet.Services.Validation.Orchestrator
         /// validation set to have its own copy of the package to mutate (via <see cref="IProcessor"/>) and validate.
         /// </summary>
         /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
-        Task CopyPackageFileForValidationSetAsync(PackageValidationSet validationSet);
+        /// <returns>The etag of the source package.</returns>
+        Task<string> CopyPackageFileForValidationSetAsync(PackageValidationSet validationSet);
 
         /// <summary>
         /// Copy a package from a location specific for the validation set to the packages container.
         /// </summary>
         /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
-        Task CopyValidationSetPackageToPackageFileAsync(PackageValidationSet validationSet);
+        /// <param name="destAccessCondition">
+        /// The access condition used for asserting the state of the destination file.
+        /// </param>
+        Task CopyValidationSetPackageToPackageFileAsync(
+            PackageValidationSet validationSet,
+            IAccessCondition destAccessCondition);
 
         /// <summary>
         /// Copy a package from the validation container to the packages container.

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -108,7 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.17.0</Version>
+      <Version>2.18.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
@@ -46,10 +46,11 @@ namespace NuGet.Services.Validation.Orchestrator
                 CoreConstants.ValidationFolderName,
                 srcFileName,
                 CoreConstants.ValidationFolderName,
-                BuildValidationSetPackageFileName(validationSet));
+                BuildValidationSetPackageFileName(validationSet),
+                AccessConditionWrapper.GenerateEmptyCondition());
         }
 
-        public Task CopyPackageFileForValidationSetAsync(PackageValidationSet validationSet)
+        public Task<string> CopyPackageFileForValidationSetAsync(PackageValidationSet validationSet)
         {
             var srcFileName = BuildFileName(
                 validationSet.PackageId,
@@ -61,7 +62,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 CoreConstants.PackagesFolderName,
                 srcFileName,
                 CoreConstants.ValidationFolderName,
-                BuildValidationSetPackageFileName(validationSet));
+                BuildValidationSetPackageFileName(validationSet),
+                AccessConditionWrapper.GenerateEmptyCondition());
         }
 
         public Task CopyValidationPackageToPackageFileAsync(string id, string normalizedVersion)
@@ -76,10 +78,13 @@ namespace NuGet.Services.Validation.Orchestrator
                 CoreConstants.ValidationFolderName,
                 fileName,
                 CoreConstants.PackagesFolderName,
-                fileName);
+                fileName,
+                AccessConditionWrapper.GenerateIfNotExistsCondition());
         }
 
-        public Task CopyValidationSetPackageToPackageFileAsync(PackageValidationSet validationSet)
+        public Task CopyValidationSetPackageToPackageFileAsync(
+            PackageValidationSet validationSet,
+            IAccessCondition destAccessCondition)
         {
             var srcFileName = BuildValidationSetPackageFileName(validationSet);
 
@@ -93,7 +98,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 CoreConstants.ValidationFolderName,
                 srcFileName,
                 CoreConstants.PackagesFolderName,
-                destFileName);
+                destFileName,
+                destAccessCondition);
         }
 
         public Task<bool> DoesValidationSetPackageExistAsync(PackageValidationSet validationSet)
@@ -123,7 +129,12 @@ namespace NuGet.Services.Validation.Orchestrator
             return _fileStorageService.GetFileReadUriAsync(CoreConstants.ValidationFolderName, fileName, endOfAccess);
         }
 
-        private Task CopyFileAsync(string srcFolderName, string srcFileName, string destFolderName, string destFileName)
+        private Task<string> CopyFileAsync(
+            string srcFolderName,
+            string srcFileName,
+            string destFolderName,
+            string destFileName,
+            IAccessCondition destAccessCondition)
         {
             _logger.LogInformation(
                 "Copying file {SrcFolderName}/{SrcFileName} to {DestFolderName}/{DestFileName}.",
@@ -136,7 +147,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 srcFolderName,
                 srcFileName,
                 destFolderName,
-                destFileName);
+                destFileName,
+                destAccessCondition);
         }
 
         private static string BuildValidationSetPackageFileName(PackageValidationSet validationSet)

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
@@ -52,48 +52,94 @@ namespace NuGet.Services.Validation.Orchestrator
                     return null;
                 }
 
-                validationSet = await CreateValidationSet(validationTrackingId, package);
+                validationSet = InitializeValidationSet(validationTrackingId, package);
 
                 if (package.PackageStatusKey == PackageStatus.Available)
                 {
-                    await _packageFileService.CopyPackageFileForValidationSetAsync(validationSet);
+                    var packageETag = await _packageFileService.CopyPackageFileForValidationSetAsync(validationSet);
+
+                    // This indicates that the package in the package container is expected to not change.
+                    validationSet.PackageETag = packageETag;
                 }
                 else
                 {
                     await _packageFileService.CopyValidationPackageForValidationSetAsync(validationSet);
+
+                    // This indicates that the package in the packages container is expected to not exist (i.e. it has
+                    // has no etag at all).
+                    validationSet.PackageETag = null;
                 }
+
+                validationSet = await PersistValidationSetAsync(validationSet, package);
             }
             else
             {
-                var sameId = package.PackageRegistration.Id.Equals(validationSet.PackageId, StringComparison.InvariantCultureIgnoreCase);
-                var sameVersion = package.NormalizedVersion.Equals(validationSet.PackageNormalizedVersion, StringComparison.InvariantCultureIgnoreCase);
+                var sameId = package.PackageRegistration.Id.Equals(
+                    validationSet.PackageId,
+                    StringComparison.InvariantCultureIgnoreCase);
+
+                var sameVersion = package.NormalizedVersion.Equals(
+                    validationSet.PackageNormalizedVersion,
+                    StringComparison.InvariantCultureIgnoreCase);
+
                 if (!sameId || !sameVersion)
                 {
-                    throw new Exception($"Validation set package identity ({validationSet.PackageId} {validationSet.PackageNormalizedVersion})" +
-                        $"does not match expected package identity ({package.PackageRegistration.Id} {package.NormalizedVersion})");
+                    throw new InvalidOperationException(
+                        $"Validation set package identity ({validationSet.PackageId} {validationSet.PackageNormalizedVersion})" +
+                        $"does not match expected package identity ({package.PackageRegistration.Id} {package.NormalizedVersion}).");
+                }
+
+                var sameKey = package.Key == validationSet.PackageKey;
+                
+                if (!sameKey)
+                {
+                    throw new InvalidOperationException($"Validation set package key ({validationSet.PackageKey}) " +
+                        $"does not match expected package key ({package.Key}).");
                 }
             }
 
             return validationSet;
         }
 
-        private async Task<PackageValidationSet> CreateValidationSet(Guid validationTrackingId, Package package)
+        private async Task<PackageValidationSet> PersistValidationSetAsync(PackageValidationSet validationSet, Package package)
         {
-            _logger.LogInformation("Creating validation set {ValidationSetId} for package {PackageId} {PackageVersion}",
+            _logger.LogInformation("Persisting validation set {ValidationSetId} for package {PackageId} {PackageVersion} (package key {PackageKey})",
+                validationSet.ValidationTrackingId,
+                package.PackageRegistration.Id,
+                package.NormalizedVersion,
+                package.Key);
+
+            var persistedValidationSet = await _validationStorageService.CreateValidationSetAsync(validationSet);
+
+            // Only track the validation set creation time when this is the first validation set to be created for that
+            // package. There will be more than one validation set when an admin has requested a manual revalidation.
+            // This can happen much later than when the package was created so the duration is less interesting in that
+            // case.
+            if (await _validationStorageService.GetValidationSetCountAsync(package.Key) == 1)
+            {
+                _telemetryService.TrackDurationToValidationSetCreation(validationSet.Created - package.Created);
+            }
+
+            return persistedValidationSet;
+        }
+
+        private PackageValidationSet InitializeValidationSet(Guid validationTrackingId, Package package)
+        {
+            _logger.LogInformation("Initializing validation set {ValidationSetId} for package {PackageId} {PackageVersion} (package key {PackageKey})",
                 validationTrackingId,
                 package.PackageRegistration.Id,
-                package.NormalizedVersion);
+                package.NormalizedVersion,
+                package.Key);
 
-            PackageValidationSet validationSet;
-            var packageValidations = new List<PackageValidation>();
             var now = DateTime.UtcNow;
-            validationSet = new PackageValidationSet
+
+            var validationSet = new PackageValidationSet
             {
                 Created = now,
                 PackageId = package.PackageRegistration.Id,
                 PackageNormalizedVersion = package.NormalizedVersion,
                 PackageKey = package.Key,
-                PackageValidations = packageValidations,
+                PackageValidations = new List<PackageValidation>(),
                 Updated = now,
                 ValidationTrackingId = validationTrackingId,
             };
@@ -108,21 +154,10 @@ namespace NuGet.Services.Validation.Orchestrator
                     ValidationStatusTimestamp = now,
                 };
 
-                packageValidations.Add(packageValidation);
+                validationSet.PackageValidations.Add(packageValidation);
             }
 
-            var persistedValidationSet = await _validationStorageService.CreateValidationSetAsync(validationSet);
-
-            // Only track the validation set creation time when this is the first validation set to be created for that
-            // package. There will be more than one validation set when an admin has requested a manual revalidation.
-            // This can happen much later than when the package was created so the duration is less interesting in that
-            // case.
-            if (await _validationStorageService.GetValidationSetCountAsync(package.Key) == 1)
-            {
-                _telemetryService.TrackDurationToValidationSetCreation(now - package.Created);
-            }
-
-            return persistedValidationSet;
+            return validationSet;
         }
     }
 }

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -72,19 +72,19 @@
       <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.17.0</Version>
+      <Version>2.18.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.17.0</Version>
+      <Version>2.18.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.17.0</Version>
+      <Version>2.18.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.17.0</Version>
+      <Version>2.18.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.4-dev-25129</Version>
+      <Version>4.4.4-dev-25609</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -71,9 +71,6 @@
     <PackageReference Include="moq">
       <Version>4.7.145</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.17.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>
     </PackageReference>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -149,13 +149,17 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Theory]
-        [InlineData(ValidationStatus.Failed, PackageStatus.Validating, PackageStatus.FailedValidation)]
-        [InlineData(ValidationStatus.Failed, PackageStatus.Available, PackageStatus.Available)]
-        [InlineData(ValidationStatus.Failed, PackageStatus.FailedValidation, PackageStatus.FailedValidation)]
-        [InlineData(ValidationStatus.Succeeded, PackageStatus.Validating, PackageStatus.Available)]
-        [InlineData(ValidationStatus.Succeeded, PackageStatus.Available, PackageStatus.Available)]
-        [InlineData(ValidationStatus.Succeeded, PackageStatus.FailedValidation, PackageStatus.Available)]
-        public async Task MarksPackageStatusBasedOnValidatorResults(ValidationStatus validation, PackageStatus fromStatus, PackageStatus toStatus)
+        [InlineData(ValidationStatus.Failed, PackageStatus.Validating, PackageStatus.FailedValidation, true)]
+        [InlineData(ValidationStatus.Failed, PackageStatus.Available, PackageStatus.Available, false)]
+        [InlineData(ValidationStatus.Failed, PackageStatus.FailedValidation, PackageStatus.FailedValidation, false)]
+        [InlineData(ValidationStatus.Succeeded, PackageStatus.Validating, PackageStatus.Available, true)]
+        [InlineData(ValidationStatus.Succeeded, PackageStatus.Available, PackageStatus.Available, true)]
+        [InlineData(ValidationStatus.Succeeded, PackageStatus.FailedValidation, PackageStatus.Available, true)]
+        public async Task MarksPackageStatusBasedOnValidatorResults(
+            ValidationStatus validation,
+            PackageStatus fromStatus,
+            PackageStatus toStatus,
+            bool setPackageStatus)
         {
             AddValidation("validation1", validation);
             Package.PackageStatusKey = fromStatus;
@@ -171,7 +175,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
             var after = DateTime.UtcNow;
 
-            if (fromStatus != toStatus)
+            if (setPackageStatus)
             {
                 PackageStateProcessorMock.Verify(
                     x => x.SetPackageStatusAsync(Package, ValidationSet, toStatus),


### PR DESCRIPTION
Depends on https://github.com/NuGet/ServerCommon/pull/140.
Depends on https://github.com/NuGet/NuGet.Jobs/pull/364.
Progress on https://github.com/NuGet/Engineering/issues/1190.

This is necessary because a revalidate on a package when processors are configured can result in a mutated package.

I will update the NuGetGallery and ServerCommon dependencies soon.