### PR TITLE
Make validator provider cache the types it discovers

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/ValidatorProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidatorProvider.cs
@@ -12,35 +12,63 @@ namespace NuGet.Services.Validation.Orchestrator
 {
     public class ValidatorProvider : IValidatorProvider
     {
+        /// <summary>
+        /// This is a cache of all of the <see cref="IValidator"/> and <see cref="IProcessor"/> implementations
+        /// available.
+        /// </summary>
+        private static EvaluatedTypes _evaluatedTypes;
+        private static object _evaluatedTypesLock = new object();
+
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<ValidatorProvider> _logger;
-        private readonly Dictionary<string, Type> _validatorTypes;
-        private readonly Dictionary<string, Type> _processorTypes;
 
         public ValidatorProvider(IServiceProvider serviceProvider, ILogger<ValidatorProvider> logger)
         {
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            using (_logger.BeginScope("Enumerating all IValidator implementations"))
+            InitializeEvaluatedTypes(Assembly.GetCallingAssembly());
+        }
+
+        /// <summary>
+        /// Discovers all <see cref="IValidator"/> and <see cref="IProcessor"/> types available and caches the result.
+        /// </summary>
+        private void InitializeEvaluatedTypes(Assembly callingAssembly)
+        {
+            if (_evaluatedTypes != null)
             {
-                _logger.LogTrace("Before enumeration");
-                IEnumerable<Type> candidateTypes = GetCandidateTypes(Assembly.GetCallingAssembly());
+                return;
+            }
 
-                _validatorTypes = candidateTypes
-                    .Where(type => typeof(IValidator).IsAssignableFrom(type)
-                           && type != typeof(IValidator)
-                           && type != typeof(IProcessor))
-                    .ToDictionary(type => type.Name);
+            lock (_evaluatedTypesLock)
+            {
+                if (_evaluatedTypes != null)
+                {
+                    return;
+                }
 
-                _processorTypes = _validatorTypes
-                    .Values
-                    .Where(IsProcessor)
-                    .ToDictionary(type => type.Name);
+                using (_logger.BeginScope("Enumerating all IValidator implementations"))
+                {
+                    _logger.LogTrace("Before enumeration");
+                    IEnumerable<Type> candidateTypes = GetCandidateTypes(callingAssembly);
 
-                _logger.LogTrace("After enumeration, got {NumImplementations} implementations: {TypeNames}",
-                    _validatorTypes.Count,
-                    _validatorTypes.Keys);
+                    var validatorTypes = candidateTypes
+                        .Where(type => typeof(IValidator).IsAssignableFrom(type)
+                               && type != typeof(IValidator)
+                               && type != typeof(IProcessor))
+                        .ToDictionary(type => type.Name);
+
+                    var processorTypes = validatorTypes
+                        .Values
+                        .Where(IsProcessorType)
+                        .ToDictionary(type => type.Name);
+
+                    _logger.LogTrace("After enumeration, got {NumImplementations} implementations: {TypeNames}",
+                        validatorTypes.Count,
+                        validatorTypes.Keys);
+
+                    _evaluatedTypes = new EvaluatedTypes(validatorTypes, processorTypes);
+                }
             }
         }
 
@@ -48,21 +76,21 @@ namespace NuGet.Services.Validation.Orchestrator
         {
             validatorName = validatorName ?? throw new ArgumentNullException(nameof(validatorName));
 
-            return _validatorTypes.ContainsKey(validatorName);
+            return _evaluatedTypes.ValidatorTypes.ContainsKey(validatorName);
         }
 
         public bool IsProcessor(string validatorName)
         {
             validatorName = validatorName ?? throw new ArgumentNullException(nameof(validatorName));
 
-            return _processorTypes.ContainsKey(validatorName);
+            return _evaluatedTypes.ProcessorTypes.ContainsKey(validatorName);
         }
 
         public IValidator GetValidator(string validatorName)
         {
             validatorName = validatorName ?? throw new ArgumentNullException(nameof(validatorName));
 
-            if (_validatorTypes.TryGetValue(validatorName, out Type validatorType))
+            if (_evaluatedTypes.ValidatorTypes.TryGetValue(validatorName, out Type validatorType))
             {
                 return (IValidator)_serviceProvider.GetRequiredService(validatorType);
             }
@@ -82,9 +110,23 @@ namespace NuGet.Services.Validation.Orchestrator
             return candidateTypes;
         }
 
-        private static bool IsProcessor(Type type)
+        private static bool IsProcessorType(Type type)
         {
             return typeof(IProcessor).IsAssignableFrom(type);
+        }
+
+        private class EvaluatedTypes
+        {
+            public EvaluatedTypes(
+                IReadOnlyDictionary<string, Type> validatorTypes,
+                IReadOnlyDictionary<string, Type> processorTypes)
+            {
+                ValidatorTypes = validatorTypes ?? throw new ArgumentNullException(nameof(validatorTypes));
+                ProcessorTypes = processorTypes ?? throw new ArgumentNullException(nameof(validatorTypes));
+            }
+
+            public IReadOnlyDictionary<string, Type> ValidatorTypes { get; }
+            public IReadOnlyDictionary<string, Type> ProcessorTypes { get; }
         }
     }
 }

--- a/tests/Validation.PackageSigning.Core.Tests/Support/RecordingLogger.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/RecordingLogger.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
-namespace Validation.PackageSigning.ExtractAndValidateSignature.Tests
+namespace Validation.PackageSigning.Core.Tests.Support
 {
     public class RecordingLogger<T> : ILogger<T>
     {

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Support\CertificateIntegrationTestFixture.cs" />
     <Compile Include="Support\DbSetMockFactory.cs" />
     <Compile Include="Support\ExtensionMethods.cs" />
+    <Compile Include="Support\RecordingLogger.cs" />
     <Compile Include="Support\TestDbAsyncEnumerable.cs" />
     <Compile Include="Support\TestDbAsyncEnumerator.cs" />
     <Compile Include="Support\TestDbAsyncQueryProvider.cs" />

--- a/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests/Validation.PackageSigning.ExtractAndValidateSignature.Tests.csproj
@@ -35,7 +35,6 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Support\RecordingLogger.cs" />
     <Compile Include="Support\CertificateIntegrationTestCollection.cs" />
     <Compile Include="Support\CertificateIntegrationTestFixture.cs" />
     <Compile Include="HashFacts.cs" />


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1190.

The validator provider is now depended on by two components so we were getting these two messages twice... per message. This stuff should not change at runtime so we can cache it to reduce log noise.

```
2018-03-13 11:26:49 [Verbose] Before enumeration
2018-03-13 11:26:49 [Verbose] After enumeration, got 3 implementations: ["VcsValidator", "PackageSigningValidator", "PackageCertificatesValidator"]
```