### PR TITLE
Add ProcessorPackageFileService to allow processors to store their .nupkgs

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/ValidationStorageConfiguration.cs
+++ b/src/NuGet.Jobs.Common/Configuration/ValidationStorageConfiguration.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Jobs.Configuration
+{
+    public class ValidationStorageConfiguration
+    {
+        public string ConnectionString { get; set; }
+    }
+}

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -191,6 +191,7 @@
     <Compile Include="Configuration\JobArgumentNames.cs" />
     <Compile Include="Configuration\ServiceBusConfiguration.cs" />
     <Compile Include="Configuration\ValidationDbConfiguration.cs" />
+    <Compile Include="Configuration\ValidationStorageConfiguration.cs" />
     <Compile Include="Extensions\SqlConnectionStringBuilderExtensions.cs" />
     <Compile Include="Extensions\XElementExtensions.cs" />
     <Compile Include="SecretReader\ISecretReaderFactory.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -108,7 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.19.1</Version>
+      <Version>2.22.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -79,7 +79,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.17.0</Version>
+      <Version>2.22.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/Settings/dev.json
+++ b/src/PackageHash/Settings/dev.json
@@ -13,7 +13,7 @@
     ]
   },
 
-  "PackageDownloadTimeout": "10:00",
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/src/PackageHash/Settings/int.json
+++ b/src/PackageHash/Settings/int.json
@@ -13,7 +13,7 @@
     ]
   },
 
-  "PackageDownloadTimeout": "10:00",
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/src/PackageHash/Settings/prod.json
+++ b/src/PackageHash/Settings/prod.json
@@ -13,7 +13,7 @@
     ]
   },
 
-  "PackageDownloadTimeout": "10:00",
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/src/Validation.Common.Job/FileStreamUtility.cs
+++ b/src/Validation.Common.Job/FileStreamUtility.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace NuGet.Jobs.Validation
+{
+    public static class FileStreamUtility
+    {
+        public const int BufferSize = 8192;
+
+        public static FileStream GetTemporaryFile()
+        {
+            return new FileStream(
+                Path.GetTempFileName(),
+                FileMode.Create,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                BufferSize,
+                FileOptions.DeleteOnClose | FileOptions.Asynchronous);
+        }
+    }
+}

