### PR TITLE
Add a visibility delay option for signature and certificate Service Bus

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -199,6 +199,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IValidationSetProvider, ValidationSetProvider>();
             services.AddTransient<IValidationSetProcessor, ValidationSetProcessor>();
             services.AddTransient<IBrokeredMessageSerializer<SignatureValidationMessage>, SignatureValidationMessageSerializer>();
+            services.AddTransient<IBrokeredMessageSerializer<CertificateValidationMessage>, CertificateValidationMessageSerializer>();
             services.AddTransient<IValidatorStateService, ValidatorStateService>();
             services.AddTransient<PackageSigningValidator>();
             services.AddTransient<MailSenderConfiguration>(serviceProvider =>

--- a/src/NuGet.Services.Validation.Orchestrator/PackageCertificates/PackageCertificatesConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageCertificates/PackageCertificatesConfiguration.cs
@@ -14,6 +14,11 @@ namespace NuGet.Services.Validation.PackageCertificates
         public TimeSpan? CertificateRevalidationThreshold { get; set; }
 
         /// <summary>
+        /// The visibility delay to apply to Service Bus messages requesting a new validation.
+        /// </summary>
+        public TimeSpan? MessageDelay { get; set; }
+
+        /// <summary>
         /// The Service Bus configuration used to enqueue package certificate validations.
         /// </summary>
         public ServiceBusConfiguration ServiceBus { get; set; }

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Jobs.Configuration;
 
 namespace NuGet.Services.Validation.PackageSigning
@@ -14,5 +15,10 @@ namespace NuGet.Services.Validation.PackageSigning
         /// The Service Bus configuration used to enqueue package signing validations.
         /// </summary>
         public ServiceBusConfiguration ServiceBus { get; set; }
+
+        /// <summary>
+        /// The visibility delay to apply to Service Bus messages requesting a new validation.
+        /// </summary>
+        public TimeSpan? MessageDelay { get; set; }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/PackageSigningValidator.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Services.Validation.Orchestrator;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
 
 namespace NuGet.Services.Validation.PackageSigning
 {
@@ -13,15 +15,18 @@ namespace NuGet.Services.Validation.PackageSigning
     {
         private readonly IValidatorStateService _validatorStateService;
         private readonly IPackageSignatureVerificationEnqueuer _signatureVerificationEnqueuer;
+        private readonly ITelemetryService _telemetryService;
         private readonly ILogger<PackageSigningValidator> _logger;
 
         public PackageSigningValidator(
             IValidatorStateService validatorStateService,
             IPackageSignatureVerificationEnqueuer signatureVerificationEnqueuer,
+            ITelemetryService telemetryService,
             ILogger<PackageSigningValidator> logger)
         {
             _validatorStateService = validatorStateService ?? throw new ArgumentNullException(nameof(validatorStateService));
             _signatureVerificationEnqueuer = signatureVerificationEnqueuer ?? throw new ArgumentNullException(nameof(signatureVerificationEnqueuer));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -57,9 +62,15 @@ namespace NuGet.Services.Validation.PackageSigning
 
             // Kick off the verification process. Note that the jobs will not verify the package until the
             // state of this validator has been persisted to the database.
+            var stopwatch = Stopwatch.StartNew();
+
             await _signatureVerificationEnqueuer.EnqueueVerificationAsync(request);
 
-            return await _validatorStateService.TryAddValidatorStatusAsync(request, validatorStatus, ValidationStatus.Incomplete);
+            var result = await _validatorStateService.TryAddValidatorStatusAsync(request, validatorStatus, ValidationStatus.Incomplete);
+
+            _telemetryService.TrackDurationToStartPackageSigningValidator(stopwatch.Elapsed);
+
+            return result;
         }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -66,6 +66,19 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         void TrackValidatorStarted(string validatorType);
 
         /// <summary>
+        /// The duration to start the package signing validator. This includes both the enqueue and DB commit time.
+        /// </summary>
+        /// <param name="duration">The duration.</param>
+        void TrackDurationToStartPackageSigningValidator(TimeSpan duration);
+
+        /// <summary>
+        /// The duration to star the package certificates validator. This includes all enqueue times and the DB commit
+        /// time.
+        /// </summary>
+        /// <param name="duration">The duration.</param>
+        void TrackDurationToStartPackageCertificatesValidator(TimeSpan duration);
+
+        /// <summary>
         /// A counter metric emmitted when a validator reaches a terminal state and potentially persists validation
         /// issues. A count of zero is emitted if the validator does not produce any issues. This metric is not emitted
         /// if the validation is still at a non-terminal state.

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -10,22 +10,28 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
 {
     public class TelemetryService : ITelemetryService
     {
-        private const string Prefix = "Orchestrator.";
+        private const string OrchestratorPrefix = "Orchestrator.";
+        private const string PackageSigningPrefix = "PackageSigning.";
+        private const string PackageCertificatesPrefix = "PackageCertificates.";
 
-        private const string DurationToValidationSetCreationSeconds = Prefix + "DurationToValidationSetCreationSeconds";
-        private const string PackageStatusChange = Prefix + "PackageStatusChange";
-        private const string TotalValidationDurationSeconds = Prefix + "TotalValidationDurationSeconds";
-        private const string SentValidationTakingTooLongMessage = Prefix + "SentValidationTakingTooLongMessage";
-        private const string ValidationSetTimeout = Prefix + "TotalValidationDurationSeconds";
-        private const string ValidationIssue = Prefix + "ValidationIssue";
-        private const string ValidationIssueCount = Prefix + "ValidationIssueCount";
-        private const string ValidatorTimeout = Prefix + "ValidatorTimeout";
-        private const string ValidatorDurationSeconds = Prefix + "ValidatorDurationSeconds";
-        private const string ValidatorStarted = Prefix + "ValidatorStarted";
-        private const string ClientValidationIssue = Prefix + "ClientValidationIssue";
-        private const string MissingPackageForValidationMessage = Prefix + "MissingPackageForValidationMessage";
-        private const string MissingNupkgForAvailablePackage = Prefix + "MissingNupkgForAvailablePackage";
-        private const string DurationToHashPackageSeconds = Prefix + "DurationToHashPackageSeconds";
+        private const string DurationToValidationSetCreationSeconds = OrchestratorPrefix + "DurationToValidationSetCreationSeconds";
+        private const string PackageStatusChange = OrchestratorPrefix + "PackageStatusChange";
+        private const string TotalValidationDurationSeconds = OrchestratorPrefix + "TotalValidationDurationSeconds";
+        private const string SentValidationTakingTooLongMessage = OrchestratorPrefix + "SentValidationTakingTooLongMessage";
+        private const string ValidationSetTimeout = OrchestratorPrefix + "TotalValidationDurationSeconds";
+        private const string ValidationIssue = OrchestratorPrefix + "ValidationIssue";
+        private const string ValidationIssueCount = OrchestratorPrefix + "ValidationIssueCount";
+        private const string ValidatorTimeout = OrchestratorPrefix + "ValidatorTimeout";
+        private const string ValidatorDurationSeconds = OrchestratorPrefix + "ValidatorDurationSeconds";
+        private const string ValidatorStarted = OrchestratorPrefix + "ValidatorStarted";
+        private const string ClientValidationIssue = OrchestratorPrefix + "ClientValidationIssue";
+        private const string MissingPackageForValidationMessage = OrchestratorPrefix + "MissingPackageForValidationMessage";
+        private const string MissingNupkgForAvailablePackage = OrchestratorPrefix + "MissingNupkgForAvailablePackage";
+        private const string DurationToHashPackageSeconds = OrchestratorPrefix + "DurationToHashPackageSeconds";
+
+        private const string DurationToStartPackageSigningValidatorSeconds = PackageSigningPrefix + "DurationToStartSeconds";
+
+        private const string DurationToStartPackageCertificatesValidatorSeconds = PackageCertificatesPrefix + "DurationToStartSeconds";
 
         private const string FromStatus = "FromStatus";
         private const string ToStatus = "ToStatus";
@@ -205,5 +211,19 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                         { NormalizedVersion, normalizedVersion },
                         { ValidationTrackingId, validationTrackingId },
                     });
+
+        public void TrackDurationToStartPackageSigningValidator(TimeSpan duration)
+        {
+            _telemetryClient.TrackMetric(
+                DurationToStartPackageSigningValidatorSeconds,
+                duration.TotalSeconds);
+        }
+
+        public void TrackDurationToStartPackageCertificatesValidator(TimeSpan duration)
+        {
+            _telemetryClient.TrackMetric(
+                DurationToStartPackageCertificatesValidatorSeconds,
+                duration.TotalSeconds);
+        }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
@@ -94,13 +94,31 @@ namespace NuGet.Services.Validation.Orchestrator
                     var validator = _validatorProvider.GetValidator(packageValidation.Type);
                     var validationRequest = await CreateValidationRequest(packageValidation.PackageValidationSet, packageValidation, package, validationConfiguration);
                     var validationResult = await validator.GetResultAsync(validationRequest);
-                    _logger.LogInformation("New status for validation {ValidationType} for {PackageId} {PackageVersion} is {ValidationStatus}, validation set {ValidationSetId}, {ValidationId}",
-                        packageValidation.Type,
-                        package.PackageRegistration.Id,
-                        package.NormalizedVersion,
-                        validationResult.Status,
-                        validationSet.ValidationTrackingId,
-                        packageValidation.Key);
+
+                    if (validationResult.Status != ValidationStatus.Incomplete)
+                    {
+                        _logger.LogInformation(
+                            "New status for validation {ValidationType} for {PackageId} {PackageVersion} is " +
+                            "{ValidationStatus}, validation set {ValidationSetId}, {ValidationId}",
+                           packageValidation.Type,
+                           package.PackageRegistration.Id,
+                           package.NormalizedVersion,
+                           validationResult.Status,
+                           validationSet.ValidationTrackingId,
+                           packageValidation.Key);
+                    }
+                    else
+                    {
+                        _logger.LogDebug(
+                            "Validation {ValidationType} for {PackageId} {PackageVersion} is still " +
+                            "{ValidationStatus}, validation set {ValidationSetId}, {ValidationId}",
+                            packageValidation.Type,
+                            package.PackageRegistration.Id,
+                            package.NormalizedVersion,
+                            validationResult.Status,
+                            validationSet.ValidationTrackingId,
+                            packageValidation.Key);
+                    }
 
                     switch (validationResult.Status)
                     {

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -20,7 +20,7 @@
         "TrackAfter": "00:10:00",
         "requiredValidations": [ "PackageSigningValidator" ],
         "ShouldStart": true,
-        "FailureBehavior": "AllowedToFail"
+        "FailureBehavior": "MustSucceed"
       }
     ],
     "ValidationStorageConnectionString": "",
@@ -47,7 +47,8 @@
       "ConnectionString": "",
       "TopicPath": "",
       "SubscriptionName": ""
-    }
+    },
+    "MessageDelay": "00:00:05"
   },
   "PackageCertificates": {
     "CertificateRevalidationThreshold": "1:00:00:00",
@@ -55,7 +56,8 @@
       "ConnectionString": "",
       "TopicPath": "",
       "SubscriptionName": ""
-    }
+    },
+    "MessageDelay": "00:00:05"
   },
   "RunnerConfiguration": {
     "ProcessRecycleInterval": "1:00:00:00",

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -46,7 +46,9 @@
     <Compile Include="Configuration\TopologicalSortFacts.cs" />
     <Compile Include="MessageServiceFacts.cs" />
     <Compile Include="OrchestrationRunnerFacts.cs" />
+    <Compile Include="PackageCertificates\CertificateVerificationEnqueuerFacts.cs" />
     <Compile Include="PackageCertificates\PackageCertificatesValidatorFacts.cs" />
+    <Compile Include="PackageSigning\PackageSignatureVerificationEnqueuerFacts.cs" />
     <Compile Include="PackageSigning\PackageSigningValidatorFacts.cs" />
     <Compile Include="PackageStatusProcessorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageCertificates/CertificateVerificationEnqueuerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageCertificates/CertificateVerificationEnqueuerFacts.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Jobs.Validation.PackageSigning.Messages;
+using NuGet.Services.ServiceBus;
+using NuGet.Services.Validation.PackageCertificates;
+using Xunit;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    public class CertificateVerificationEnqueuerFacts
+    {
+        [Fact]
+        public async Task UsesConfiguredMessageDelay()
+        {
+            var messageDelay = TimeSpan.FromMinutes(1);
+            _configuration.MessageDelay = messageDelay;
+
+            var before = DateTimeOffset.UtcNow;
+            await _target.EnqueueVerificationAsync(_validationRequest.Object, _endCertificate);
+            var after = DateTimeOffset.UtcNow;
+
+            Assert.InRange(_brokeredMessage.Object.ScheduledEnqueueTimeUtc, before.Add(messageDelay), after.Add(messageDelay));
+        }
+
+        [Fact]
+        public async Task DefaultsNullMessageDelayToZero()
+        {
+            var before = DateTimeOffset.UtcNow;
+            await _target.EnqueueVerificationAsync(_validationRequest.Object, _endCertificate);
+            var after = DateTimeOffset.UtcNow;
+
+            Assert.InRange(_brokeredMessage.Object.ScheduledEnqueueTimeUtc, before, after);
+        }
+
+        [Fact]
+        public async Task SendsSerializeMessage()
+        {
+            CertificateValidationMessage message = null;
+            _serializer
+                .Setup(x => x.Serialize(It.IsAny<CertificateValidationMessage>()))
+                .Returns(() => _brokeredMessage.Object)
+                .Callback<CertificateValidationMessage>(x => message = x);
+
+            await _target.EnqueueVerificationAsync(_validationRequest.Object, _endCertificate);
+
+            Assert.Equal(_validationRequest.Object.ValidationId, message.ValidationId);
+            Assert.Equal(_endCertificate.Key, message.CertificateKey);
+            Assert.False(message.RevalidateRevokedCertificate);
+            _serializer.Verify(
+                x => x.Serialize(It.IsAny<CertificateValidationMessage>()),
+                Times.Once);
+            _topicClient.Verify(x => x.SendAsync(_brokeredMessage.Object), Times.Once);
+            _topicClient.Verify(x => x.SendAsync(It.IsAny<IBrokeredMessage>()), Times.Once);
+        }
+
+        private readonly Mock<ITopicClient> _topicClient;
+        private readonly Mock<IBrokeredMessageSerializer<CertificateValidationMessage>> _serializer;
+        private readonly Mock<IOptionsSnapshot<PackageCertificatesConfiguration>> _options;
+        private readonly PackageCertificatesConfiguration _configuration;
+        private readonly Mock<IBrokeredMessage> _brokeredMessage;
+        private readonly Mock<IValidationRequest> _validationRequest;
+        private readonly EndCertificate _endCertificate;
+        private readonly CertificateVerificationEnqueuer _target;
+
+        public CertificateVerificationEnqueuerFacts()
+        {
+            _configuration = new PackageCertificatesConfiguration();
+            _brokeredMessage = new Mock<IBrokeredMessage>();
+            _validationRequest = new Mock<IValidationRequest>();
+            _endCertificate = new EndCertificate { Key = 23 };
+
+            _validationRequest.Setup(x => x.ValidationId).Returns(new Guid("68fc78da-af04-4e4e-8128-de68dcfec3ba"));
+            _brokeredMessage.SetupProperty(x => x.ScheduledEnqueueTimeUtc);
+
+            _topicClient = new Mock<ITopicClient>();
+            _serializer = new Mock<IBrokeredMessageSerializer<CertificateValidationMessage>>();
+            _options = new Mock<IOptionsSnapshot<PackageCertificatesConfiguration>>();
+
+            _options.Setup(x => x.Value).Returns(() => _configuration);
+            _serializer
+                .Setup(x => x.Serialize(It.IsAny<CertificateValidationMessage>()))
+                .Returns(() => _brokeredMessage.Object);
+
+            _target = new CertificateVerificationEnqueuer(
+                _topicClient.Object,
+                _serializer.Object,
+                _options.Object);
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageCertificates/PackageCertificatesValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageCertificates/PackageCertificatesValidatorFacts.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
 using NuGet.Services.Validation.PackageCertificates;
 using Validation.PackageSigning.Helpers;
 using Xunit;
@@ -558,6 +559,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Never);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Never);
 
                 Assert.Equal(status, actual.Status);
             }
