### PR TITLE
[Package Signing] Improve logging

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
@@ -161,7 +161,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     {
                         var duration = DateTime.UtcNow - validation.Started;
 
-                        _logger.LogWarning("Validation {Validation} for package {PackageId} {PackageVersion} has reached the configured failure timeout after duration {Duration}",
+                        _logger.LogWarning("Validation {Validation} for package {PackageId} {PackageVersion} is past its expected duration after duration {Duration}",
                             validation.Type,
                             validationSet.PackageId,
                             validationSet.PackageNormalizedVersion,

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
@@ -161,7 +161,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     {
                         var duration = DateTime.UtcNow - validation.Started;
 
-                        _logger.LogWarning("Validation {Validation} for package {PackageId} {PackageVersion} is past its expected duration after duration {Duration}",
+                        _logger.LogWarning("Validation {Validation} for package {PackageId} {PackageVersion} is past its expected duration after {Duration}",
                             validation.Type,
                             validationSet.PackageId,
                             validationSet.PackageNormalizedVersion,

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -64,91 +64,97 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 
         private async Task<bool> HandleAsync(SignatureValidationMessage message, CancellationToken cancellationToken)
         {
-            // Find the signature validation entity that matches this message.
-            var validation = await _validatorStateService.GetStatusAsync(message.ValidationId);
-
-            // A signature validation should be queued with ValidatorState == Incomplete.
-            if (validation == null)
+            using (_logger.BeginScope("Handling message for {PackageId} {PackageVersion} validation set {ValidationSetId}",
+                message.PackageId,
+                message.PackageVersion,
+                message.ValidationId))
             {
-                _logger.LogInformation(
-                    "Could not find validation entity, requeueing (package: {PackageId} {PackageVersion}, validationId: {ValidationId})",
-                    message.PackageId,
-                    message.PackageVersion,
-                    message.ValidationId);
+                // Find the signature validation entity that matches this message.
+                var validation = await _validatorStateService.GetStatusAsync(message.ValidationId);
 
-                // Message may be retried.
-                return false;
-            }
-            else if (validation.State == ValidationStatus.NotStarted)
-            {
-                _logger.LogWarning(
-                    "Unexpected signature verification status '{ValidatorState}' when 'Incomplete' was expected, requeueing (package id: {PackageId} package version: {PackageVersion} validation id: {ValidationId})",
-                    validation.State,
-                    message.PackageId,
-                    message.PackageVersion,
-                    message.ValidationId);
-
-                // Message may be retried.
-                return false;
-            }
-            else if (validation.State != ValidationStatus.Incomplete)
-            {
-                _logger.LogWarning(
-                    "Terminal signature verification status '{ValidatorState}' when 'Incomplete' was expected, dropping message (package id: {PackageId} package version: {PackageVersion} validation id: {ValidationId})",
-                    validation.State,
-                    message.PackageId,
-                    message.PackageVersion,
-                    message.ValidationId);
-
-                // Consume the message.
-                return true;
-            }
-
-            // Validate package
-            using (var packageStream = await _packageDownloader.DownloadAsync(message.NupkgUri, cancellationToken))
-            using (var packageWriteStream = new MemoryStream()) // Unused, but to be careful we don't pass the original stream.
-            using (var package = new SignedPackageArchive(packageStream, packageWriteStream))
-            {
-                var result = await _signatureValidator.ValidateAsync(
-                    validation.PackageKey,
-                    package,
-                    message,
-                    cancellationToken);
-
-                validation.State = result.State;
-
-                // Save any issues if the resulting state is terminal.
-                if (validation.State == ValidationStatus.Failed
-                    || validation.State == ValidationStatus.Succeeded)
+                // A signature validation should be queued with ValidatorState == Incomplete.
+                if (validation == null)
                 {
-                    validation.ValidatorIssues = validation.ValidatorIssues ?? new List<ValidatorIssue>();
-                    foreach (var issue in result.Issues)
+                    _logger.LogInformation(
+                        "Could not find validation entity, requeueing (package: {PackageId} {PackageVersion}, validationId: {ValidationId})",
+                        message.PackageId,
+                        message.PackageVersion,
+                        message.ValidationId);
+
+                    // Message may be retried.
+                    return false;
+                }
+                else if (validation.State == ValidationStatus.NotStarted)
+                {
+                    _logger.LogWarning(
+                        "Unexpected signature verification status '{ValidatorState}' when 'Incomplete' was expected, requeueing (package id: {PackageId} package version: {PackageVersion} validation id: {ValidationId})",
+                        validation.State,
+                        message.PackageId,
+                        message.PackageVersion,
+                        message.ValidationId);
+
+                    // Message may be retried.
+                    return false;
+                }
+                else if (validation.State != ValidationStatus.Incomplete)
+                {
+                    _logger.LogWarning(
+                        "Terminal signature verification status '{ValidatorState}' when 'Incomplete' was expected, dropping message (package id: {PackageId} package version: {PackageVersion} validation id: {ValidationId})",
+                        validation.State,
+                        message.PackageId,
+                        message.PackageVersion,
+                        message.ValidationId);
+
+                    // Consume the message.
+                    return true;
+                }
+
+                // Validate package
+                using (var packageStream = await _packageDownloader.DownloadAsync(message.NupkgUri, cancellationToken))
+                using (var packageWriteStream = new MemoryStream()) // Unused, but to be careful we don't pass the original stream.
+                using (var package = new SignedPackageArchive(packageStream, packageWriteStream))
+                {
+                    var result = await _signatureValidator.ValidateAsync(
+                        validation.PackageKey,
+                        package,
+                        message,
+                        cancellationToken);
+
+                    validation.State = result.State;
+
+                    // Save any issues if the resulting state is terminal.
+                    if (validation.State == ValidationStatus.Failed
+                        || validation.State == ValidationStatus.Succeeded)
                     {
-                        validation.ValidatorIssues.Add(new ValidatorIssue
+                        validation.ValidatorIssues = validation.ValidatorIssues ?? new List<ValidatorIssue>();
+                        foreach (var issue in result.Issues)
                         {
-                            IssueCode = issue.IssueCode,
-                            Data = issue.Serialize(),
-                        });
+                            validation.ValidatorIssues.Add(new ValidatorIssue
+                            {
+                                IssueCode = issue.IssueCode,
+                                Data = issue.Serialize(),
+                            });
+                        }
                     }
                 }
+
+                // The signature validator should do all of the work to bring this validation to its completion.
+                if (validation.State != ValidationStatus.Succeeded
+                    && validation.State != ValidationStatus.Failed)
+                {
+                    _logger.LogError("The signature validator should have set the status 'Succeeded' or 'Failed', not " +
+                        "'{ValidatorState}' (package id: {PackageId} package version: {PackageVersion} validation id: {ValidationId})",
+                        validation.State,
+                        message.PackageId,
+                        message.PackageVersion,
+                        message.ValidationId);
+
+                    return false;
+                }
+
+                // Save the resulting validation status.
+                return await SaveStatusAsync(validation, message);
             }
-
-            // The signature validator should do all of the work to bring this validation to its completion.
-            if (validation.State != ValidationStatus.Succeeded
-                && validation.State != ValidationStatus.Failed)
-            {
-                _logger.LogError("The signature validator should have set the status 'Succeeded' or 'Failed', not " +
-                    "'{ValidatorState}' (package id: {PackageId} package version: {PackageVersion} validation id: {ValidationId})",
-                    validation.State,
-                    message.PackageId,
-                    message.PackageVersion,
-                    message.ValidationId);
-
-                return false;
-            }
-
-            // Save the resulting validation status.
-            return await SaveStatusAsync(validation, message);
         }
 
         private async Task<bool> SaveStatusAsync(ValidatorStatus validation, SignatureValidationMessage message)

--- a/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ExtractAndValidateSignature/SignatureValidationMessageHandler.cs
@@ -64,7 +64,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ExtractAndValidateSignature
 
         private async Task<bool> HandleAsync(SignatureValidationMessage message, CancellationToken cancellationToken)
         {
-            using (_logger.BeginScope("Handling message for {PackageId} {PackageVersion} validation set {ValidationSetId}",
+            using (_logger.BeginScope("Handling signature validation message for package {PackageId} {PackageVersion}, validation set {ValidationSetId}",
                 message.PackageId,
                 message.PackageVersion,
                 message.ValidationId))

--- a/src/Validation.PackageSigning.ValidateCertificate/CertificateValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/CertificateValidationMessageHandler.cs
@@ -50,94 +50,99 @@ namespace Validation.PackageSigning.ValidateCertificate
         /// <returns>Whether the validation completed. If false, the validation should be retried later.</returns>
         public async Task<bool> HandleAsync(CertificateValidationMessage message)
         {
-            var validation = await _certificateValidationService.FindCertificateValidationAsync(message);
-
-            if (validation == null)
+            using (_logger.BeginScope("Handling message for {CertificateKey} {ValidationId}",
+                message.CertificateKey,
+                message.ValidationId))
             {
-                _logger.LogInformation(
-                    "Could not find a certificate validation entity, failing (certificate: {CertificateKey} validation: {ValidationId})",
-                    message.CertificateKey,
-                    message.ValidationId);
+                var validation = await _certificateValidationService.FindCertificateValidationAsync(message);
 
-                return false;
-            }
-
-            if (validation.Status != null)
-            {
-                // A certificate validation should be queued with a Status of null, and once the certificate validation
-                // completes, the Status should be updated to a non-null value. Hence, the Status here SHOULD be null.
-                // A non-null Status may indicate message duplication.
-                _logger.LogWarning(
-                    "Invalid certificate validation entity's status, dropping message (certificate: {CertificateThumbprint} validation: {ValidationId})",
-                    validation.EndCertificate.Thumbprint,
-                    validation.ValidationId);
-
-                return true;
-            }
-
-            if (validation.EndCertificate.Status == EndCertificateStatus.Revoked)
-            {
-                if (message.RevalidateRevokedCertificate)
+                if (validation == null)
                 {
-                    _logger.LogWarning(
-                        "Revalidating certificate that is known to be revoked " +
-                        "(certificate: {CertificateThumbprint} validation: {ValidationId})",
-                        validation.EndCertificate.Thumbprint,
-                        validation.ValidationId);
+                    _logger.LogInformation(
+                        "Could not find a certificate validation entity, failing (certificate: {CertificateKey} validation: {ValidationId})",
+                        message.CertificateKey,
+                        message.ValidationId);
+
+                    return false;
                 }
-                else
+
+                if (validation.Status != null)
                 {
-                    // Do NOT revalidate a certificate that is known to be revoked unless explicitly told to!
-                    // Certificate Authorities are not required to keep a certificate's revocation information
-                    // forever, therefore, revoked certificates should only be revalidated in special cases.
-                    _logger.LogError(
-                        "Certificate known to be revoked MUST be validated with the " +
-                        $"{nameof(CertificateValidationMessage.RevalidateRevokedCertificate)} flag enabled " +
-                        "(certificate: {CertificateThumbprint} validation: {ValidationId})",
+                    // A certificate validation should be queued with a Status of null, and once the certificate validation
+                    // completes, the Status should be updated to a non-null value. Hence, the Status here SHOULD be null.
+                    // A non-null Status may indicate message duplication.
+                    _logger.LogWarning(
+                        "Invalid certificate validation entity's status, dropping message (certificate: {CertificateThumbprint} validation: {ValidationId})",
                         validation.EndCertificate.Thumbprint,
                         validation.ValidationId);
 
                     return true;
                 }
-            }
 
-            CertificateVerificationResult result;
-
-            using (var certificates = await LoadCertificatesAsync(validation))
-            {
-                switch (validation.EndCertificate.Use)
+                if (validation.EndCertificate.Status == EndCertificateStatus.Revoked)
                 {
-                    case EndCertificateUse.CodeSigning:
-                        result = _certificateVerifier.VerifyCodeSigningCertificate(
-                                    certificates.EndCertificate,
-                                    certificates.AncestorCertificates);
-                        break;
+                    if (message.RevalidateRevokedCertificate)
+                    {
+                        _logger.LogWarning(
+                            "Revalidating certificate that is known to be revoked " +
+                            "(certificate: {CertificateThumbprint} validation: {ValidationId})",
+                            validation.EndCertificate.Thumbprint,
+                            validation.ValidationId);
+                    }
+                    else
+                    {
+                        // Do NOT revalidate a certificate that is known to be revoked unless explicitly told to!
+                        // Certificate Authorities are not required to keep a certificate's revocation information
+                        // forever, therefore, revoked certificates should only be revalidated in special cases.
+                        _logger.LogError(
+                            "Certificate known to be revoked MUST be validated with the " +
+                            $"{nameof(CertificateValidationMessage.RevalidateRevokedCertificate)} flag enabled " +
+                            "(certificate: {CertificateThumbprint} validation: {ValidationId})",
+                            validation.EndCertificate.Thumbprint,
+                            validation.ValidationId);
 
-                    case EndCertificateUse.Timestamping:
-                        result = _certificateVerifier.VerifyTimestampingCertificate(
-                                    certificates.EndCertificate,
-                                    certificates.AncestorCertificates);
-                        break;
-
-                    default:
-                        throw new InvalidOperationException($"Unknown {nameof(EndCertificateUse)}: {validation.EndCertificate.Use}");
+                        return true;
+                    }
                 }
+
+                CertificateVerificationResult result;
+
+                using (var certificates = await LoadCertificatesAsync(validation))
+                {
+                    switch (validation.EndCertificate.Use)
+                    {
+                        case EndCertificateUse.CodeSigning:
+                            result = _certificateVerifier.VerifyCodeSigningCertificate(
+                                        certificates.EndCertificate,
+                                        certificates.AncestorCertificates);
+                            break;
+
+                        case EndCertificateUse.Timestamping:
+                            result = _certificateVerifier.VerifyTimestampingCertificate(
+                                        certificates.EndCertificate,
+                                        certificates.AncestorCertificates);
+                            break;
+
+                        default:
+                            throw new InvalidOperationException($"Unknown {nameof(EndCertificateUse)}: {validation.EndCertificate.Use}");
+                    }
+                }
+
+                // Save the result. This may alert if packages are invalidated.
+                if (!await _certificateValidationService.TrySaveResultAsync(validation, result))
+                {
+                    _logger.LogWarning(
+                        "Failed to save certificate validation result " +
+                        "(certificate: {CertificateThumbprint} validation: {ValidationId}), " +
+                        "failing validation",
+                        validation.EndCertificate.Thumbprint,
+                        validation.ValidationId);
+
+                    return false;
+                }
+
+                return HasValidationCompleted(validation, result);
             }
-
-            // Save the result. This may alert if packages are invalidated.
-            if (!await _certificateValidationService.TrySaveResultAsync(validation, result))
-            {
-                _logger.LogWarning(
-                    "Failed to save certificate validation result " +
-                    "(certificate: {CertificateThumbprint} validation: {ValidationId}), " +
-                    "failing validation",
-                    validation.EndCertificate.Thumbprint,
-                    validation.ValidationId);
-
-                return false;
-            }
-
-            return HasValidationCompleted(validation, result);
         }
 
         private bool HasValidationCompleted(EndCertificateValidation validation, CertificateVerificationResult result)

--- a/src/Validation.PackageSigning.ValidateCertificate/CertificateValidationMessageHandler.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/CertificateValidationMessageHandler.cs
@@ -50,7 +50,7 @@ namespace Validation.PackageSigning.ValidateCertificate
         /// <returns>Whether the validation completed. If false, the validation should be retried later.</returns>
         public async Task<bool> HandleAsync(CertificateValidationMessage message)
         {
-            using (_logger.BeginScope("Handling message for {CertificateKey} {ValidationId}",
+            using (_logger.BeginScope("Handling validate certificate message {CertificateKey} {ValidationId}",
                 message.CertificateKey,
                 message.ValidationId))
             {


### PR DESCRIPTION
Add logging scopes to package signing validation jobs to ease log correlation. Example scenario: find all logs for the Extract and Validate job that are for package X.

I would recommend reviewing this with [whitespace changes disabled](https://github.com/NuGet/NuGet.Jobs/pull/376/files?w=1)