--- a/src/Validation.Common.Job/PackageDownloader.cs
+++ b/src/Validation.Common.Job/PackageDownloader.cs
@@ -14,8 +14,6 @@ namespace NuGet.Jobs.Validation
 {
     public class PackageDownloader : IPackageDownloader
     {
-        private const int BufferSize = 8192;
-
         private readonly HttpClient _httpClient;
         private readonly ICommonTelemetryService _telemetryService;
         private readonly ILogger<PackageDownloader> _logger;
@@ -56,15 +54,9 @@ namespace NuGet.Jobs.Validation
 
                     using (var networkStream = await response.Content.ReadAsStreamAsync())
                     {
-                        packageStream = new FileStream(
-                                            Path.GetTempFileName(),
-                                            FileMode.Create,
-                                            FileAccess.ReadWrite,
-                                            FileShare.None,
-                                            BufferSize,
-                                            FileOptions.DeleteOnClose | FileOptions.Asynchronous);
+                        packageStream = FileStreamUtility.GetTemporaryFile();
 
-                        await networkStream.CopyToAsync(packageStream, BufferSize, cancellationToken);
+                        await networkStream.CopyToAsync(packageStream, FileStreamUtility.BufferSize, cancellationToken);
                     }
                 }
 

--- a/src/Validation.Common.Job/Storage/IProcessorPackageFileService.cs
+++ b/src/Validation.Common.Job/Storage/IProcessorPackageFileService.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs.Validation.Storage
+{
+    public interface IProcessorPackageFileService
+    {
+        Task<Uri> GetReadAndDeleteUriAsync(string packageId, string packageNormalizedVersion, Guid validationId);
+        Task SaveAsync(string packageId, string packageNormalizedVersion, Guid validationId, Stream packageFile);
+    }
+}

--- a/src/Validation.Common.Job/Storage/ISimpleCloudBlobProvider.cs
+++ b/src/Validation.Common.Job/Storage/ISimpleCloudBlobProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGetGallery;
+
+namespace NuGet.Jobs.Validation.Storage
+{
+    public interface ISimpleCloudBlobProvider
+    {
+        /// <summary>
+        /// Initializes a blob from a blob URL. This blob URL can contain a SAS token as the query string to allow
+        /// read access to private blob or allow write operations.
+        /// </summary>
+        /// <param name="blobUrl">The blob URL, optionally having a SAS token query string.</param>
+        /// <returns>The blob.</returns>
+        ISimpleCloudBlob GetBlobFromUrl(string blobUrl);
+    }
+}

--- a/src/Validation.Common.Job/Storage/ProcessorPackageFileService.cs
+++ b/src/Validation.Common.Job/Storage/ProcessorPackageFileService.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Services.Validation;
+using NuGetGallery;
+
+namespace NuGet.Jobs.Validation.Storage
+{
+    public class ProcessorPackageFileService : IProcessorPackageFileService
+    {
+        /// <summary>
+        /// This meant to be significantly longer than the maximum validation set duration (currently 1 day).
+        /// </summary>
+        private static readonly TimeSpan AccessDuration = TimeSpan.FromDays(7);
+
+        private ICoreFileStorageService _fileStorageService;
+        private ILogger<ProcessorPackageFileService> _logger;
+        private readonly string _processorName;
+
+        public ProcessorPackageFileService(
+            ICoreFileStorageService fileStorageService,
+            Type processorType,
+            ILogger<ProcessorPackageFileService> logger)
+        {
+            _fileStorageService = fileStorageService ?? throw new ArgumentNullException(nameof(fileStorageService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            if (processorType == null)
+            {
+                throw new ArgumentNullException(nameof(processorType));
+            }
+
+            if (!typeof(IProcessor).IsAssignableFrom(processorType))
+            {
+                throw new ArgumentException($"The validator type {processorType} must extend {nameof(IProcessor)}", nameof(processorType));
+            }
+
+            _processorName = processorType.Name;
+        }
+
+        public Task<Uri> GetReadAndDeleteUriAsync(
+            string packageId,
+            string packageNormalizedVersion,
+            Guid validationId)
+        {
+            var fileName = BuildFileName(packageId, packageNormalizedVersion, validationId);
+
+            return _fileStorageService.GetPriviledgedFileUriAsync(
+                CoreConstants.ValidationFolderName,
+                fileName,
+                FileUriPermissions.Read | FileUriPermissions.Delete,
+                DateTimeOffset.UtcNow + AccessDuration);
+        }
+
+        public Task SaveAsync(
+            string packageId,
+            string packageNormalizedVersion,
+            Guid validationId,
+            Stream packageFile)
+        {
+            if (packageFile == null)
+            {
+                throw new ArgumentNullException(nameof(packageFile));
+            }
+
+            var fileName = BuildFileName(packageId, packageNormalizedVersion, validationId);
+
+            _logger.LogInformation(
+                "Saving package file {PackageId} {PackageNormalizedVersion} for processor {ProcessorName} and " +
+                "validation ID {ValidationId}.",
+                packageId,
+                packageNormalizedVersion,
+                _processorName,
+                validationId);
+
+            packageFile.Position = 0;
+
+            return _fileStorageService.SaveFileAsync(
+                CoreConstants.ValidationFolderName,
+                fileName,
+                packageFile,
+                overwrite: true);
+        }
+
+        private string BuildFileName(string packageId, string packageNormalizedVersion, Guid validationId)
+        {
+            if (packageId == null)
+            {
+                throw new ArgumentNullException(nameof(packageId));
+            }
+
+            if (packageNormalizedVersion == null)
+            {
+                throw new ArgumentNullException(nameof(packageNormalizedVersion));
+            }
+
+            return $"{_processorName}/{validationId}/{packageId.ToLowerInvariant()}." +
+                packageNormalizedVersion.ToLowerInvariant() +
+                CoreConstants.NuGetPackageFileExtension;
+        }
+    }
+}

--- a/src/Validation.Common.Job/Storage/SimpleCloudBlobProvider.cs
+++ b/src/Validation.Common.Job/Storage/SimpleCloudBlobProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.WindowsAzure.Storage.Auth;
+using Microsoft.WindowsAzure.Storage.Blob;
+using NuGetGallery;
+
+namespace NuGet.Jobs.Validation.Storage
+{
+    public class SimpleCloudBlobProvider : ISimpleCloudBlobProvider
+    {
+        public ISimpleCloudBlob GetBlobFromUrl(string blobUrl)
+        {
+            var blobUri = new Uri(blobUrl);
+            var sasToken = blobUri.Query;
+            var blobUriBuilder = new UriBuilder(blobUri) { Query = null };
+
+            CloudBlockBlob innerBlob;
+            if (string.IsNullOrEmpty(sasToken))
+            {
+                innerBlob = new CloudBlockBlob(blobUriBuilder.Uri);
+            }
+            else
+            {
+                innerBlob = new CloudBlockBlob(
+                    blobUriBuilder.Uri,
+                    new StorageCredentials(sasToken));
+            }
+
+            return new CloudBlobWrapper(innerBlob);
+        }
+    }
+}

--- a/src/Validation.Common.Job/Storage/ValidatorStateService.cs
+++ b/src/Validation.Common.Job/Storage/ValidatorStateService.cs
@@ -33,7 +33,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
 
             if (!typeof(IValidator).IsAssignableFrom(validatorType))
             {
-                throw new ArgumentException($"The validator type {validatorType} must extend {nameof(IValidator)}", nameof(validatorType));
+                throw new ArgumentException($"The validator type {validatorType} must implement {nameof(IValidator)}.", nameof(validatorType));
             }
 
             _validatorName = validatorType.Name;

--- a/src/Validation.Common.Job/Storage/ValidatorStatusExtensions.cs
+++ b/src/Validation.Common.Job/Storage/ValidatorStatusExtensions.cs
@@ -36,7 +36,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
                 .Select(x => new SerializedValidationIssue(x.IssueCode, x.Data))
                 .ToList();
 
-            return new ValidationResult(validatorStatus.State, issues);
+            return new ValidationResult(validatorStatus.State, issues, validatorStatus.NupkgUrl);
         }
     }
 }

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -39,6 +39,7 @@
     <Compile Include="CommonTelemetryService.cs" />
     <Compile Include="Error.cs" />
     <Compile Include="ExceptionExtensions.cs" />