@@ -592,6 +596,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
                 Assert.Equal(ValidationStatus.Succeeded, validatorStatus.State);
@@ -671,6 +678,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
                 Assert.Equal(ValidationStatus.Succeeded, validatorStatus.State);
@@ -748,6 +758,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Exactly(2));
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
                 Assert.Equal(ValidationStatus.Incomplete, validatorStatus.State);
@@ -828,6 +841,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Once);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
                 Assert.Equal(ValidationStatus.Incomplete, validatorStatus.State);
@@ -906,6 +922,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Never);
 
                 Assert.Equal(ValidationStatus.Failed, actual.Status);
                 Assert.Equal(ValidationStatus.Failed, validatorStatus.State);
@@ -1068,6 +1087,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Exactly(expectedCertificateValidations));
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
                 Assert.Equal(ValidationStatus.Incomplete, validatorStatus.State);
@@ -1133,6 +1155,9 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Never);
 
                 Assert.Equal(ValidationStatus.Failed, actual.Status);
                 Assert.Equal(ValidationStatus.Failed, validatorStatus.State);
@@ -1147,6 +1172,7 @@ namespace NuGet.Services.Validation.PackageSigning
         {
             protected readonly Mock<IValidationEntitiesContext> _validationContext;
             protected readonly Mock<ICertificateVerificationEnqueuer> _certificateVerifier;
+            protected readonly Mock<ITelemetryService> _telemetryService;
             protected readonly Mock<ILogger<PackageCertificatesValidator>> _logger;
             protected readonly Mock<IValidationRequest> _validationRequest;
             protected readonly PackageCertificatesValidator _target;
@@ -1155,6 +1181,7 @@ namespace NuGet.Services.Validation.PackageSigning
             {
                 _validationContext = new Mock<IValidationEntitiesContext>();
                 _certificateVerifier = new Mock<ICertificateVerificationEnqueuer>();
+                _telemetryService = new Mock<ITelemetryService>();
                 _logger = new Mock<ILogger<PackageCertificatesValidator>>();
 
                 _validationRequest = new Mock<IValidationRequest>();
@@ -1174,6 +1201,7 @@ namespace NuGet.Services.Validation.PackageSigning
                         _validationContext.Object,
                         validatorStateService,
                         _certificateVerifier.Object,
+                        _telemetryService.Object,
                         _logger.Object);
             }
         }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSignatureVerificationEnqueuerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSignatureVerificationEnqueuerFacts.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Jobs.Validation.PackageSigning.Messages;
