### PR TITLE
[Orchestrator] Remove validation failure on timeout

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ConfigurationValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ConfigurationValidator.cs
@@ -67,9 +67,9 @@ namespace NuGet.Services.Validation.Orchestrator
                     throw new ConfigurationErrorsException("Validation name cannot be empty");
                 }
 
-                if (validationConfigurationItem.FailAfter == TimeSpan.Zero)
+                if (validationConfigurationItem.TrackAfter == TimeSpan.Zero)
                 {
-                    throw new ConfigurationErrorsException($"failAfter timeout must be set for validation {validationConfigurationItem.Name}");
+                    throw new ConfigurationErrorsException($"{nameof(validationConfigurationItem.TrackAfter)} must be set for validation {validationConfigurationItem.Name}");
                 }
             }
         }

--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfiguration.cs
@@ -39,5 +39,15 @@ namespace NuGet.Services.Validation.Orchestrator
         /// this window.
         /// </summary>
         public TimeSpan NewValidationRequestDeduplicationWindow { get; set; }
+
+        /// <summary>
+        /// The threshold until which an email will be sent out due to a validation set taking too long.
+        /// </summary>
+        public TimeSpan ValidationSetNotificationTimeout { get; set; }
+
+        /// <summary>
+        /// The threshold until a validation set is no longer processed.
+        /// </summary>
+        public TimeSpan TimeoutValidationSetAfter { get; set; }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationItem.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationItem.cs
@@ -17,9 +17,9 @@ namespace NuGet.Services.Validation.Orchestrator
         public string Name { get; set; }
 
         /// <summary>
-        /// Timeout after which started validation is considered failed if it didn't produce any outcome
+        /// Time after which a validation's processing time will be tracked. Use this to track validations that take too long.
         /// </summary>
-        public TimeSpan FailAfter { get; set; }
+        public TimeSpan TrackAfter { get; set; }
 
         /// <summary>
         /// List of validation names that must finish before this validation can run

--- a/src/NuGet.Services.Validation.Orchestrator/IMessageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IMessageService.cs
@@ -10,5 +10,6 @@ namespace NuGet.Services.Validation.Orchestrator
         void SendPackagePublishedMessage(Package package);
         void SendPackageValidationFailedMessage(Package package);
         void SendPackageSignedValidationFailedMessage(Package package);
+        void SendPackageValidationTakingTooLongMessage(Package package);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/IValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidationStorageService.cs
@@ -46,6 +46,13 @@ namespace NuGet.Services.Validation.Orchestrator
         Task MarkValidationStartedAsync(PackageValidation packageValidation, IValidationResult validationResult);
 
         /// <summary>
+        /// Updates the <see cref="PackageValidationSet.Updated"/> to the current timestamp and persists changes.
+        /// </summary>
+        /// <param name="packageValidationSet">The validation set to update.</param>
+        /// <returns>Task object tracking the async operation status.</returns>
+        Task UpdateValidationSetAsync(PackageValidationSet packageValidationSet);
+
+        /// <summary>
         /// Updates the passed <see cref="PackageValidation"/> object with the result's validation status,
         /// updates the <see cref="PackageValidation.ValidationStatusTimestamp"/> property to the current
         /// timestamp, adds the result's <see cref="PackageValidationIssue"/>s to the validation, and then persists

--- a/src/NuGet.Services.Validation.Orchestrator/MessageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/MessageService.cs
@@ -49,8 +49,9 @@ namespace NuGet.Services.Validation.Orchestrator
         {
             package = package ?? throw new ArgumentNullException(nameof(package));
 
-            var galleryPackageUrl = string.Format(_emailConfiguration.PackageUrlTemplate, package.PackageRegistration.Id, package.NormalizedVersion);
-            var packageSupportUrl = string.Format(_emailConfiguration.PackageSupportTemplate, package.PackageRegistration.Id, package.NormalizedVersion);
+            var galleryPackageUrl = GalleryPackageUrl(package);
+            var packageSupportUrl = PackageSupportUrl(package);
+
             _coreMessageService.SendPackageAddedNotice(package, galleryPackageUrl, packageSupportUrl, _emailConfiguration.EmailSettingsUrl);
         }
 
@@ -58,8 +59,9 @@ namespace NuGet.Services.Validation.Orchestrator
         {
             package = package ?? throw new ArgumentNullException(nameof(package));
 
-            var galleryPackageUrl = string.Format(_emailConfiguration.PackageUrlTemplate, package.PackageRegistration.Id, package.NormalizedVersion);
-            var packageSupportUrl = string.Format(_emailConfiguration.PackageSupportTemplate, package.PackageRegistration.Id, package.NormalizedVersion);
+            var galleryPackageUrl = GalleryPackageUrl(package);
+            var packageSupportUrl = PackageSupportUrl(package);
+
             _coreMessageService.SendPackageValidationFailedNotice(package, galleryPackageUrl, packageSupportUrl);
         }
 
