### PR TITLE
AggregateCdnDownloadsInGallery packages download count update batching

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -59,6 +59,9 @@ namespace NuGet.Jobs
         public const string RetryCount = "RetryCount";
         public const string MaxManifestSize = "MaxManifestSize";
         public const string OutputDirectory = "OutputDirectory";
+
+        // Arguments specific to AggregateCdnDownloadsInGallery
+        public const string PackagesPerCommit = "PackagesPerCommit";
         
         //Arguments specific to UpdateLicenseReports
         public const string LicenseReportService = "LicenseReportService";

--- a/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
@@ -51,6 +51,9 @@ namespace Stats.AggregateCdnDownloadsInGallery
         private SqlConnectionStringBuilder _statisticsDatabase;
         private SqlConnectionStringBuilder _destinationDatabase;
 
+        private const int DefaultPackagesPerCommit = 1000;
+        private int _packagesPerCommit = DefaultPackagesPerCommit;
+
         public override void Init(IDictionary<string, string> jobArgsDictionary)
         {
             var statisticsDatabaseConnectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.StatisticsDatabase);
@@ -58,6 +61,8 @@ namespace Stats.AggregateCdnDownloadsInGallery
 
             var destinationDatabaseConnectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.DestinationDatabase);
             _destinationDatabase = new SqlConnectionStringBuilder(destinationDatabaseConnectionString);
+
+            _packagesPerCommit = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.PackagesPerCommit) ?? DefaultPackagesPerCommit;
         }
 
         public override async Task Run()
@@ -84,77 +89,15 @@ namespace Stats.AggregateCdnDownloadsInGallery
             if (downloadData.Any())
             {
                 // Group based on Package Id
-                var packageRegistrationGroups = downloadData.GroupBy(p => p.PackageId).ToList();
+                var packageRegistrationGroups = downloadData.GroupBy(p => p.PackageId);
+                var packageRegistrationGroupsRemaining = packageRegistrationGroups;
 
-                using (var destinationDatabase = await _destinationDatabase.ConnectTo())
+                // Copy the new download data to the destination DB in batches
+                while (packageRegistrationGroupsRemaining.Any())
                 {
-                    // Fetch package registrations so we can match
-                    var packageRegistrationLookup = await GetPackageRegistrations(destinationDatabase);
+                    await CopyPackageDownloadDataToDB(packageRegistrationGroupsRemaining.Take(_packagesPerCommit));
 
-                    // Create a temporary table
-                    Logger.LogDebug("Creating temporary table...");
-                    await destinationDatabase.ExecuteAsync(_createTempTable);
-
-                    // Load temporary table
-                    var aggregateCdnDownloadsInGalleryTable = new DataTable();
-                    var command = new SqlCommand("SELECT * FROM " + _tempTableName, destinationDatabase);
-                    command.CommandType = CommandType.Text;
-                    command.CommandTimeout = (int)TimeSpan.FromMinutes(10).TotalSeconds;
-                    var reader = await command.ExecuteReaderAsync();
-                    aggregateCdnDownloadsInGalleryTable.Load(reader);
-                    aggregateCdnDownloadsInGalleryTable.Rows.Clear();
-                    aggregateCdnDownloadsInGalleryTable.TableName = $"dbo.{_tempTableName}";
-                    Logger.LogInformation("Created temporary table.");
-
-                    // Populate temporary table in memory
-                    Logger.LogDebug("Populating temporary table in memory...");
-                    foreach (var packageRegistrationGroup in packageRegistrationGroups)
-                    {
-                        // don't process empty package id's
-                        if (string.IsNullOrEmpty(packageRegistrationGroup.First().PackageId))
-                        {
-                            continue;
-                        }
-
-                        var packageId = packageRegistrationGroup.First().PackageId.ToLowerInvariant();
-
-                        // Get package registration key
-                        if (!packageRegistrationLookup.ContainsKey(packageId))
-                        {
-                            continue;
-                        }
-                        var packageRegistrationKey = packageRegistrationLookup[packageId];
-
-                        // Set download count on individual packages
-                        foreach (var package in packageRegistrationGroup)
-                        {
-                            var row = aggregateCdnDownloadsInGalleryTable.NewRow();
-                            row["PackageRegistrationKey"] = packageRegistrationKey;
-                            row["PackageVersion"] = package.PackageVersion;
-                            row["DownloadCount"] = package.TotalDownloadCount;
-                            aggregateCdnDownloadsInGalleryTable.Rows.Add(row);
-                        }
-                    }
-                    Logger.LogInformation("Populated temporary table in memory. ({RecordCount} rows).", aggregateCdnDownloadsInGalleryTable.Rows.Count);
-
-                    // Transfer to SQL database
-                    Logger.LogDebug("Populating temporary table in database...");
-                    using (SqlBulkCopy bulkcopy = new SqlBulkCopy(destinationDatabase))
-                    {
-                        bulkcopy.BulkCopyTimeout = (int)TimeSpan.FromMinutes(30).TotalSeconds;
-                        bulkcopy.DestinationTableName = _tempTableName;
-                        bulkcopy.WriteToServer(aggregateCdnDownloadsInGalleryTable);
-                        bulkcopy.Close();
-                    }
-                    Logger.LogInformation("Populated temporary table in database.");
-
-                    // Update counts in destination database
-                    Logger.LogDebug("Updating destination database Download Counts... ({RecordCount} package registrations to process).", packageRegistrationGroups.Count());
-
-                    await destinationDatabase.ExecuteAsync(_updateFromTempTable,
-                        commandTimeout: TimeSpan.FromMinutes(30));
-
-                    Logger.LogInformation("Updated destination database Download Counts.");
+                    packageRegistrationGroupsRemaining = packageRegistrationGroupsRemaining.Skip(_packagesPerCommit);
                 }
             }
         }
