### PR TITLE
Symbols generation for common libraries

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -137,7 +137,10 @@ Invoke-BuildStep 'Prepare NuGetCDNRedirect Package' { Prepare-NuGetCDNRedirect }
     -ev +BuildErrors
 
 Invoke-BuildStep 'Creating artifacts' {
-        $CommonLibsProjects =
+        # We need a few projects to be published for sharing the common bits with other repos.
+        # We need symbols published for those, too. All other packages are deployment ones and
+        # don't need to be shared, hence no need for symbols for them
+        $ProjectsWithSymbols =
             "src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj",
             "src/Validation.Common.Job/Validation.Common.Job.csproj"
 
@@ -166,7 +169,7 @@ Invoke-BuildStep 'Creating artifacts' {
             + $CommonLibsProjects
 
         Foreach ($Project in $Projects) {
-            $Symbols = $CommonLibsProjects -contains $Project;
+            $Symbols = $ProjectsWithSymbols -contains $Project;
             New-Package (Join-Path $PSScriptRoot "$Project") -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -Branch $Branch -MSBuildVersion "$msBuildVersion" -Symbols:$Symbols
         }
     } `

--- a/build.ps1
+++ b/build.ps1
@@ -166,7 +166,7 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/Stats.CollectAzureChinaCDNLogs/Stats.CollectAzureChinaCDNLogs.csproj", `
             "src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj", `
             "src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj" `
-            + $CommonLibsProjects
+            + $ProjectsWithSymbols
 
         Foreach ($Project in $Projects) {
             $Symbols = $ProjectsWithSymbols -contains $Project;

--- a/build.ps1
+++ b/build.ps1
@@ -137,8 +137,9 @@ Invoke-BuildStep 'Prepare NuGetCDNRedirect Package' { Prepare-NuGetCDNRedirect }
     -ev +BuildErrors
 
 Invoke-BuildStep 'Creating artifacts' {
-        $CommonLibsProjects = @("src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj",
-            "src/Validation.Common.Job/Validation.Common.Job.csproj");
+        $CommonLibsProjects =
+            "src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj",
+            "src/Validation.Common.Job/Validation.Common.Job.csproj"
 
         $Projects = `
             "src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj", `
@@ -162,7 +163,7 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/Stats.CollectAzureChinaCDNLogs/Stats.CollectAzureChinaCDNLogs.csproj", `
             "src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj", `
             "src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj" `
-            + $CommonLibsProjects;
+            + $CommonLibsProjects
 
         Foreach ($Project in $Projects) {
         	$Symbols = $CommonLibsProjects -contains $Project;

--- a/build.ps1
+++ b/build.ps1
@@ -137,6 +137,9 @@ Invoke-BuildStep 'Prepare NuGetCDNRedirect Package' { Prepare-NuGetCDNRedirect }
     -ev +BuildErrors
 
 Invoke-BuildStep 'Creating artifacts' {
+        $CommonLibsProjects = @("src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj",
+            "src/Validation.Common.Job/Validation.Common.Job.csproj");
+
         $Projects = `
             "src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.csproj", `
             "src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj", `
@@ -158,12 +161,12 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj", `
             "src/Stats.CollectAzureChinaCDNLogs/Stats.CollectAzureChinaCDNLogs.csproj", `
             "src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj", `
-            "src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj", `
-            "src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj", `
-            "src/Validation.Common.Job/Validation.Common.Job.csproj"
+            "src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj" `
+            + $CommonLibsProjects;
 
         Foreach ($Project in $Projects) {
-            New-Package (Join-Path $PSScriptRoot "$Project") -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -Branch $Branch -MSBuildVersion "$msBuildVersion"
+        	$Symbols = $CommonLibsProjects -contains $Project;
+            New-Package (Join-Path $PSScriptRoot "$Project") -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -Branch $Branch -MSBuildVersion "$msBuildVersion" -Symbols:$Symbols
         }
     } `
     -ev +BuildErrors

--- a/build.ps1
+++ b/build.ps1
@@ -166,7 +166,7 @@ Invoke-BuildStep 'Creating artifacts' {
             + $CommonLibsProjects
 
         Foreach ($Project in $Projects) {
-        	$Symbols = $CommonLibsProjects -contains $Project;
+            $Symbols = $CommonLibsProjects -contains $Project;
             New-Package (Join-Path $PSScriptRoot "$Project") -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -Branch $Branch -MSBuildVersion "$msBuildVersion" -Symbols:$Symbols
         }
     } `


### PR DESCRIPTION
Currently, sign build queue expects symbols packages to be present, so build script is updated to generate those for common libraries.