@@ -67,8 +69,19 @@ namespace NuGet.Services.Validation.Orchestrator
         {
             package = package ?? throw new ArgumentNullException(nameof(package));
 
-            var galleryPackageUrl = string.Format(_emailConfiguration.PackageUrlTemplate, package.PackageRegistration.Id, package.NormalizedVersion);
+            var galleryPackageUrl = GalleryPackageUrl(package);
+
             _coreMessageService.SendSignedPackageNotAllowedNotice(package, galleryPackageUrl, _emailConfiguration.AnnouncementsUrl, _emailConfiguration.TwitterUrl);
         }
+
+        public void SendPackageValidationTakingTooLongMessage(Package package)
+        {
+            package = package ?? throw new ArgumentNullException(nameof(package));
+
+            _coreMessageService.SendValidationTakingTooLongNotice(package, GalleryPackageUrl(package));
+        }
+
+        private string GalleryPackageUrl(Package package) => string.Format(_emailConfiguration.PackageUrlTemplate, package.PackageRegistration.Id, package.NormalizedVersion);
+        private string PackageSupportUrl(Package package) => string.Format(_emailConfiguration.PackageSupportTemplate, package.PackageRegistration.Id, package.NormalizedVersion);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -34,7 +34,17 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         void TrackTotalValidationDuration(TimeSpan duration, bool isSuccess);
 
         /// <summary>
-        /// A counter metric emitted when a validator fails due to the <see cref="ValidationConfigurationItem.FailAfter"/>
+        /// A counter metric emitted when a notification is sent because a validation set takes too long.
+        /// </summary>
+        void TrackSentValidationTakingTooLongMessage(string packageId, string normalizedVersion, Guid validationTrackingId);
+
+        /// <summary>
+        /// A counter metric emitted when a validation set times out.
+        /// </summary>
+        void TrackValidationSetTimeout(string packageId, string normalizedVersion, Guid validationTrackingId);
+
+        /// <summary>
+        /// A counter metric emitted when a validation is past its validator's <see cref="ValidationConfigurationItem.TrackAfter"/>
         /// configuration.
         /// </summary>
         /// <param name="validatorType">The validator type (name).</param>

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -15,6 +15,8 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string DurationToValidationSetCreationSeconds = Prefix + "DurationToValidationSetCreationSeconds";
         private const string PackageStatusChange = Prefix + "PackageStatusChange";
         private const string TotalValidationDurationSeconds = Prefix + "TotalValidationDurationSeconds";
+        private const string SentValidationTakingTooLongMessage = Prefix + "SentValidationTakingTooLongMessage";
+        private const string ValidationSetTimeout = Prefix + "TotalValidationDurationSeconds";
         private const string ValidationIssue = Prefix + "ValidationIssue";
         private const string ValidationIssueCount = Prefix + "ValidationIssueCount";
         private const string ValidatorTimeout = Prefix + "ValidatorTimeout";
@@ -89,6 +91,28 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                     { IsSuccess, isSuccess.ToString() },
                 });
         }