+using NuGet.Services.ServiceBus;
+using Xunit;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    public class PackageSignatureVerificationEnqueuerFacts
+    {
+        [Fact]
+        public async Task UsesConfiguredMessageDelay()
+        {
+            var messageDelay = TimeSpan.FromMinutes(1);
+            _configuration.MessageDelay = messageDelay;
+
+            var before = DateTimeOffset.UtcNow;
+            await _target.EnqueueVerificationAsync(_validationRequest.Object);
+            var after = DateTimeOffset.UtcNow;
+
+            Assert.InRange(_brokeredMessage.Object.ScheduledEnqueueTimeUtc, before.Add(messageDelay), after.Add(messageDelay));
+        }
+
+        [Fact]
+        public async Task DefaultsNullMessageDelayToZero()
+        {
+            var before = DateTimeOffset.UtcNow;
+            await _target.EnqueueVerificationAsync(_validationRequest.Object);
+            var after = DateTimeOffset.UtcNow;
+
+            Assert.InRange(_brokeredMessage.Object.ScheduledEnqueueTimeUtc, before, after);
+        }
+
+        [Fact]
+        public async Task SendsSerializeMessage()
+        {
+            SignatureValidationMessage message = null;
+            _serializer
+                .Setup(x => x.Serialize(It.IsAny<SignatureValidationMessage>()))
+                .Returns(() => _brokeredMessage.Object)
+                .Callback<SignatureValidationMessage>(x => message = x);
+
+            await _target.EnqueueVerificationAsync(_validationRequest.Object);
+
+            Assert.Equal(_validationRequest.Object.ValidationId, message.ValidationId);
+            Assert.Equal(_validationRequest.Object.PackageId, message.PackageId);
+            Assert.Equal(_validationRequest.Object.PackageVersion, message.PackageVersion);
+            Assert.Equal(_validationRequest.Object.NupkgUrl, message.NupkgUri.AbsoluteUri);
+            _serializer.Verify(
+                x => x.Serialize(It.IsAny<SignatureValidationMessage>()),
+                Times.Once);
+            _topicClient.Verify(x => x.SendAsync(_brokeredMessage.Object), Times.Once);
+            _topicClient.Verify(x => x.SendAsync(It.IsAny<IBrokeredMessage>()), Times.Once);
+        }
+
+        private readonly Mock<ITopicClient> _topicClient;
+        private readonly Mock<IBrokeredMessageSerializer<SignatureValidationMessage>> _serializer;
+        private readonly Mock<IOptionsSnapshot<PackageSigningConfiguration>> _options;
+        private readonly PackageSigningConfiguration _configuration;
+        private readonly Mock<IBrokeredMessage> _brokeredMessage;
+        private readonly Mock<IValidationRequest> _validationRequest;
+        private readonly PackageSignatureVerificationEnqueuer _target;
+
+        public PackageSignatureVerificationEnqueuerFacts()
+        {
+            _configuration = new PackageSigningConfiguration();
+            _brokeredMessage = new Mock<IBrokeredMessage>();
+            _validationRequest = new Mock<IValidationRequest>();
+
+            _validationRequest.Setup(x => x.ValidationId).Returns(new Guid("ab2629ce-2d67-403a-9a42-49748772ae90"));
+            _validationRequest.Setup(x => x.PackageId).Returns("NuGet.Versioning");
+            _validationRequest.Setup(x => x.PackageVersion).Returns("4.6.0");
+            _validationRequest.Setup(x => x.NupkgUrl).Returns("http://example/nuget.versioning.4.6.0.nupkg?my-sas");
+            _brokeredMessage.SetupProperty(x => x.ScheduledEnqueueTimeUtc);
+
+            _topicClient = new Mock<ITopicClient>();
+            _serializer = new Mock<IBrokeredMessageSerializer<SignatureValidationMessage>>();
+            _options = new Mock<IOptionsSnapshot<PackageSigningConfiguration>>();
+
+            _options.Setup(x => x.Value).Returns(() => _configuration);
+            _serializer
+                .Setup(x => x.Serialize(It.IsAny<SignatureValidationMessage>()))
+                .Returns(() => _brokeredMessage.Object);
+
+            _target = new PackageSignatureVerificationEnqueuer(
+                _topicClient.Object,
+                _serializer.Object,
+                _options.Object);
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/PackageSigningValidatorFacts.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
 using Xunit;
 
 namespace NuGet.Services.Validation.PackageSigning
@@ -129,6 +130,10 @@ namespace NuGet.Services.Validation.PackageSigning
 
                 _validatorStateService
                     .Verify(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
+
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageSigningValidator(It.IsAny<TimeSpan>()),
+                    Times.Never);
             }
 
             [Fact]
@@ -188,6 +193,10 @@ namespace NuGet.Services.Validation.PackageSigning
                                 It.Is<ValidationStatus>(s => s == ValidationStatus.Incomplete)),
                         Times.Once);
 
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageSigningValidator(It.IsAny<TimeSpan>()),
+                    Times.Once);
+
                 Assert.True(verificationQueuedBeforeStatePersisted);
             }
 