@@ -198,6 +141,80 @@ namespace Stats.AggregateCdnDownloadsInGallery
             Logger.LogInformation("Retrieved package registrations.");
 
             return packageRegistrationDictionary;
+        }
+
+        private async Task CopyPackageDownloadDataToDB(IEnumerable<IGrouping<string, DownloadCountData>> packageRegistrationGroups)
+        {
+            using (var destinationDatabase = await _destinationDatabase.ConnectTo())
+            {
+                // Fetch package registrations so we can match
+                var packageRegistrationLookup = await GetPackageRegistrations(destinationDatabase);
+
+                // Create a temporary table
+                Logger.LogDebug("Creating temporary table...");
+                await destinationDatabase.ExecuteAsync(_createTempTable);
+
+                // Load temporary table
+                var aggregateCdnDownloadsInGalleryTable = new DataTable();
+                var command = new SqlCommand("SELECT * FROM " + _tempTableName, destinationDatabase);
+                command.CommandType = CommandType.Text;
+                command.CommandTimeout = (int)TimeSpan.FromMinutes(10).TotalSeconds;
+                var reader = await command.ExecuteReaderAsync();
+                aggregateCdnDownloadsInGalleryTable.Load(reader);
+                aggregateCdnDownloadsInGalleryTable.Rows.Clear();
+                aggregateCdnDownloadsInGalleryTable.TableName = $"dbo.{_tempTableName}";
+                Logger.LogInformation("Created temporary table.");
+
+                // Populate temporary table in memory
+                Logger.LogDebug("Populating temporary table in memory...");
+                foreach (var packageRegistrationGroup in packageRegistrationGroups)
+                {
+                    // don't process empty package id's
+                    if (string.IsNullOrEmpty(packageRegistrationGroup.First().PackageId))
+                    {
+                        continue;
+                    }
+
+                    var packageId = packageRegistrationGroup.First().PackageId.ToLowerInvariant();
+
+                    // Get package registration key
+                    if (!packageRegistrationLookup.ContainsKey(packageId))
+                    {
+                        continue;
+                    }
+                    var packageRegistrationKey = packageRegistrationLookup[packageId];
+
+                    // Set download count on individual packages
+                    foreach (var package in packageRegistrationGroup)
+                    {
+                        var row = aggregateCdnDownloadsInGalleryTable.NewRow();
+                        row["PackageRegistrationKey"] = packageRegistrationKey;
+                        row["PackageVersion"] = package.PackageVersion;
+                        row["DownloadCount"] = package.TotalDownloadCount;
+                        aggregateCdnDownloadsInGalleryTable.Rows.Add(row);
+                    }
+                }
+                Logger.LogInformation("Populated temporary table in memory. ({RecordCount} rows).", aggregateCdnDownloadsInGalleryTable.Rows.Count);
+
+                // Transfer to SQL database
+                Logger.LogDebug("Populating temporary table in database...");
+                using (SqlBulkCopy bulkcopy = new SqlBulkCopy(destinationDatabase))
+                {
+                    bulkcopy.BulkCopyTimeout = (int)TimeSpan.FromMinutes(30).TotalSeconds;
+                    bulkcopy.DestinationTableName = _tempTableName;
+                    bulkcopy.WriteToServer(aggregateCdnDownloadsInGalleryTable);
+                    bulkcopy.Close();
+                }
+                Logger.LogInformation("Populated temporary table in database.");
+
+                // Update counts in destination database
+                Logger.LogDebug("Updating destination database Download Counts... ({RecordCount} package registrations to process).", packageRegistrationGroups.Count());
+
+                await destinationDatabase.ExecuteAsync(_updateFromTempTable,
+                    commandTimeout: TimeSpan.FromMinutes(30));
+
+                Logger.LogInformation("Updated destination database Download Counts.");
+            }
         }
     }
 }

--- a/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Job.cs
@@ -89,15 +89,15 @@ namespace Stats.AggregateCdnDownloadsInGallery
             if (downloadData.Any())
             {
                 // Group based on Package Id
-                var packageRegistrationGroups = downloadData.GroupBy(p => p.PackageId);
+                var packageRegistrationGroups = downloadData.GroupBy(p => p.PackageId).ToList();
                 var packageRegistrationGroupsRemaining = packageRegistrationGroups;
 
                 // Copy the new download data to the destination DB in batches
                 while (packageRegistrationGroupsRemaining.Any())
                 {
-                    await CopyPackageDownloadDataToDB(packageRegistrationGroupsRemaining.Take(_packagesPerCommit));
+                    await CopyPackageDownloadDataToDB(packageRegistrationGroupsRemaining.Take(_packagesPerCommit).ToList());
 
-                    packageRegistrationGroupsRemaining = packageRegistrationGroupsRemaining.Skip(_packagesPerCommit);
+                    packageRegistrationGroupsRemaining = packageRegistrationGroupsRemaining.Skip(_packagesPerCommit).ToList();
                 }
             }
         }


### PR DESCRIPTION
`AggregateCdnDownloadsInGallery` no longer updates all package download counts in a single query, but batches them by 1000. I made the batch size configurable so that we can find a better value for it--1000 was a guess and may be too big/too small. Will be testing this on DEV to see if it improves anything.