+
+        public void TrackSentValidationTakingTooLongMessage(string packageId, string normalizedVersion, Guid validationTrackingId)
+            => _telemetryClient.TrackMetric(
+                    SentValidationTakingTooLongMessage,
+                    1,
+                    new Dictionary<string, string>
+                    {
+                        { PackageId, packageId },
+                        { NormalizedVersion, normalizedVersion },
+                        { ValidationTrackingId, validationTrackingId.ToString() },
+                    });
+
+        public void TrackValidationSetTimeout(string packageId, string normalizedVersion, Guid validationTrackingId)
+            => _telemetryClient.TrackMetric(
+                    ValidationSetTimeout,
+                    1,
+                    new Dictionary<string, string>
+                    {
+                        { PackageId, packageId },
+                        { NormalizedVersion, normalizedVersion },
+                        { ValidationTrackingId, validationTrackingId.ToString() },
+                    });
 
         public void TrackValidationIssue(string validatorType, ValidationIssueCode code)
         {

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
@@ -14,15 +14,18 @@ namespace NuGet.Services.Validation.Orchestrator
 {
     public class ValidationOutcomeProcessor : IValidationOutcomeProcessor
     {
+        private readonly IValidationStorageService _validationStorageService;
         private readonly IPackageValidationEnqueuer _validationEnqueuer;
         private readonly IPackageStatusProcessor _packageStateProcessor;
         private readonly IValidationPackageFileService _packageFileService;
         private readonly ValidationConfiguration _validationConfiguration;
+        private readonly Dictionary<string, ValidationConfigurationItem> _validationConfigurationsByName;
         private readonly IMessageService _messageService;
         private readonly ITelemetryService _telemetryService;
         private readonly ILogger<ValidationOutcomeProcessor> _logger;
 
         public ValidationOutcomeProcessor(
+            IValidationStorageService validationStorageService,
             IPackageValidationEnqueuer validationEnqueuer,
             IPackageStatusProcessor validatedPackageProcessor,
             IValidationPackageFileService packageFileService,
@@ -31,6 +34,7 @@ namespace NuGet.Services.Validation.Orchestrator
             ITelemetryService telemetryService,
             ILogger<ValidationOutcomeProcessor> logger)
         {
+            _validationStorageService = validationStorageService ?? throw new ArgumentNullException(nameof(validationStorageService));
             _validationEnqueuer = validationEnqueuer ?? throw new ArgumentNullException(nameof(validationEnqueuer));
             _packageStateProcessor = validatedPackageProcessor ?? throw new ArgumentNullException(nameof(validatedPackageProcessor));
             _packageFileService = packageFileService ?? throw new ArgumentNullException(nameof(packageFileService));
@@ -44,24 +48,16 @@ namespace NuGet.Services.Validation.Orchestrator
             _messageService = messageService ?? throw new ArgumentNullException(nameof(messageService));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _validationConfigurationsByName = _validationConfiguration.Validations.ToDictionary(v => v.Name);
         }
 
         public async Task ProcessValidationOutcomeAsync(PackageValidationSet validationSet, Package package)
         {
-            var validations = _validationConfiguration.Validations.ToDictionary(v => v.Name);
-            ValidationConfigurationItem GetValidationConfigurationItem(string validationName)
-            {
-                if (validations.TryGetValue(validationName, out ValidationConfigurationItem validationConfigurationItem))
-                {
-                    return validationConfigurationItem;
-                }
-                return null;
-            }
+            var failedValidations = GetFailedValidations(validationSet);
 
-            if (AnyValidationFailed(validationSet, GetValidationConfigurationItem))
+            if (failedValidations.Any())
             {
-                var failedValidations = GetFailedValidations(validationSet, GetValidationConfigurationItem).ToList();
-
                 _logger.LogWarning("Some validations failed for package {PackageId} {PackageVersion}, validation set {ValidationSetId}: {FailedValidations}",
                     package.PackageRegistration.Id,
                     package.NormalizedVersion,
@@ -108,7 +104,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
                 await CompleteValidationSetAsync(package, validationSet, isSuccess: false);
             }
-            else if (AllValidationsSucceeded(validationSet, GetValidationConfigurationItem))
+            else if (AllValidationsSucceeded(validationSet))
             {
                 _logger.LogInformation("All validations are complete for the package {PackageId} {PackageVersion}, validation set {ValidationSetId}",
                     package.PackageRegistration.Id,
@@ -134,10 +130,59 @@ namespace NuGet.Services.Validation.Orchestrator
             }
             else
             {
-                // No failed validations and some validations are still in progress.
-                // Scheduling another check
-                var messageData = new PackageValidationMessageData(package.PackageRegistration.Id, package.Version, validationSet.ValidationTrackingId);
-                await _validationEnqueuer.StartValidationAsync(messageData, DateTimeOffset.UtcNow + _validationConfiguration.ValidationMessageRecheckPeriod);
+                // There are no failed validations and some validations are still in progress. Update
+                // the validation set's Updated field and send a notice if the validation set is taking
+                // too long to complete.
+                var previousUpdateTime = validationSet.Updated;
+
+                await _validationStorageService.UpdateValidationSetAsync(validationSet);
+
+                var validationSetDuration = validationSet.Updated - validationSet.Created;
+                var previousDuration = previousUpdateTime - validationSet.Created;
+
+                // Only send a "validating taking too long" notice once. This is ensured by verifying this is
+                // the package's first validation set and that this is the first time the validation set duration
+                // is greater than the configured threshold. Service Bus message duplication for a single validation
+                // set will not cause multiple notices to be sent due to the row version on PackageValidationSet.
+                if (validationSetDuration > _validationConfiguration.ValidationSetNotificationTimeout &&
+                    previousDuration <= _validationConfiguration.ValidationSetNotificationTimeout &&
+                    await _validationStorageService.GetValidationSetCountAsync(package.Key) == 1)
+                {
+                    _messageService.SendPackageValidationTakingTooLongMessage(package);
+                    _telemetryService.TrackSentValidationTakingTooLongMessage(package.PackageRegistration.Id, package.NormalizedVersion, validationSet.ValidationTrackingId);
+                }
+
+                // Track any validations that have timed out.
+                var timedOutValidations = GetIncompleteTimedOutValidations(validationSet);
+
+                if (timedOutValidations.Any())
+                {
+                    foreach (var validation in timedOutValidations)
+                    {
+                        var duration = DateTime.UtcNow - validation.Started;
+
+                        _logger.LogWarning("Validation {Validation} for package {PackageId} {PackageVersion} has reached the configured failure timeout after duration {Duration}",
+                            validation.Type,
+                            validationSet.PackageId,
+                            validationSet.PackageNormalizedVersion,
+                            duration);
+
+                        _telemetryService.TrackValidatorTimeout(validation.Type);
+                    }
+                }
+
+                // Schedule another check if we haven't reached the validation set timeout yet.
+                if (validationSetDuration <= _validationConfiguration.TimeoutValidationSetAfter)
+                {
+                    var messageData = new PackageValidationMessageData(package.PackageRegistration.Id, package.Version, validationSet.ValidationTrackingId);
+                    var postponeUntil = DateTimeOffset.UtcNow + _validationConfiguration.ValidationMessageRecheckPeriod;
+
+                    await _validationEnqueuer.StartValidationAsync(messageData, postponeUntil);
+                }
+                else
+                {
+                    _telemetryService.TrackValidationSetTimeout(package.PackageRegistration.Id, package.NormalizedVersion, validationSet.ValidationTrackingId);
+                }
             }
         }
 
@@ -154,6 +199,13 @@ namespace NuGet.Services.Validation.Orchestrator
             TrackTotalValidationDuration(validationSet, isSuccess);
         }
 
+        private ValidationConfigurationItem GetValidationConfigurationItemByName(string name)
+        {
+            _validationConfigurationsByName.TryGetValue(name, out var item);
+
+            return item;
+        }
+
         private void TrackTotalValidationDuration(PackageValidationSet validationSet, bool isSuccess)
         {
             _telemetryService.TrackTotalValidationDuration(
@@ -161,31 +213,38 @@ namespace NuGet.Services.Validation.Orchestrator
                 isSuccess);
         }
 
-        private bool AllValidationsSucceeded(
-            PackageValidationSet packageValidationSet,
-            Func<string, ValidationConfigurationItem> getValidationConfigurationItem)
+        private bool AllValidationsSucceeded(PackageValidationSet packageValidationSet)
         {
             return packageValidationSet
                 .PackageValidations
                 .All(pv => pv.ValidationStatus == ValidationStatus.Succeeded
-                    || getValidationConfigurationItem(pv.Type)?.FailureBehavior == ValidationFailureBehavior.AllowedToFail);
+                    || GetValidationConfigurationItemByName(pv.Type)?.FailureBehavior == ValidationFailureBehavior.AllowedToFail);
         }
 
-        private IEnumerable<PackageValidation> GetFailedValidations(
-            PackageValidationSet packageValidationSet,
-            Func<string, ValidationConfigurationItem> getValidationConfigurationItem)
+        private List<PackageValidation> GetFailedValidations(PackageValidationSet packageValidationSet)
         {
             return packageValidationSet
                 .PackageValidations
-                .Where(v => v.ValidationStatus == ValidationStatus.Failed
-                    && getValidationConfigurationItem(v.Type)?.FailureBehavior == ValidationFailureBehavior.MustSucceed);
+                .Where(v => v.ValidationStatus == ValidationStatus.Failed)
+                .Where(v => GetValidationConfigurationItemByName(v.Type)?.FailureBehavior == ValidationFailureBehavior.MustSucceed)
+                .ToList();
         }
 
-        private bool AnyValidationFailed(
-            PackageValidationSet packageValidationSet,
-            Func<string, ValidationConfigurationItem> getValidationConfigurationItem)
+        private List<PackageValidation> GetIncompleteTimedOutValidations(PackageValidationSet packageValidationSet)
         {
-            return GetFailedValidations(packageValidationSet, getValidationConfigurationItem).Any();
+            bool IsPackageValidationTimedOut(PackageValidation validation)
+            {
+                var config = GetValidationConfigurationItemByName(validation.Type);
+                var duration = DateTime.UtcNow - validation.Started;
+
+                return duration > config?.TrackAfter;
+            }
+
+            return packageValidationSet
+                .PackageValidations
+                .Where(v => v.ValidationStatus == ValidationStatus.Incomplete)
+                .Where(IsPackageValidationTimedOut)
+                .ToList();
         }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
@@ -90,6 +90,20 @@ namespace NuGet.Services.Validation.Orchestrator
             TrackValidationStatus(packageValidation);
         }
 
+        public Task UpdateValidationSetAsync(PackageValidationSet packageValidationSet)
+        {
+            packageValidationSet = packageValidationSet ?? throw new ArgumentNullException(nameof(packageValidationSet));
+
+            _logger.LogInformation("Updating the status of the validation set {ValidationId} {PackageId} {PackageVersion}",
+                packageValidationSet.ValidationTrackingId,
+                packageValidationSet.PackageId,
+                packageValidationSet.PackageNormalizedVersion);
+
+            packageValidationSet.Updated = DateTime.UtcNow;
+
+            return _validationContext.SaveChangesAsync();
+        }
+
         public async Task UpdateValidationStatusAsync(PackageValidation packageValidation, IValidationResult validationResult)
         {
             packageValidation = packageValidation ?? throw new ArgumentNullException(nameof(packageValidation));

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -3,21 +3,21 @@
     "Validations": [
       {
         "name": "VcsValidator",
-        "failAfter": "1:00:00:00",
+        "TrackAfter": "1:00:00:00",
         "requiredValidations": [],
         "ShouldStart": true,
         "FailureBehavior": "MustSucceed"
       },
       {
         "name": "PackageSigningValidator",
-        "failAfter": "1:00:00:00",
+        "TrackAfter": "00:10:00",
         "requiredValidations": [],
         "ShouldStart": true,
         "FailureBehavior": "MustSucceed"
       },
       {
         "name": "PackageCertificatesValidator",
-        "failAfter": "10:00",
+        "TrackAfter": "00:10:00",
         "requiredValidations": [ "PackageSigningValidator" ],
         "ShouldStart": true,
         "FailureBehavior": "AllowedToFail"
@@ -26,7 +26,9 @@
     "ValidationStorageConnectionString": "",
     "MissingPackageRetryCount": 15,
     "ValidationMessageRecheckPeriod": "00:01:00",
-    "NewValidationRequestDeduplicationWindow": "00:20:00"
+    "NewValidationRequestDeduplicationWindow": "00:20:00",
+    "ValidationSetNotificationTimeout": "00:50:00",
+    "TimeoutValidationSetAfter": "1:00:00:00"
   },
   "Vcs": {
     "ContainerName": "validation",

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
@@ -23,13 +23,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation2" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     }
                 }
@@ -51,12 +51,12 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = validationName,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                     },
                     new ValidationConfigurationItem
                     {
                         Name = validationName,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                     }
                 }
             };
@@ -79,7 +79,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ NonExistentValidationName }
                     },
                 }