@@ -198,6 +207,7 @@ namespace NuGet.Services.Validation.PackageSigning
         {
             protected readonly Mock<IValidatorStateService> _validatorStateService;
             protected readonly Mock<IPackageSignatureVerificationEnqueuer> _packageSignatureVerifier;
+            protected readonly Mock<ITelemetryService> _telemetryService;
             protected readonly Mock<ILogger<PackageSigningValidator>> _logger;
             protected readonly Mock<IValidationRequest> _validationRequest;
             protected readonly PackageSigningValidator _target;
@@ -206,6 +216,7 @@ namespace NuGet.Services.Validation.PackageSigning
             {
                 _validatorStateService = new Mock<IValidatorStateService>();
                 _packageSignatureVerifier = new Mock<IPackageSignatureVerificationEnqueuer>();
+                _telemetryService = new Mock<ITelemetryService>();
                 _logger = new Mock<ILogger<PackageSigningValidator>>();
 
                 _validationRequest = new Mock<IValidationRequest>();
@@ -218,6 +229,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _target = new PackageSigningValidator(
                         _validatorStateService.Object,
                         _packageSignatureVerifier.Object,
+                        _telemetryService.Object,
                         _logger.Object);
             }
         }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1190.

Very similar to @loic-sharma's change in gallery for the initial enqueuing. However in practice we could take a lower enqueue delay (1 instead of 5 seconds).

