### PR TITLE
Make PackageSigningValidator into an IProcessor

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -23,6 +23,7 @@ using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.Common;
 using NuGet.Jobs.Validation.PackageSigning.Messages;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.Storage;
 using NuGet.Services.Configuration;
 using NuGet.Services.KeyVault;
 using NuGet.Services.Logging;
@@ -203,6 +204,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IBrokeredMessageSerializer<SignatureValidationMessage>, SignatureValidationMessageSerializer>();
             services.AddTransient<IBrokeredMessageSerializer<CertificateValidationMessage>, CertificateValidationMessageSerializer>();
             services.AddTransient<IValidatorStateService, ValidatorStateService>();
+            services.AddTransient<ISimpleCloudBlobProvider, SimpleCloudBlobProvider>();
             services.AddTransient<PackageSigningValidator>();
             services.AddTransient<MailSenderConfiguration>(serviceProvider =>
             {

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -4,7 +4,7 @@
       {
         "name": "VcsValidator",
         "TrackAfter": "1:00:00:00",
-        "requiredValidations": [],
+        "requiredValidations": [ "PackageSigningValidator" ],
         "ShouldStart": true,
         "FailureBehavior": "MustSucceed"
       },

--- a/src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj
+++ b/src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj
@@ -76,10 +76,6 @@
       <Project>{fa87d075-a934-4443-8d0b-5db32640b6d7}</Project>
       <Name>Validation.Common.Job</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Validation.Common\Validation.Common.csproj">
-      <Project>{2539DDF3-0CC5-4A03-B5F9-39B47744A7BD}</Project>
-      <Name>Validation.Common</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj">
       <Project>{91c060da-736f-4da9-a57f-cb3ac0e6cb10}</Project>
       <Name>Validation.PackageSigning.Core</Name>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationProviderFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationProviderFacts.cs
@@ -85,7 +85,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             /// </summary>
             [Theory]
             [InlineData("VcsValidator", false)]
-            [InlineData("PackageSigningValidator", false)]
+            [InlineData("PackageSigningValidator", true)]
             [InlineData("PackageCertificatesValidator", false)]
             public void KnownValidatorsDoNotChangeNames(string validatorName, bool isProcessor)
             {


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/1207.
Depends on https://github.com/NuGet/NuGet.Jobs/pull/388.

I am working on testing the impact on total validation duration of making VCS validator come after PackageSigningValidator (aka SignatureProcessor). My guess is that we will need to add an "enqueue to orchestrator" feature to downstream validators so that we can fast track the 1 minute polling and gain back the lost validation time.