@@ -102,7 +102,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = validationName,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>(),
                     },
                 }
@@ -128,19 +128,19 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = validationName1,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>(),
                     },
                     new ValidationConfigurationItem
                     {
                         Name = validationName2,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string> { validationName1 },
                     },
                     new ValidationConfigurationItem
                     {
                         Name = processorName1,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string> { validationName1 },
                     },
                 }
@@ -177,19 +177,19 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = validationName1,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>(),
                     },
                     new ValidationConfigurationItem
                     {
                         Name = validationName2,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string> { validationName1 },
                     },
                     new ValidationConfigurationItem
                     {
                         Name = processorName1,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string> { validationName2 },
                     },
                 }
@@ -221,13 +221,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation2"}
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation1"}
                     }
                 }
@@ -249,7 +249,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation1" }
                     },
                 }
@@ -271,13 +271,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation2" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation2" }
                     }
                 }
@@ -299,7 +299,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "",
-                        FailAfter = TimeSpan.FromHours(1)
+                        TrackAfter = TimeSpan.FromHours(1)
                     }
                 }
             };
@@ -311,7 +311,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Fact]
-        public void FailureTimeoutsCantBeZero()
+        public void ValidationTimeoutsCantBeZero()
         {
             var configuration = new ValidationConfiguration()
             {
@@ -320,7 +320,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "SomeValidation",
-                        FailAfter = TimeSpan.Zero
+                        TrackAfter = TimeSpan.Zero
                     }
                 }
             };