AI query:
```
traces
| where timestamp > ago(90d)
| where message startswith "Got validationStatus = Incomplete for validation \"PackageSigningValidator\" for" 
| extend validationId = tostring(customDimensions.ValidationId)
| join kind=inner (
    traces
    | where message startswith "Requesting validation \"PackageSigningValidator\" for"
    | extend validationId = tostring(customDimensions.ValidationId)
) on $left.validationId == $right.validationId
| extend packageId = tostring(customDimensions1.PackageId)
| extend packageVersion = tostring(customDimensions1.PackageVersion)
| extend delta = datetime_diff('millisecond', timestamp, timestamp1) 
| project delta, timestamp1, timestamp, packageId, packageVersion
| summarize percentiles(delta, 50, 90, 95, 99, 99.9)
```

Results (in milliseconds):

P50 | P90 | P95 | P99 | P99.9
-- | -- | -- | -- | --
268 | 671 | 688 | 796 | 953

I chose not to make this a setting on `ServiceBusConfiguration` because I don't think it's right to assume every Service Bus enqueuer cares about this setting. Also, these properties are basically just for the subscription and topic clients. Leaving it in the component-specific configuration emphasizes that the value is defined _only_ by component's implementation details.

Today this will only help in the E2E test case where VCS is skipped but will help a lot when repository signing is implemented.