### PR TITLE
Introduce LoggerDiagnosticsService for improved NuGetGallery.Core logging

### DIFF
--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -113,6 +113,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Common.Job", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageHash", "src\PackageHash\PackageHash.csproj", "{40843020-6F0A-48F0-AC28-42FFE3A5C21E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Common.Job.Tests", "tests\Validation.Common.Job.Tests\Validation.Common.Job.Tests.csproj", "{430F63C7-20C2-4872-AC3E-DDE846E50AA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -289,6 +291,10 @@ Global
 		{40843020-6F0A-48F0-AC28-42FFE3A5C21E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{40843020-6F0A-48F0-AC28-42FFE3A5C21E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{40843020-6F0A-48F0-AC28-42FFE3A5C21E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{430F63C7-20C2-4872-AC3E-DDE846E50AA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{430F63C7-20C2-4872-AC3E-DDE846E50AA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{430F63C7-20C2-4872-AC3E-DDE846E50AA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{430F63C7-20C2-4872-AC3E-DDE846E50AA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -336,6 +342,7 @@ Global
 		{B4B7564A-965B-447B-927F-6749E2C08880} = {6A776396-02B1-475D-A104-26940ADB04AB}
 		{FA87D075-A934-4443-8D0B-5DB32640B6D7} = {678D7B14-F8BC-4193-99AF-2EE8AA390A02}
 		{40843020-6F0A-48F0-AC28-42FFE3A5C21E} = {FA5644B5-4F08-43F6-86B3-039374312A47}
+		{430F63C7-20C2-4872-AC3E-DDE846E50AA4} = {6A776396-02B1-475D-A104-26940ADB04AB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {284A7AC3-FB43-4F1F-9C9C-2AF0E1F46C2B}

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -25,11 +25,13 @@ using NuGet.Jobs.Validation.PackageSigning.Messages;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
+using NuGet.Services.Logging;
 using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 using NuGet.Services.Validation.PackageCertificates;
 using NuGet.Services.Validation.PackageSigning;
 using NuGet.Services.Validation.Vcs;
+using NuGetGallery.Diagnostics;
 using NuGetGallery.Services;
 
 namespace NuGet.Services.Validation.Orchestrator
@@ -235,6 +237,8 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IMessageService, MessageService>();
             services.AddTransient<ICommonTelemetryService, CommonTelemetryService>();
             services.AddTransient<ITelemetryService, TelemetryService>();
+            services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
+            services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
             services.AddSingleton(new TelemetryClient());
             services.AddTransient<IValidationOutcomeProcessor, ValidationOutcomeProcessor>();
             services.AddSingleton(p =>

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -108,7 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.18.0</Version>
+      <Version>2.19.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
+using NuGet.Services.Logging;
 using NuGetGallery;
 
 namespace NuGet.Services.Validation.Orchestrator.Telemetry
@@ -46,9 +47,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string HashAlgorithm = "HashAlgorithm";
         private const string StreamType = "StreamType";
 
-        private readonly TelemetryClient _telemetryClient;
+        private readonly ITelemetryClient _telemetryClient;
 
-        public TelemetryService(TelemetryClient telemetryClient)
+        public TelemetryService(ITelemetryClient telemetryClient)
         {
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
         }

--- a/src/Validation.Common.Job/CommonTelemetryService.cs
+++ b/src/Validation.Common.Job/CommonTelemetryService.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.ApplicationInsights;
+using NuGet.Services.Logging;
 
 namespace NuGet.Jobs.Validation
 {
@@ -13,9 +13,9 @@ namespace NuGet.Jobs.Validation
         private const string PackageUri = "PackageUri";
         private const string PackageSize = "PackageSize";
 
-        private readonly TelemetryClient _telemetryClient;
+        private readonly ITelemetryClient _telemetryClient;
 
-        public CommonTelemetryService(TelemetryClient telemetryClient)
+        public CommonTelemetryService(ITelemetryClient telemetryClient)
         {
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
         }

--- a/src/Validation.Common.Job/IPackageDownloader.cs
+++ b/src/Validation.Common.Job/IPackageDownloader.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Validation.Common.Job/JsonConfigurationJob.cs
+++ b/src/Validation.Common.Job/JsonConfigurationJob.cs
@@ -17,9 +17,11 @@ using Microsoft.Extensions.Options;
 using NuGet.Jobs.Configuration;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
+using NuGet.Services.Logging;
 using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation;
 using NuGetGallery;
+using NuGetGallery.Diagnostics;
 
 namespace NuGet.Jobs.Validation
 {
@@ -107,7 +109,9 @@ namespace NuGet.Jobs.Validation
             services.Configure<ServiceBusConfiguration>(configurationRoot.GetSection(ServiceBusConfigurationSectionName));
 
             services.AddSingleton(new TelemetryClient());
+            services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
             services.AddTransient<ICommonTelemetryService, CommonTelemetryService>();
+            services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
             services.AddTransient<IPackageDownloader, PackageDownloader>();
 
             services.AddScoped<IValidationEntitiesContext>(p =>

--- a/src/Validation.Common.Job/LoggerDiagnosticsService.cs
+++ b/src/Validation.Common.Job/LoggerDiagnosticsService.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.Logging;
+using NuGetGallery.Diagnostics;
+
+namespace NuGet.Jobs.Validation
+{
+    public class LoggerDiagnosticsService : IDiagnosticsService
+    {
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ITelemetryClient _telemetryClient;
+
+        public LoggerDiagnosticsService(ILoggerFactory loggerFactory, ITelemetryClient telemetryClient)
+        {
+            _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public IDiagnosticsSource GetSource(string name)
+        {
+            return new LoggerDiagnosticsSource(
+                _telemetryClient,
+                _loggerFactory.CreateLogger(name));
+        }
+    }
+}

--- a/src/Validation.Common.Job/LoggerDiagnosticsSource.cs
+++ b/src/Validation.Common.Job/LoggerDiagnosticsSource.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.Logging;
+using NuGetGallery.Diagnostics;
+
+namespace NuGet.Jobs.Validation
+{
+    public class LoggerDiagnosticsSource : IDiagnosticsSource
+    {
+        private readonly ITelemetryClient _telemetryClient;
+        private readonly ILogger _logger;
+
+        public LoggerDiagnosticsSource(ITelemetryClient telemetryClient, ILogger logger)
+        {
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void ExceptionEvent(Exception exception)
+        {
+            _telemetryClient.TrackException(exception);
+        }
+
+        public void PerfEvent(
+            string name,
+            TimeSpan time,
+            IEnumerable<KeyValuePair<string, object>> payload)
+        {
+            _telemetryClient.TrackMetric(
+                name,
+                time.TotalMilliseconds,
+                GetProperties(payload));
+        }
+
+        public void TraceEvent(
+            TraceEventType type,
+            int id,
+            string message,
+            [CallerMemberName] string member = null,
+            [CallerFilePath] string file = null,
+            [CallerLineNumber] int line = 0)
+        {
+            _logger.Log(
+                TraceEventTypeToLogLevel(type),
+                id,
+                state: new TraceState(type, id, message, member, file, line),
+                exception: null,
+                formatter: (s, e) => s.Message);
+        }
+
+        private static LogLevel TraceEventTypeToLogLevel(TraceEventType type)
+        {
+            switch (type)
+            {
+                case TraceEventType.Critical:
+                    return LogLevel.Critical;
+                case TraceEventType.Error:
+                    return LogLevel.Error;
+                case TraceEventType.Warning:
+                    return LogLevel.Warning;
+                case TraceEventType.Information:
+                    return LogLevel.Information;
+                default:
+                    return LogLevel.Trace;
+            }
+        }
+
+        private static IDictionary<string, string> GetProperties(
+            IEnumerable<KeyValuePair<string, object>> payload)
+        {
+            if (payload == null)
+            {
+                return null;
+            }
+
+            var dictionary = new Dictionary<string, string>();
+            foreach (var pair in payload)
+            {
+                dictionary[pair.Key] = pair.Value?.ToString();
+            }
+
+            return dictionary;
+        }
+
+        /// <summary>
+        /// The parameters provided to <see cref="TraceEvent(TraceEventType, int, string, string, string, int)"/>. This
+        /// type implements <see cref="IEnumerable{KeyValuePair{string, object}}" /> because Serilog uses this to
+        /// populate the Application Insights custom dimensions property bag.
+        /// </summary>
+        public class TraceState : IEnumerable<KeyValuePair<string, object>>
+        {
+            private readonly Dictionary<string, object> _pairs;
+
+            public TraceState(TraceEventType traceEventType, int id, string message, string member, string file, int line)
+            {
+                TraceEventType = traceEventType;
+                Id = id;
+                Message = message;
+                Member = member;
+                File = file;
+                Line = line;
+
+                _pairs = new Dictionary<string, object>
+                {
+                    { nameof(TraceEventType), TraceEventType },
+                    { nameof(Id), Id },
+                    { nameof(Message), Message },
+                    { nameof(Member), Member },
+                    { nameof(File), File },
+                    { nameof(Line), Line },
+                };
+            }
+
+            public TraceEventType TraceEventType { get; }
+            public int Id { get; }
+            public string Message { get; }
+            public string Member { get; }
+            public string File { get; }
+            public int Line { get; }
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            {
+                return _pairs.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return _pairs.GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -41,6 +41,8 @@
     <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="ICommonTelemetryService.cs" />
     <Compile Include="IPackageDownloader.cs" />
+    <Compile Include="LoggerDiagnosticsService.cs" />
+    <Compile Include="LoggerDiagnosticsSource.cs" />
     <Compile Include="PackageDownloader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Storage\AddStatusResult.cs" />
@@ -72,19 +74,19 @@
       <Version>4.7.0-preview1-4886</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.18.0</Version>
+      <Version>2.19.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.18.0</Version>
+      <Version>2.19.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.18.0</Version>
+      <Version>2.19.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.18.0</Version>
+      <Version>2.19.1</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.4-dev-25969</Version>
+      <Version>4.4.4-dev-26021</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>

--- a/test.ps1
+++ b/test.ps1
@@ -34,7 +34,8 @@ Function Run-Tests {
         "tests\Validation.Common.Tests\bin\$Configuration\Validation.Common.Tests.dll", `
         "tests\Validation.PackageSigning.ExtractAndValidateSignature.Tests\bin\$Configuration\Validation.PackageSigning.ExtractAndValidateSignature.Tests.dll", `
         "tests\Validation.PackageSigning.ValidateCertificate.Tests\bin\$Configuration\Validation.PackageSigning.ValidateCertificate.Tests.dll", `
-        "tests\Validation.PackageSigning.Core.Tests\bin\$Configuration\Validation.PackageSigning.Core.Tests.dll"
+        "tests\Validation.PackageSigning.Core.Tests\bin\$Configuration\Validation.PackageSigning.Core.Tests.dll", `
+        "tests\Validation.Common.Job.Tests\bin\$Configuration\Validation.Common.Job.Tests.dll"
     
     $TestCount = 0
     

--- a/tests/Validation.Common.Job.Tests/CommonTelemetryServiceFacts.cs
+++ b/tests/Validation.Common.Job.Tests/CommonTelemetryServiceFacts.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NuGet.Jobs.Validation;
+using NuGet.Services.Logging;
+using Xunit;
+
+namespace Validation.Common.Job.Tests
+{
+    public class CommonTelemetryServiceFacts
+    {
+        public class TrackPackageDownloaded : BaseFacts
+        {
+            [Theory]
+            [InlineData("/a/b/?foo=bar", "/a/b/")]
+            [InlineData("?foo=bar", "/")]
+            [InlineData("/?foo=bar", "/")]
+            [InlineData("/a?foo=bar&foo=bar", "/a")]
+            [InlineData("/a?foo=bar&baz", "/a")]
+            [InlineData("/a?foo=bar&", "/a")]
+            [InlineData("/a?foo=bar", "/a")]
+            [InlineData("/a?foo", "/a")]
+            [InlineData("/a?", "/a")]
+            [InlineData("/a", "/a")]
+            public void StripsQueryString(string inputPath, string expectedPath)
+            {
+                // Arrange
+                var uri = new Uri("http://example" + inputPath);
+                var expectedUri = "http://example" + expectedPath;
+
+                // Act
+                _target.TrackPackageDownloaded(uri, _duration, _size);
+
+                // Assert
+                _telemetryClient.Verify(
+                    x => x.TrackMetric("PackageDownloadedSeconds", _duration.TotalSeconds, It.IsAny<IDictionary<string, string>>()),
+                    Times.Once);
+                Assert.NotNull(_properties);
+                Assert.Equal(new[] { "PackageSize", "PackageUri" }, _properties.Keys.OrderBy(x => x));
+                Assert.Equal("42", _properties["PackageSize"]);
+                Assert.Equal(expectedUri, _properties["PackageUri"]);
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly TimeSpan _duration;
+            protected readonly int _size;
+            protected readonly Mock<ITelemetryClient> _telemetryClient;
+            protected readonly CommonTelemetryService _target;
+            protected IDictionary<string, string> _properties;
+
+            public BaseFacts()
+            {
+                _duration = TimeSpan.FromTicks(2018031908);
+                _size = 42;
+                _properties = null;
+
+                _telemetryClient = new Mock<ITelemetryClient>();
+
+                _telemetryClient
+                    .Setup(x => x.TrackMetric(
+                        It.IsAny<string>(),
+                        It.IsAny<double>(),
+                        It.IsAny<IDictionary<string, string>>()))
+                    .Callback<string, double, IDictionary<string, string>>((_, __, p) => _properties = p);
+
+                _target = new CommonTelemetryService(_telemetryClient.Object);
+            }
+        }
+    }
+}

--- a/tests/Validation.Common.Job.Tests/LoggerDiagnosticSourceFacts.cs
+++ b/tests/Validation.Common.Job.Tests/LoggerDiagnosticSourceFacts.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Jobs.Validation;
+using NuGet.Services.Logging;
+using Validation.PackageSigning.Core.Tests.Support;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Validation.Common.Job.Tests
+{
+    public class LoggerDiagnosticSourceFacts
+    {
+        public class TraceEvent : BaseFacts
+        {
+            private readonly TraceEventType _traceEventType;
+            private readonly int _id;
+            private readonly string _message;
+            private readonly string _member;
+            private readonly string _file;
+            private readonly int _line;
+
+            public TraceEvent(ITestOutputHelper output) : base(output)
+            {
+                _traceEventType = TraceEventType.Information;
+                _id = 23;
+                _message = "So interesting!";
+                _member = "MyClass";
+                _file = "MyClass.cs";
+                _line = 42;
+            }
+
+            [Fact]
+            public void UsesCallerInfo()
+            {
+                // Arrange
+                LoggerDiagnosticsSource.TraceState state = null;
+                _logger
+                    .Setup(x => x.Log(
+                        It.IsAny<LogLevel>(),
+                        It.IsAny<EventId>(),
+                        It.IsAny<LoggerDiagnosticsSource.TraceState>(),
+                        It.IsAny<Exception>(),
+                        It.IsAny<Func<LoggerDiagnosticsSource.TraceState, Exception, string>>()))
+                    .Callback<LogLevel, EventId, LoggerDiagnosticsSource.TraceState, Exception, Func<LoggerDiagnosticsSource.TraceState, Exception, string>>(
+                        (_, __, s, ___, ____) => state = s);
+
+                // Act
+                _target.TraceEvent(
+                    _traceEventType,
+                    _id,
+                    _message);
+
+                // Assert
+                Assert.NotNull(state);
+                Assert.NotNull(state.Member);
+                Assert.NotEqual(string.Empty, state.Member);
+                Assert.NotNull(state.File);
+                Assert.NotEqual(string.Empty, state.File);
+                Assert.NotEqual(default(int), state.Line);
+            }
+
+            [Fact]
+            public void LogsCorrectState()
+            {
+                // Arrange
+                LoggerDiagnosticsSource.TraceState state = null;
+                _logger
+                    .Setup(x => x.Log(
+                        It.IsAny<LogLevel>(),
+                        It.IsAny<EventId>(),
+                        It.IsAny<LoggerDiagnosticsSource.TraceState>(),
+                        It.IsAny<Exception>(),
+                        It.IsAny<Func<LoggerDiagnosticsSource.TraceState, Exception, string>>()))
+                    .Callback<LogLevel, EventId, LoggerDiagnosticsSource.TraceState, Exception, Func<LoggerDiagnosticsSource.TraceState, Exception, string>>(
+                        (_, __, s, ___, ____) => state = s);
+
+                // Act
+                _target.TraceEvent(
+                    _traceEventType,
+                    _id,
+                    _message,
+                    _member,
+                    _file,
+                    _line);
+
+                // Assert
+                Assert.NotNull(state);
+                Assert.Equal(_traceEventType, state.TraceEventType);
+                Assert.Equal(_id, state.Id);
+                Assert.Equal(_message, state.Message);
+                Assert.Equal(_member, state.Member);
+                Assert.Equal(_file, state.File);
+                Assert.Equal(_line, state.Line);
+
+                var pairs = Assert.IsAssignableFrom<IEnumerable<KeyValuePair<string, object>>>(state);
+                Assert.Equal(new[] { "File", "Id", "Line", "Member", "Message", "TraceEventType" }, pairs.Select(x => x.Key).OrderBy(x => x));
+                var pairDictionary = pairs.ToDictionary(x => x.Key, x => x.Value);
+                Assert.Equal(_traceEventType, pairDictionary["TraceEventType"]);
+                Assert.Equal(_id, pairDictionary["Id"]);
+                Assert.Equal(_message, pairDictionary["Message"]);
+                Assert.Equal(_member, pairDictionary["Member"]);
+                Assert.Equal(_file, pairDictionary["File"]);
+                Assert.Equal(_line, pairDictionary["Line"]);
+            }
+
+            [Theory]
+            [InlineData(TraceEventType.Critical, LogLevel.Critical)]
+            [InlineData(TraceEventType.Error, LogLevel.Error)]
+            [InlineData(TraceEventType.Information, LogLevel.Information)]
+            [InlineData(TraceEventType.Resume, LogLevel.Trace)]
+            [InlineData(TraceEventType.Start, LogLevel.Trace)]
+            [InlineData(TraceEventType.Stop, LogLevel.Trace)]
+            [InlineData(TraceEventType.Suspend, LogLevel.Trace)]
+            [InlineData(TraceEventType.Transfer, LogLevel.Trace)]
+            [InlineData(TraceEventType.Verbose, LogLevel.Trace)]
+            [InlineData(TraceEventType.Warning, LogLevel.Warning)]
+            [InlineData((TraceEventType)(-1), LogLevel.Trace)]
+            public void MapsToLogLevel(TraceEventType traceEventType, LogLevel logLevel)
+            {
+                // Arrange & Act
+                _target.TraceEvent(
+                    traceEventType,
+                    _id,
+                    _message,
+                    _member,
+                    _file,
+                    _line);
+
+                // Assert
+                var actualMessage = Assert.Single(_logger.Object.Messages);
+                Assert.Equal(_message, actualMessage);
+
+                _logger.Verify(
+                    x => x.Log(
+                        logLevel,
+                        _id,
+                        It.IsAny<LoggerDiagnosticsSource.TraceState>(),
+                        null,
+                        It.IsAny<Func<LoggerDiagnosticsSource.TraceState, Exception, string>>()),
+                    Times.Once);
+                _logger.Verify(
+                    x => x.Log(
+                        It.IsAny<LogLevel>(),
+                        It.IsAny<EventId>(),
+                        It.IsAny<LoggerDiagnosticsSource.TraceState>(),
+                        It.IsAny<Exception>(),
+                        It.IsAny<Func<LoggerDiagnosticsSource.TraceState, Exception, string>>()),
+                    Times.Once);
+            }
+        }
+
+        public class ExceptionEvent : BaseFacts
+        {
+            public ExceptionEvent(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Fact]
+            public void TracksException()
+            {
+                // Arrange
+                var exception = new InvalidOperationException("Something bad.");
+
+                // Act
+                _target.ExceptionEvent(exception);
+
+                // Assert
+                _telemetryClient.Verify(
+                    x => x.TrackException(exception, null, null),
+                    Times.Once);
+            }
+        }
+
+        public class PerfEvent : BaseFacts
+        {
+            private readonly string _name;
+            private readonly TimeSpan _time;
+            private Dictionary<string, object> _payload;
+
+            public PerfEvent(ITestOutputHelper output) : base(output)
+            {
+                _name = "SomeTimedEvent";
+                _time = TimeSpan.FromTicks(23420009);
+                _payload = new Dictionary<string, object>
+                {
+                    { "Age", 10 },
+                    { "Cost", null },
+                    { "Created", new DateTimeOffset(2017, 1, 3, 8, 30, 0, TimeSpan.FromHours(-8)) },
+                };
+            }
+
+            [Fact]
+            public void AllowsNullPayload()
+            {
+                // Arrange & Act
+                _target.PerfEvent(
+                    _name,
+                    _time,
+                    payload: null);
+
+                // Assert
+                _telemetryClient.Verify(
+                    x => x.TrackMetric(_name, _time.TotalMilliseconds, null),
+                    Times.Once);
+            }
+
+            [Fact]
+            public void TracksMetric()
+            {
+                // Arrange
+                IDictionary<string, string> properties = null;
+                _telemetryClient
+                    .Setup(x => x.TrackMetric(It.IsAny<string>(), It.IsAny<double>(), It.IsAny<IDictionary<string, string>>()))
+                    .Callback<string, double, IDictionary<string, string>>((_, __, p) => properties = p);
+
+                // Act
+                _target.PerfEvent(
+                    _name,
+                    _time,
+                    _payload);
+
+                // Assert
+                _telemetryClient.Verify(
+                    x => x.TrackMetric(_name, _time.TotalMilliseconds, It.IsAny<IDictionary<string, string>>()),
+                    Times.Once);
+                Assert.Equal(new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>("Age", "10"),
+                    new KeyValuePair<string, string>("Cost", null),
+                    new KeyValuePair<string, string>("Created", "1/3/2017 8:30:00 AM -08:00"),
+                }, properties.OrderBy(x => x.Key).ToList());
+            }
+        }
+
+        public abstract class BaseFacts
+        {
+            protected readonly ITestOutputHelper _output;
+            protected readonly Mock<ITelemetryClient> _telemetryClient;
+            protected readonly Mock<RecordingLogger<LoggerDiagnosticSourceFacts>> _logger;
+            protected readonly LoggerDiagnosticsSource _target;
+
+            public BaseFacts(ITestOutputHelper output)
+            {
+                _output = output;
+                _telemetryClient = new Mock<ITelemetryClient>();
+                var loggerFactory = new LoggerFactory().AddXunit(output);
+                var innerLogger = loggerFactory.CreateLogger<LoggerDiagnosticSourceFacts>();
+                _logger = new Mock<RecordingLogger<LoggerDiagnosticSourceFacts>>(innerLogger)
+                {
+                    CallBase = true,
+                };
+
+                _target = new LoggerDiagnosticsSource(
+                    _telemetryClient.Object,
+                    _logger.Object);
+            }
+        }
+    }
+}

--- a/tests/Validation.Common.Job.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Validation.Common.Job.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Validation.Common.Job.Tests")]
+[assembly: ComVisible(false)]
+[assembly: Guid("430f63c7-20c2-4872-ac3e-dde846e50aa4")]

--- a/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
+++ b/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{430F63C7-20C2-4872-AC3E-DDE846E50AA4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Validation.Common.Job.Tests</RootNamespace>
+    <AssemblyName>Validation.Common.Job.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CommonTelemetryServiceFacts.cs" />
+    <Compile Include="LoggerDiagnosticSourceFacts.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Moq">
+      <Version>4.7.145</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.3.1</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.3.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Validation.Common.Job\Validation.Common.Job.csproj">
+      <Project>{FA87D075-A934-4443-8D0B-5DB32640B6D7}</Project>
+      <Name>Validation.Common.Job</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Validation.PackageSigning.Core.Tests\Validation.PackageSigning.Core.Tests.csproj">
+      <Project>{b4b7564a-965b-447b-927f-6749e2c08880}</Project>
+      <Name>Validation.PackageSigning.Core.Tests</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/Validation.PackageSigning.Core.Tests/Support/RecordingLogger.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/RecordingLogger.cs
@@ -19,17 +19,17 @@ namespace Validation.PackageSigning.Core.Tests.Support
 
         public IReadOnlyList<string> Messages => _messages;
 
-        public IDisposable BeginScope<TState>(TState state)
+        public virtual IDisposable BeginScope<TState>(TState state)
         {
             return _inner.BeginScope(state);
         }
 
-        public bool IsEnabled(LogLevel logLevel)
+        public virtual bool IsEnabled(LogLevel logLevel)
         {
             return _inner.IsEnabled(logLevel);
         }
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             _messages.Add(formatter(state, exception));
             _inner.Log(logLevel, eventId, state, exception, formatter);


### PR DESCRIPTION
I added some tracing to NuGetGallery.Core. Tracing in NuGetGallery repository uses `IDiagnosticsService`. In NuGetGallery process this dumps to `Trace`. In orchestrator, I will write to a `ILogger`.

The traces I add provide better resolution on how a server-side blob storage copy ends up (e.g. did it de-dupe? did it replace a failed copy?).