+    <Compile Include="FileStreamUtility.cs" />
     <Compile Include="ICommonTelemetryService.cs" />
     <Compile Include="IPackageDownloader.cs" />
     <Compile Include="LoggerDiagnosticsService.cs" />
@@ -47,9 +48,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="Storage\AddStatusResult.cs" />
+    <Compile Include="Storage\IProcessorPackageFileService.cs" />
+    <Compile Include="Storage\ISimpleCloudBlobProvider.cs" />
     <Compile Include="Storage\IValidatorStateService.cs" />
+    <Compile Include="Storage\ProcessorPackageFileService.cs" />
     <Compile Include="Storage\SaveStatusResult.cs" />
     <Compile Include="Storage\SerializedValidationIssue.cs" />
+    <Compile Include="Storage\SimpleCloudBlobProvider.cs" />
     <Compile Include="Storage\ValidatorStateService.cs" />
     <Compile Include="Storage\ValidatorStatusExtensions.cs" />
     <Compile Include="SubcriptionProcessorJob.cs" />
@@ -75,19 +80,19 @@
       <Version>4.7.0-preview1.5029</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.19.1</Version>
+      <Version>2.22.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.19.1</Version>
+      <Version>2.22.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.19.1</Version>
+      <Version>2.22.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.19.1</Version>
+      <Version>2.22.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.4-dev-26021</Version>
+      <Version>4.4.4-dev-26726</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.nuspec
+++ b/src/Validation.Common.Job/Validation.Common.Job.nuspec
@@ -16,11 +16,11 @@
         <dependency id="Microsoft.Extensions.DependencyInjection" version="1.1.1" />
         <dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="1.1.2" />
         <dependency id="NuGet.Packaging" version="4.7.0-preview1.5029" />
-        <dependency id="NuGet.Services.Configuration" version="2.19.1" />
-        <dependency id="NuGet.Services.Logging" version="2.19.1" />
-        <dependency id="NuGet.Services.Storage" version="2.19.1" />
-        <dependency id="NuGet.Services.Validation" version="2.19.1" />
-        <dependency id="NuGetGallery.Core" version="4.4.4-dev-26021" />
+        <dependency id="NuGet.Services.Configuration" version="2.22.0" />
+        <dependency id="NuGet.Services.Logging" version="2.22.0" />
+        <dependency id="NuGet.Services.Storage" version="2.22.0" />
+        <dependency id="NuGet.Services.Validation" version="2.22.0" />
+        <dependency id="NuGetGallery.Core" version="4.4.4-dev-26726" />
         <dependency id="Serilog" version="2.5.0" />
         <dependency id="System.Net.Http" version="4.3.3" />
     </dependencies>

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
@@ -14,8 +14,11 @@
     "ContainerName": "certificates",
     "DataStorageAccount": "DefaultEndpointsProtocol=https;AccountName=nugetdev0;AccountKey=$$Dev-NuGetDev0Storage-Key$$"
   },
