### PR TITLE
Back up the package if there are any processors

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/IValidationPackageFileService.cs
@@ -18,6 +18,13 @@ namespace NuGet.Services.Validation.Orchestrator
         Task<Stream> DownloadPackageFileToDiskAsync(Package package);
 
         /// <summary>
+        /// Backs up the package file from the location specific for the validation set.
+        /// </summary>
+        /// <param name="package">The package metadata.</param>
+        /// <param name="validationSet">The validation set, containing validation set and package identifiers.</param>
+        Task BackupPackageFileFromValidationSetPackageAsync(Package package, PackageValidationSet validationSet);
+
+        /// <summary>
         /// Copy a package from the validation container to a location specific for the validation set. This allows the
         /// validation set to have its own copy of the package to mutate (via <see cref="IProcessor"/>) and validate.
         /// </summary>

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
@@ -13,6 +13,12 @@ namespace NuGet.Services.Validation.Orchestrator
 {
     public class ValidationPackageFileService : CorePackageFileService, IValidationPackageFileService
     {
+        /// <summary>
+        /// The value picked today is based off of the maximum duration we wait when downloading packages using the
+        /// <see cref="IPackageDownloader"/>.
+        /// </summary>
+        private static readonly TimeSpan AccessDuration = TimeSpan.FromMinutes(10);
+
         private readonly ICoreFileStorageService _fileStorageService;
         private readonly IPackageDownloader _packageDownloader;
         private readonly ILogger<ValidationPackageFileService> _logger;
@@ -48,6 +54,24 @@ namespace NuGet.Services.Validation.Orchestrator
                 CoreConstants.ValidationFolderName,
                 BuildValidationSetPackageFileName(validationSet),
                 AccessConditionWrapper.GenerateEmptyCondition());
+        }
+
+        public async Task BackupPackageFileFromValidationSetPackageAsync(Package package, PackageValidationSet validationSet)
+        {
+            _logger.LogInformation(
+                "Backing up package for validation set {ValidationTrackingId} ({PackageId} {PackageVersion}).",
+                validationSet.ValidationTrackingId,
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion);
+
+            var packageUri = await GetPackageForValidationSetReadUriAsync(
+                validationSet,
+                DateTimeOffset.UtcNow.Add(AccessDuration));
+
+            using (var packageStream = await _packageDownloader.DownloadAsync(packageUri, CancellationToken.None))
+            {
+                await StorePackageFileInBackupLocationAsync(package, packageStream);
+            }
         }
 
         public Task<string> CopyPackageFileForValidationSetAsync(PackageValidationSet validationSet)

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -84,7 +84,7 @@
       <Version>2.18.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.4-dev-25804</Version>
+      <Version>4.4.4-dev-25969</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGetGallery/pull/5612.
Progress on https://github.com/NuGet/Engineering/issues/1190.

If there are any processors configured into the orchestrator, back up the package that is about to be validated into the `package-backups` container.