@@ -328,7 +328,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             var ex = Record.Exception(() => Validate(configuration));
 
             Assert.IsType<ConfigurationErrorsException>(ex);
-            Assert.Contains("FailAfter", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(nameof(ValidationConfigurationItem.TrackAfter), ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
@@ -352,25 +352,25 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation3", "Validation4" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation3", "Validation4" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation3",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation4",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     }
                 }
@@ -401,25 +401,25 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation2", "Validation3" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation4" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation3",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation4" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation4",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     }
                 }
@@ -441,19 +441,19 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation2" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation3",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation1" }
                     }
                 }
@@ -474,13 +474,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     }
                 }
@@ -506,19 +506,19 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = "Validation1",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>()
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation2",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation3" }
                     },
                     new ValidationConfigurationItem
                     {
                         Name = "Validation3",
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>{ "Validation2" }
                     }
                 }
@@ -553,7 +553,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     new ValidationConfigurationItem
                     {
                         Name = firstValidationName,
-                        FailAfter = TimeSpan.FromHours(1),
+                        TrackAfter = TimeSpan.FromHours(1),
                         RequiredValidations = new List<string>(),
                         ShouldStart = false
                     }
@@ -567,7 +567,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 configuration.Validations.Add(new ValidationConfigurationItem
                 {
                     Name = intermediateValidationName,
-                    FailAfter = TimeSpan.FromHours(1),
+                    TrackAfter = TimeSpan.FromHours(1),
                     RequiredValidations = new List<string> { previousValidationName },
                     ShouldStart = true,
                     FailureBehavior = intermediateValidationsFailureBehavior
@@ -578,7 +578,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             configuration.Validations.Add(new ValidationConfigurationItem
             {
                 Name = lastValidationName,
-                FailAfter = TimeSpan.FromHours(1),
+                TrackAfter = TimeSpan.FromHours(1),
                 RequiredValidations = new List<string> { previousValidationName },
                 ShouldStart = true,
                 FailureBehavior = lastValidationFailureBehavior

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -76,11 +76,151 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Fact]
+        public async Task TracksTimedOutValidators()
+        {
+            const int postponeMinutes = 1;
+
+            AddValidation(
+                "IncompleteAndNotTimedOut",
+                ValidationStatus.Incomplete,
+                validationStart: DateTime.UtcNow,
+                trackAfter: TimeSpan.FromDays(1));
+            AddValidation(
+                "IncompleteButTimedOut",
+                ValidationStatus.Incomplete,
+                validationStart: DateTime.UtcNow + TimeSpan.FromDays(-5),
+                trackAfter: TimeSpan.FromDays(1));
+
+            Configuration.TimeoutValidationSetAfter = TimeSpan.FromDays(1);
+            Configuration.ValidationMessageRecheckPeriod = TimeSpan.FromMinutes(postponeMinutes);
+
+            var processor = CreateProcessor();
+            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+
+            TelemetryServiceMock
+                .Verify(t => t.TrackValidatorTimeout("IncompleteButTimedOut"));
+            ValidationEnqueuerMock
+                .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Once);
+            PackageFileServiceMock
+                .Verify(x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task DoesNotReEnqueueProcessingIfValidationSetTimesOut()
+        {
+            const int postponeMinutes = 1;
+
+            AddValidation("validation1", ValidationStatus.Incomplete);
+
+            Configuration.TimeoutValidationSetAfter = TimeSpan.FromDays(1);
+            Configuration.ValidationMessageRecheckPeriod = TimeSpan.FromMinutes(postponeMinutes);
+
+            ValidationSet.Created = DateTime.UtcNow - TimeSpan.FromDays(1) - TimeSpan.FromHours(1);
+
+            var processor = CreateProcessor();
+            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+
+            TelemetryServiceMock
+                .Verify(t => t.TrackValidationSetTimeout(Package.PackageRegistration.Id, Package.NormalizedVersion, ValidationSet.ValidationTrackingId));
+            ValidationEnqueuerMock
+                .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Never);
+            PackageFileServiceMock
+                .Verify(x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task SendsValidatingTooLongMessageOnce()
+        {
+            const int postponeMinutes = 1;
+
+            AddValidation("validation1", ValidationStatus.Incomplete);
+
+            Configuration.TimeoutValidationSetAfter = TimeSpan.FromDays(1);
+            Configuration.ValidationSetNotificationTimeout = TimeSpan.FromMinutes(20);
+            Configuration.ValidationMessageRecheckPeriod = TimeSpan.FromMinutes(postponeMinutes);
+
+            ValidationSet.Created = DateTime.UtcNow - TimeSpan.FromMinutes(21);
+            ValidationSet.Updated = DateTime.UtcNow - TimeSpan.FromMinutes(15);
+
+            ValidationStorageServiceMock
+                .Setup(s => s.UpdateValidationSetAsync(It.IsAny<PackageValidationSet>()))
+                .Callback<PackageValidationSet>(s => s.Updated = DateTime.UtcNow)
+                .Returns(Task.FromResult(0));
+
+            ValidationStorageServiceMock
+                .Setup(s => s.GetValidationSetCountAsync(Package.Key))
+                .Returns(Task.FromResult(1));
+
+            // Process the outcome once - the "too long to validate" message should be sent.
+            var processor = CreateProcessor();
+            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+
+            TelemetryServiceMock
+                .Verify(t => t.TrackSentValidationTakingTooLongMessage(Package.PackageRegistration.Id, Package.NormalizedVersion, ValidationSet.ValidationTrackingId), Times.Once);
+            MessageServiceMock
+                .Verify(m => m.SendPackageValidationTakingTooLongMessage(Package), Times.Once);
+            ValidationEnqueuerMock
+                .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Once);
+            PackageFileServiceMock
+                .Verify(x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Never);
+
+            // Process the outcome again - the "too long to validate" message should NOT be sent.
+            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+
+            TelemetryServiceMock
+                .Verify(t => t.TrackSentValidationTakingTooLongMessage(Package.PackageRegistration.Id, Package.NormalizedVersion, ValidationSet.ValidationTrackingId), Times.Once);
+            MessageServiceMock
+                .Verify(m => m.SendPackageValidationTakingTooLongMessage(Package), Times.Once);
+            ValidationEnqueuerMock
+                .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Exactly(2));
+            PackageFileServiceMock
+                .Verify(x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task DoesNotSendValidatingTooLongMessageOnRevalidations()
+        {
+            const int postponeMinutes = 1;
+
+            AddValidation("validation1", ValidationStatus.Incomplete);
+
+            Configuration.TimeoutValidationSetAfter = TimeSpan.FromDays(1);
+            Configuration.ValidationSetNotificationTimeout = TimeSpan.FromMinutes(20);
+            Configuration.ValidationMessageRecheckPeriod = TimeSpan.FromMinutes(postponeMinutes);
+
+            ValidationSet.Created = DateTime.UtcNow - TimeSpan.FromMinutes(21);
+            ValidationSet.Updated = DateTime.UtcNow - TimeSpan.FromMinutes(15);
+
+            ValidationStorageServiceMock
+                .Setup(s => s.UpdateValidationSetAsync(It.IsAny<PackageValidationSet>()))
+                .Callback<PackageValidationSet>(s => s.Updated = DateTime.UtcNow)
+                .Returns(Task.FromResult(0));
+
+            ValidationStorageServiceMock
+                .Setup(s => s.GetValidationSetCountAsync(Package.Key))
+                .Returns(Task.FromResult(2));
+
+            // Process the outcome once - the "too long to validate" message should NOT be sent.
+            var processor = CreateProcessor();
+            await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+
+            TelemetryServiceMock
+                .Verify(t => t.TrackSentValidationTakingTooLongMessage(Package.PackageRegistration.Id, Package.NormalizedVersion, ValidationSet.ValidationTrackingId), Times.Never);
+            MessageServiceMock
+                .Verify(m => m.SendPackageValidationTakingTooLongMessage(Package), Times.Never);
+            ValidationEnqueuerMock
+                .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Once);
+            PackageFileServiceMock
+                .Verify(x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Never);
+        }
+
+        [Fact]
         public async Task ReEnqueuesProcessingIfNotAllComplete()
         {
             const int postponeMinutes = 1;
             AddValidation("validation1", ValidationStatus.Incomplete);
             Configuration.ValidationMessageRecheckPeriod = TimeSpan.FromMinutes(postponeMinutes);
+            Configuration.TimeoutValidationSetAfter = TimeSpan.FromDays(1);
 
             PackageValidationMessageData messageData = null;
             DateTimeOffset postponeTill = DateTimeOffset.MinValue;
@@ -92,6 +232,9 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             var processor = CreateProcessor();
             var startTime = DateTimeOffset.Now;
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
+
+            ValidationStorageServiceMock
+                .Verify(s => s.UpdateValidationSetAsync(ValidationSet), Times.Once);
 
             ValidationEnqueuerMock
                 .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Once());
@@ -246,7 +389,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 Configuration.Validations.Add(new ValidationConfigurationItem
                 {
                     Name = "validation" + cfgValidatorIndex,
-                    FailAfter = TimeSpan.FromDays(1),
+                    TrackAfter = TimeSpan.FromDays(1),
                     RequiredValidations = new List<string> { }
                 });
             }
@@ -307,6 +450,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
         public ValidationOutcomeProcessorFacts()
         {
+            ValidationStorageServiceMock = new Mock<IValidationStorageService>();
             ValidationEnqueuerMock = new Mock<IPackageValidationEnqueuer>();
             PackageStateProcessorMock = new Mock<IPackageStatusProcessor>();
             PackageFileServiceMock = new Mock<IValidationPackageFileService>();
@@ -332,7 +476,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationSet.PackageId = Package.PackageRegistration.Id;
             ValidationSet.PackageNormalizedVersion = Package.NormalizedVersion;
             ValidationSet.ValidationTrackingId = Guid.NewGuid();
-            ValidationSet.Created = new DateTime(2017, 1, 1, 8, 30, 0, DateTimeKind.Utc);
+            ValidationSet.Created = DateTime.UtcNow - TimeSpan.FromHours(3);
+            ValidationSet.Updated = ValidationSet.Created + TimeSpan.FromHours(1);
 
             ConfigurationAccessorMock
                 .SetupGet(ca => ca.Value)
@@ -342,6 +487,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         protected ValidationOutcomeProcessor CreateProcessor()
         {
             return new ValidationOutcomeProcessor(
+                ValidationStorageServiceMock.Object,
                 ValidationEnqueuerMock.Object,
                 PackageStateProcessorMock.Object,
                 PackageFileServiceMock.Object,
@@ -351,6 +497,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 LoggerMock.Object);
         }
 
+        protected Mock<IValidationStorageService> ValidationStorageServiceMock { get; }
         protected Mock<IPackageStatusProcessor> PackageStateProcessorMock { get; }
         protected Mock<IValidationPackageFileService> PackageFileServiceMock { get; }
         protected Mock<IPackageValidationEnqueuer> ValidationEnqueuerMock { get; }
@@ -362,18 +509,24 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         protected PackageValidationSet ValidationSet { get; }
         protected Package Package { get; }
 
-        private void AddValidation(string validationName, ValidationStatus validationStatus, ValidationFailureBehavior failureBehavior = ValidationFailureBehavior.MustSucceed)
+        private void AddValidation(
+            string validationName,
+            ValidationStatus validationStatus,
+            ValidationFailureBehavior failureBehavior = ValidationFailureBehavior.MustSucceed,
+            DateTime? validationStart = null,
+            TimeSpan? trackAfter = null)
         {
             ValidationSet.PackageValidations.Add(new PackageValidation
             {
                 Type = validationName,
+                Started = validationStart,
                 ValidationStatus = validationStatus,
                 PackageValidationIssues = new List<PackageValidationIssue> { },
             });
             Configuration.Validations.Add(new ValidationConfigurationItem
             {
                 Name = validationName,
-                FailAfter = TimeSpan.FromDays(1),
+                TrackAfter = trackAfter ?? TimeSpan.FromDays(1),
                 RequiredValidations = new List<string> { },
                 ShouldStart = true,
                 FailureBehavior = failureBehavior

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -117,6 +117,11 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             ValidationSet.Created = DateTime.UtcNow - TimeSpan.FromDays(1) - TimeSpan.FromHours(1);
 
+            ValidationStorageServiceMock
+                .Setup(s => s.UpdateValidationSetAsync(It.IsAny<PackageValidationSet>()))
+                .Callback<PackageValidationSet>(s => s.Updated = DateTime.UtcNow)
+                .Returns(Task.FromResult(0));
+
             var processor = CreateProcessor();
             await processor.ProcessValidationOutcomeAsync(ValidationSet, Package);
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
@@ -63,7 +63,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 new ValidationConfigurationItem
                 {
                     Name = validation1,
-                    FailAfter = TimeSpan.FromDays(1),
+                    TrackAfter = TimeSpan.FromDays(1),
                     RequiredValidations = new List<string>{}
                 }
             };
@@ -111,7 +111,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string validation1 = "validation1";
             Configuration.Validations = new List<ValidationConfigurationItem>
             {
-                new ValidationConfigurationItem(){ Name = validation1, FailAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
             };
 
             Package.PackageStatusKey = PackageStatus.Available;
@@ -155,7 +155,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string validation1 = "validation1";
             Configuration.Validations = new List<ValidationConfigurationItem>
             {
-                new ValidationConfigurationItem(){ Name = validation1, FailAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
             };
 
             Package.PackageStatusKey = packageStatus;
@@ -249,8 +249,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string validation2 = "validation2";
             Configuration.Validations = new List<ValidationConfigurationItem>
             {
-                new ValidationConfigurationItem(){ Name = validation1, FailAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ validation2 } },
-                new ValidationConfigurationItem(){ Name = validation2, FailAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ validation2 } },
+                new ValidationConfigurationItem(){ Name = validation2, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
             };
 
             Guid validationTrackingId = Guid.NewGuid();
@@ -320,7 +320,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string validation1 = "validation1";
             Configuration.Validations = new List<ValidationConfigurationItem>
             {
-                new ValidationConfigurationItem(){ Name = validation1, FailAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
             };
 
             Guid validationTrackingId = Guid.NewGuid();

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
@@ -16,6 +16,37 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 {
     public class ValidationStorageServiceFacts
     {
+        public class UpdateValidationSetStatusAsync : TelemetryFacts
+        {
+            public UpdateValidationSetStatusAsync(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            protected override async Task ExecuteAsync(ValidationResult validationResult)
+            {
+                await _target.UpdateValidationStatusAsync(_packageValidation, validationResult);
+            }
+
+            [Fact]
+            public async Task UpdatesUpdateTimestamp()
+            {
+                // Arrange
+                var originalUpdated = DateTime.UtcNow - TimeSpan.FromMinutes(5);
+
+                var validationSet = new PackageValidationSet()
+                {
+                    Updated = originalUpdated
+                };
+
+                // Act & Assert
+                await _target.UpdateValidationSetAsync(validationSet);
+
+                _entitiesContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+
+                Assert.True(validationSet.Updated > originalUpdated);
+            }
+        }
+
         public class UpdateValidationStatusAsync : TelemetryFacts
         {
             public UpdateValidationStatusAsync(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
Change the Orchestrator so that:

* Validation timeouts no longer fail validations
* An email is sent when a validation set reaches the `SendPackageIsTakingTooLongToValidateMessageAfter` threshold. This is currently set to 50m due to the state of our current pipeline.
* Metrics are emitted when validators reach their `TimeoutAfter` threshold
* A validation set no longer gets processed after its duration passes the `TimeoutValidationSetAfter` threshold

An alert will be raised when a validation set times out. The on-call engineer will need to either:
1. Revalidate the package
2. Mark the package as invalid in the Gallery (PackageStatusKey = Invalid) and send a canned email to the user. We should consider making an admin panel for this.

Total validation times since March 1st:

50% | 90% | 95% | 99%
--- | --- | --- | ---
2.2m | 11m | 47m | 4.7h

Progress on https://github.com/NuGet/Engineering/issues/1144