+  "ValidationStorage": {
+    "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$"
+  },
 
-  "PackageDownloadTimeout": "10:00",
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
@@ -14,8 +14,11 @@
     "ContainerName": "certificates",
     "DataStorageAccount": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$"
   },
+  "ValidationStorage": {
+    "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$"
+  },
 
-  "PackageDownloadTimeout": "10:00",
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
@@ -14,8 +14,11 @@
     "ContainerName": "certificates",
     "DataStorageAccount": "DefaultEndpointsProtocol=https;AccountName=nugetprod0;AccountKey=$$Prod-NuGetProd0Storage-Key$$"
   },
+  "ValidationStorage": {
+    "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$"
+  },
 
-  "PackageDownloadTimeout": "10:00",
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/tests/Validation.Common.Job.Tests/FileStreamUtilityFacts.cs
+++ b/tests/Validation.Common.Job.Tests/FileStreamUtilityFacts.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet.Jobs.Validation;
+using Xunit;
+
+namespace Validation.Common.Job.Tests
+{
+    public class FileStreamUtilityFacts
+    {
+        public class GetTemporaryFile
+        {
+            private const string FileContent = "Hello, world.";
+
+            [Fact]
+            public void ReturnsFileStreamThatDeletesOnDispose()
+            {
+                // Arrange
+                string fileName;
+                using (var stream = FileStreamUtility.GetTemporaryFile())
+                using (var writer = new StreamWriter(stream))
+                {
+                    fileName = stream.Name;
+                    writer.WriteLine(FileContent);
+                    writer.Flush();
+
+                    // Act & Assert
+                    Assert.True(File.Exists(fileName), "The file should still exist.");
+                }
+
+                Assert.False(File.Exists(fileName), "The file should no longer exist.");
+            }
+
+            [Fact]
+            public void CanReadAndWriteStream()
+            {
+                // Arrange
+                using (var stream = FileStreamUtility.GetTemporaryFile())
+                using (var reader = new StreamReader(stream))
+                using (var writer = new StreamWriter(stream))
+                {
+                    // Act & Assert
+                    writer.Write(FileContent);
+                    writer.Flush();
+                    stream.Position = 0;
+                    var actualContent = reader.ReadToEnd();
+                    Assert.Equal(FileContent, actualContent);
+                }
+            }
+        }
+    }
+}

--- a/tests/Validation.Common.Job.Tests/Storage/ProcessorPackageFileServiceFacts.cs
+++ b/tests/Validation.Common.Job.Tests/Storage/ProcessorPackageFileServiceFacts.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Jobs.Validation.Storage;
+using NuGet.Services.Validation;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Validation.Common.Job.Tests.Storage
+{
+    public class ProcessorPackageFileServiceFacts
+    {
+        private readonly ILogger<ProcessorPackageFileService> _logger;
+        private readonly ProcessorPackageFileService _target;
+        private readonly Mock<ICoreFileStorageService> _fileStorageService;
+        private readonly string _packageId;
+        private readonly string _packageNormalizedVersion;
+        private readonly Guid _validationId;
+        private readonly string _folderName;
+        private readonly string _fileName;
+        private readonly Uri _packageUri;
+        private readonly TimeSpan _accessDuration;
+        private readonly MemoryStream _stream;
+
+        public ProcessorPackageFileServiceFacts(ITestOutputHelper output)
+        {
+            _packageId = "NuGet.Versioning";
+            _packageNormalizedVersion = "4.6.0-BETA";
+            _validationId = new Guid("913ce2b1-66b9-4e33-8b19-2001229afc94");
+            _folderName = "validation";
+            _fileName = "TestProcessor/913ce2b1-66b9-4e33-8b19-2001229afc94/nuget.versioning.4.6.0-beta.nupkg";
+            _packageUri = new Uri("http://example/" + _fileName + "?secret=42");
+            _accessDuration = TimeSpan.FromDays(7);
+            _stream = new MemoryStream(Encoding.ASCII.GetBytes("Hello, world."));
+
+            _fileStorageService = new Mock<ICoreFileStorageService>(MockBehavior.Strict);
+
+            var loggerFactory = new LoggerFactory().AddXunit(output);
+            _logger = loggerFactory.CreateLogger<ProcessorPackageFileService>();
+
+            _target = new ProcessorPackageFileService(
+                _fileStorageService.Object,
+                typeof(TestProcessor),
+                _logger);
+        }
+
+        [Fact]
+        public async Task GetReadAndDeleteUriAsync()
+        {
+            DateTimeOffset endOfAccess = default(DateTimeOffset);
+            _fileStorageService
+                .Setup(x => x.GetPriviledgedFileUriAsync(
+                    _folderName,
+                    _fileName,
+                    FileUriPermissions.Read | FileUriPermissions.Delete,
+                    It.IsAny<DateTimeOffset>()))
+                .ReturnsAsync(_packageUri)
+                .Callback<string, string, FileUriPermissions, DateTimeOffset>((_, __, ___, d) => endOfAccess = d)
+                .Verifiable();
+
+            var before = DateTimeOffset.UtcNow;
+            await _target.GetReadAndDeleteUriAsync(
+                _packageId,
+                _packageNormalizedVersion,
+                _validationId);
+            var after = DateTimeOffset.UtcNow;
+
+            _fileStorageService.Verify();
+            Assert.InRange(endOfAccess, before.Add(_accessDuration), after.Add(_accessDuration));
+        }
+
+        [Fact]
+        public async Task SaveAsync()
+        {
+            _stream.Position = 1;
+            _fileStorageService
+                .Setup(x => x.SaveFileAsync(
+                    _folderName,
+                    _fileName,
+                    _stream,
+                    true))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
+
+            await _target.SaveAsync(
+                _packageId,
+                _packageNormalizedVersion,
+                _validationId,
+                _stream);
+
+            _fileStorageService.Verify();
+            Assert.Equal(0, _stream.Position);
+        }
+
+        private class TestProcessor : IProcessor
+        {
+            public Task CleanUpAsync(IValidationRequest request) => throw new NotImplementedException();
+            public Task<IValidationResult> GetResultAsync(IValidationRequest request) => throw new NotImplementedException();
+            public Task<IValidationResult> StartAsync(IValidationRequest request) => throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
+++ b/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
@@ -41,8 +41,10 @@
   <ItemGroup>
     <Compile Include="CommonTelemetryServiceFacts.cs" />
     <Compile Include="CsprojNuspecConsistencyFacts.cs" />
+    <Compile Include="FileStreamUtilityFacts.cs" />
     <Compile Include="LoggerDiagnosticSourceFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Storage\ProcessorPackageFileServiceFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">

--- a/tests/Validation.PackageSigning.Core.Tests/Storage/ValidatorStatusExtensionsFacts.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Storage/ValidatorStatusExtensionsFacts.cs
@@ -59,6 +59,28 @@ namespace Validation.PackageSigning.Core.Tests.Storage
             }
 
             [Fact]
+            public void IncludesNupkgUrlIfPresent()
+            {
+                // Arrange
+                var nupkgUrl = "http://example/packages/nuget.versioning.4.6.0.nupkg";
+                var validatorStatus = new ValidatorStatus
+                {
+                    State = ValidationStatus.Succeeded,
+                    ValidatorIssues = new List<ValidatorIssue>(),
+                    NupkgUrl = nupkgUrl,
+                };
+
+                // Act
+                var result = validatorStatus.ToValidationResult();
+
+                // Assert
+                Assert.Equal(ValidationStatus.Succeeded, result.Status);
+                Assert.NotNull(result.Issues);
+                Assert.Empty(result.Issues);
+                Assert.Equal(nupkgUrl, result.NupkgUrl);
+            }
+
+            [Fact]
             public void BlindlyConvertsIssues()
             {
                 // Arrange


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1207

1. Add ProcessorPackageFileService to allow processors to store their .nupkgs
1. Update ServerCommon
1. Update NuGetGallery.Core
1. Fix some `PackageDownloadTimeout` oopsies

This is a PR preparing for SignatureProcessor stripping repository signatures.