### PR TITLE
Persist repository signature information in database

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.22.0</Version>
+      <Version>2.23.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.Common.Job/Storage/ValidatorStateService.cs
+++ b/src/Validation.Common.Job/Storage/ValidatorStateService.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Validation;
-using NuGet.Services.Validation.Orchestrator;
 
 namespace NuGet.Jobs.Validation.PackageSigning.Storage
 {
@@ -21,20 +20,11 @@ namespace NuGet.Jobs.Validation.PackageSigning.Storage
 
         public ValidatorStateService(
             IValidationEntitiesContext validationContext,
-            IValidatorProvider validatorProvider,
             string validatorName,
             ILogger<ValidatorStateService> logger)
         {
             _validationContext = validationContext ?? throw new ArgumentNullException(nameof(validationContext));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            if (validatorProvider == null)
-            {
-                throw new ArgumentNullException(nameof(validatorProvider));
-            }
-            if (!validatorProvider.IsValidator(validatorName))
-            {
-                throw new ArgumentException($"\"{validatorName}\" is not a proper validator alias.", nameof(validatorName));
-            }
             _validatorName = validatorName ?? throw new ArgumentNullException(nameof(validatorName));
         }
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -88,19 +88,19 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.7.0-preview1.5029</Version>
+      <Version>4.7.0-preview4.5067</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.22.0</Version>
+      <Version>2.23.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.22.0</Version>
+      <Version>2.23.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.22.0</Version>
+      <Version>2.23.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.22.0</Version>
+      <Version>2.23.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.4-dev-26726</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.nuspec
+++ b/src/Validation.Common.Job/Validation.Common.Job.nuspec
@@ -15,11 +15,11 @@
         <dependency id="Microsoft.ApplicationInsights" version="2.2.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection" version="1.1.1" />
         <dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="1.1.2" />
-        <dependency id="NuGet.Packaging" version="4.7.0-preview1.5029" />
-        <dependency id="NuGet.Services.Configuration" version="2.22.0" />
-        <dependency id="NuGet.Services.Logging" version="2.22.0" />
-        <dependency id="NuGet.Services.Storage" version="2.22.0" />
-        <dependency id="NuGet.Services.Validation" version="2.22.0" />
+        <dependency id="NuGet.Packaging" version="4.7.0-preview4.5067" />
+        <dependency id="NuGet.Services.Configuration" version="2.23.0" />
+        <dependency id="NuGet.Services.Logging" version="2.23.0" />
+        <dependency id="NuGet.Services.Storage" version="2.23.0" />
+        <dependency id="NuGet.Services.Validation" version="2.23.0" />
         <dependency id="NuGetGallery.Core" version="4.4.4-dev-26726" />
         <dependency id="Serilog" version="2.5.0" />
         <dependency id="System.Net.Http" version="4.3.3" />

--- a/src/Validation.PackageSigning.ProcessSignature/Job.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Job.cs
@@ -79,10 +79,6 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                 .As<IValidatorStateService>();
 
             containerBuilder
-                .RegisterType<PackageSigningStateService>()
-                .As<IPackageSigningStateService>();
-
-            containerBuilder
                 .RegisterType<ScopedMessageHandler<SignatureValidationMessage>>()
                 .Keyed<IMessageHandler<SignatureValidationMessage>>(validateSignatureBindingKey);
 

--- a/src/Validation.PackageSigning.ProcessSignature/MinimalSignatureVerificationProvider.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/MinimalSignatureVerificationProvider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             CancellationToken token)
         {
             var result = new SignedPackageVerificationResult(
-                SignatureVerificationStatus.Trusted,
+                SignatureVerificationStatus.Valid,
                 signature,
                 Enumerable.Empty<SignatureLog>());
 

--- a/src/Validation.PackageSigning.ProcessSignature/PackageSignatureVerifierFactory.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/PackageSignatureVerifierFactory.cs
@@ -23,6 +23,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: true,
+                allowIllegal: false,
                 allowUntrusted: false, // Invalid format of the signature uses this flag to determine success.
                 allowUntrustedSelfIssuedCertificate: true,
                 allowIgnoreTimestamp: true,
@@ -48,6 +49,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
             var settings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
+                allowIllegal: false,
                 allowUntrusted: false,
                 allowUntrustedSelfIssuedCertificate: false,
                 allowIgnoreTimestamp: false,

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
@@ -1173,7 +1173,6 @@ namespace NuGet.Services.Validation.PackageSigning
         public abstract class FactsBase
         {
             protected readonly Mock<IValidationEntitiesContext> _validationContext;
-            protected readonly Mock<IValidatorProvider> _validatorProvider;
             protected readonly Mock<IValidateCertificateEnqueuer> _certificateVerifier;
             protected readonly Mock<ITelemetryService> _telemetryService;
             protected readonly Mock<ILogger<PackageCertificatesValidator>> _logger;
@@ -1183,13 +1182,9 @@ namespace NuGet.Services.Validation.PackageSigning
             public FactsBase()
             {
                 _validationContext = new Mock<IValidationEntitiesContext>();
-                _validatorProvider = new Mock<IValidatorProvider>();
                 _certificateVerifier = new Mock<IValidateCertificateEnqueuer>();
                 _telemetryService = new Mock<ITelemetryService>();
                 _logger = new Mock<ILogger<PackageCertificatesValidator>>();
-
-                _validatorProvider.Setup(vp => vp.IsValidator(It.IsAny<string>())).Returns(true);
-                _validatorProvider.Setup(vp => vp.IsProcessor(It.IsAny<string>())).Returns(true);
 
                 _validationRequest = new Mock<IValidationRequest>();
                 _validationRequest.Setup(x => x.NupkgUrl).Returns(NupkgUrl);
@@ -1201,7 +1196,6 @@ namespace NuGet.Services.Validation.PackageSigning
                 var validatorStateServiceLogger = new Mock<ILogger<ValidatorStateService>>();
                 var validatorStateService = new ValidatorStateService(
                     _validationContext.Object,
-                    _validatorProvider.Object,
                     ValidatorName.PackageCertificate,
                     validatorStateServiceLogger.Object);
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
@@ -483,24 +483,9 @@ namespace NuGet.Services.Validation
             }
         }
 
-        public class TheConstructor : FactsBase
-        {
-            [Fact]
-            public void ThrowsWhenValidatorNameIsNotProperAlias()
-            {
-                const string notAValidatorAlias = "pew-pew";
-
-                _validatorProvider.Setup(vp => vp.IsValidator(notAValidatorAlias)).Returns(false);
-
-                var ex = Assert.Throws<ArgumentException>(() => CreateValidatorStateService(notAValidatorAlias));
-                Assert.Equal("validatorName", ex.ParamName);
-            }
-        }
-
         public abstract class FactsBase
         {
             protected readonly Mock<IValidationEntitiesContext> _validationContext;
-            protected readonly Mock<IValidatorProvider> _validatorProvider;
             protected readonly Mock<ILogger<ValidatorStateService>> _logger;
             protected readonly Mock<IValidationRequest> _validationRequest;
             protected readonly ValidatorStateService _target;
@@ -508,11 +493,7 @@ namespace NuGet.Services.Validation
             public FactsBase()
             {
                 _validationContext = new Mock<IValidationEntitiesContext>();
-                _validatorProvider = new Mock<IValidatorProvider>();
                 _logger = new Mock<ILogger<ValidatorStateService>>();
-
-                _validatorProvider.Setup(vp => vp.IsValidator(It.IsAny<string>())).Returns(true);
-                _validatorProvider.Setup(vp => vp.IsProcessor(It.IsAny<string>())).Returns(true);
 
                 _validationRequest = new Mock<IValidationRequest>();
                 _validationRequest.Setup(x => x.NupkgUrl).Returns(NupkgUrl);
@@ -527,7 +508,6 @@ namespace NuGet.Services.Validation
             protected ValidatorStateService CreateValidatorStateService(string validatorName)
                 => new ValidatorStateService(
                     _validationContext.Object,
-                    _validatorProvider.Object,
                     validatorName,
                     _logger.Object);
         }

--- a/tests/Validation.PackageSigning.Core.Tests/Support/DbSetMockFactory.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/DbSetMockFactory.cs
@@ -20,6 +20,7 @@ namespace Validation.PackageSigning.Core.Tests.Support
             dbSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(() => list.AsQueryable().ElementType);
             dbSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => list.GetEnumerator());
             dbSet.Setup(m => m.Add(It.IsAny<T>())).Callback<T>(e => list.Add(e));
+            dbSet.Setup(m => m.Remove(It.IsAny<T>())).Callback<T>(e => list.Remove(e));
 
             return dbSet.Object;
         }

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -73,7 +73,7 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Test.Utility">
-      <Version>4.7.0-preview1.5029</Version>
+      <Version>4.7.0-preview4.5067</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.3.1</Version>

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignaturePartsExtractorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignaturePartsExtractorFacts.cs
@@ -30,35 +30,82 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             .Parse("2018-01-26T22:09:01.0000000Z")
             .ToUniversalTime();
 
+        private static readonly DateTime RepoSignedLeaf1TimestampValue = DateTime
+            .Parse("2018-03-21T17:55:33.0000000Z")
+            .ToUniversalTime();
+
+        private static readonly DateTime AuthorAndRepoSignedPrimaryTimestampValue = DateTime
+            .Parse("2018-03-21T17:55:50.0000000Z")
+            .ToUniversalTime();
+
+        private static readonly DateTime AuthorAndRepoSignedCounterTimestampValue = DateTime
+            .Parse("2018-03-21T17:56:00.0000000Z")
+            .ToUniversalTime();
+
         /// <summary>
         /// This contains the SHA-256 thumbprints of the test certificate chain as well as the time stamping
         /// authoring (TSA) chain. In this case, Symantec's TSA is used.
         /// </summary>
         private static readonly ExtractedCertificatesThumbprints Leaf1Certificates = new ExtractedCertificatesThumbprints
         {
-            SignatureEndCertificate = new SubjectAndThumbprint(
+            PrimarySignature = new SignatureCertificateThumprints
+            {
+                SignatureEndCertificate = new SubjectAndThumbprint(
                 "CN=NUGET_DO_NOT_TRUST.leaf-1.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
                 TestResources.Leaf1Thumbprint),
-            SignatureParentCertificates = new[]
-            {
-                new SubjectAndThumbprint(
-                    "CN=NUGET_DO_NOT_TRUST.intermediate.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
-                    "7358e4597696b1d02e7aa2b3cf30a7cf154f2c8ff0710fd0dc3ace17e3784054"),
-                new SubjectAndThumbprint(
-                    "CN=NUGET_DO_NOT_TRUST.root.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
-                    TestResources.RootThumbprint),
+                SignatureParentCertificates = new[]
+                {
+                    new SubjectAndThumbprint(
+                        "CN=NUGET_DO_NOT_TRUST.intermediate.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
+                        "7358e4597696b1d02e7aa2b3cf30a7cf154f2c8ff0710fd0dc3ace17e3784054"),
+                    new SubjectAndThumbprint(
+                        "CN=NUGET_DO_NOT_TRUST.root.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
+                        TestResources.RootThumbprint),
+                },
+                    TimestampEndCertificate = new SubjectAndThumbprint(
+                    "CN=Symantec SHA256 TimeStamping Signer - G2, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
+                    TestResources.Leaf1TimestampThumbprint),
+                    TimestampParentCertificates = new[]
+                {
+                    new SubjectAndThumbprint(
+                        "CN=Symantec SHA256 TimeStamping CA, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
+                        "f3516ddcc8afc808788bd8b0e840bda2b5e23c6244252ca3000bb6c87170402a"),
+                    new SubjectAndThumbprint(
+                        "CN=VeriSign Universal Root Certification Authority, OU=\"(c) 2008 VeriSign, Inc. - For authorized use only\", OU=VeriSign Trust Network, O=\"VeriSign, Inc.\", C=US",
+                        "2399561127a57125de8cefea610ddf2fa078b5c8067f4e828290bfb860e84b3c"),
+                },
             },
-            TimestampEndCertificate = new SubjectAndThumbprint(
-                "CN=Symantec SHA256 TimeStamping Signer - G2, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
-                TestResources.Leaf1TimestampThumbprint),
-            TimestampParentCertificates = new[]
+        };
+
+        private static readonly ExtractedCertificatesThumbprints AuthorAndRepoSignedCertificates = new ExtractedCertificatesThumbprints
+        {
+            PrimarySignature = Leaf1Certificates.PrimarySignature,
+            Countersignature = new SignatureCertificateThumprints
             {
-                new SubjectAndThumbprint(
-                    "CN=Symantec SHA256 TimeStamping CA, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
-                    "f3516ddcc8afc808788bd8b0e840bda2b5e23c6244252ca3000bb6c87170402a"),
-                new SubjectAndThumbprint(
-                    "CN=VeriSign Universal Root Certification Authority, OU=\"(c) 2008 VeriSign, Inc. - For authorized use only\", OU=VeriSign Trust Network, O=\"VeriSign, Inc.\", C=US",
-                    "2399561127a57125de8cefea610ddf2fa078b5c8067f4e828290bfb860e84b3c"),
+                SignatureEndCertificate = new SubjectAndThumbprint(
+                "CN=NUGET_DO_NOT_TRUST.leaf-2.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
+                TestResources.Leaf2Thumbprint),
+                SignatureParentCertificates = new[]
+                {
+                    new SubjectAndThumbprint(
+                        "CN=NUGET_DO_NOT_TRUST.intermediate.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
+                        "7358e4597696b1d02e7aa2b3cf30a7cf154f2c8ff0710fd0dc3ace17e3784054"),
+                    new SubjectAndThumbprint(
+                        "CN=NUGET_DO_NOT_TRUST.root.test.test, OU=Test Organizational Unit Name, O=Test Organization Name, L=Redmond, S=WA, C=US",
+                        TestResources.RootThumbprint),
+                },
+                TimestampEndCertificate = new SubjectAndThumbprint(
+                    "CN=Symantec SHA256 TimeStamping Signer - G2, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
+                    TestResources.Leaf1TimestampThumbprint),
+                TimestampParentCertificates = new[]
+                {
+                    new SubjectAndThumbprint(
+                        "CN=Symantec SHA256 TimeStamping CA, OU=Symantec Trust Network, O=Symantec Corporation, C=US",
+                        "f3516ddcc8afc808788bd8b0e840bda2b5e23c6244252ca3000bb6c87170402a"),
+                    new SubjectAndThumbprint(
+                        "CN=VeriSign Universal Root Certification Authority, OU=\"(c) 2008 VeriSign, Inc. - For authorized use only\", OU=VeriSign Trust Network, O=\"VeriSign, Inc.\", C=US",
+                        "2399561127a57125de8cefea610ddf2fa078b5c8067f4e828290bfb860e84b3c"),
+                },
             },
         };
 
@@ -86,7 +133,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _certificateStore
                     .Setup(x => x.SaveAsync(It.IsAny<X509Certificate2>(), It.IsAny<CancellationToken>()))
                     .Returns(Task.CompletedTask)
-                    .Callback<X509Certificate2, CancellationToken>((cert, _) => _savedCertificates.Add(cert));
+                    .Callback<X509Certificate2, CancellationToken>((cert, _) => _savedCertificates.Add(new X509Certificate2(cert.RawData)));
 
                 _entitiesContext = new Mock<IValidationEntitiesContext>();
                 _entitiesContext
@@ -114,7 +161,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             }
 
             [Fact]
-            public async Task SaveSigningAndTimestampCertificates()
+            public async Task SaveSigningAndTimestampCertificatesForAuthorPrimarySignature()
             {
                 // Arrange
                 var signature = await TestResources.LoadPrimarySignatureAsync(TestResources.SignedPackageLeaf1);
@@ -123,7 +170,35 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 await _target.ExtractAsync(_packageKey, signature, _token);
 
                 // Assert
-                VerifySavedCertificates(Leaf1Certificates, Leaf1TimestampValue);
+                VerifyExtractedInformation(Leaf1Certificates, Leaf1TimestampValue, PackageSignatureType.Author);
+            }
+
+            [Fact]
+            public async Task SaveSigningAndTimestampCertificatesForRepositoryPrimarySignature()
+            {
+                // Arrange
+                var signature = await TestResources.LoadPrimarySignatureAsync(TestResources.RepoSignedPackageLeaf1);
+
+                // Act
+                await _target.ExtractAsync(_packageKey, signature, _token);
+
+                // Assert
+                VerifyExtractedInformation(Leaf1Certificates, RepoSignedLeaf1TimestampValue, PackageSignatureType.Repository);
+            }
+
+            [Fact]
+            public async Task SaveSigningAndTimestampCertificatesForAuthorAndReposignedPackage()
+            {
+                // Arrange
+                var signature = await TestResources.LoadPrimarySignatureAsync(TestResources.AuthorAndRepoSignedPackageLeaf1);
+
+                // Act
+                await _target.ExtractAsync(_packageKey, signature, _token);
+
+                // Assert
+                VerifyStoredCertificates(AuthorAndRepoSignedCertificates);
+                VerifyPackageSignatureRecord(AuthorAndRepoSignedCertificates.PrimarySignature, AuthorAndRepoSignedPrimaryTimestampValue, PackageSignatureType.Author);
+                VerifyPackageSignatureRecord(AuthorAndRepoSignedCertificates.Countersignature, AuthorAndRepoSignedCounterTimestampValue, PackageSignatureType.Repository);
             }
 
             [Fact]
@@ -191,7 +266,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 await _target.ExtractAsync(_packageKey, signature, _token);
 
                 // Assert
-                VerifySavedCertificates(Leaf1Certificates, Leaf1TimestampValue);
+                VerifyExtractedInformation(Leaf1Certificates, Leaf1TimestampValue, PackageSignatureType.Author);
                 Assert.Equal(2, _entitiesContext.Object.EndCertificates.Count());
                 Assert.Equal(4, _entitiesContext.Object.ParentCertificates.Count());
                 Assert.Equal(4, _entitiesContext.Object.CertificateChainLinks.Count());
@@ -236,6 +311,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     Status = PackageSignatureStatus.Valid,
                     CreatedAt = new DateTime(2017, 1, 1, 8, 30, 0, DateTimeKind.Utc),
                     PackageKey = _packageKey,
+                    Type = PackageSignatureType.Author,
                     TrustedTimestamps = new List<TrustedTimestamp>(),
                 };
 
@@ -256,7 +332,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 await _target.ExtractAsync(_packageKey, signature, _token);
 
                 // Assert
-                VerifySavedCertificates(Leaf1Certificates, Leaf1TimestampValue);
+                VerifyExtractedInformation(Leaf1Certificates, Leaf1TimestampValue, PackageSignatureType.Author);
                 Assert.Equal(2, _entitiesContext.Object.EndCertificates.Count());
                 Assert.Equal(4, _entitiesContext.Object.ParentCertificates.Count());
                 Assert.Equal(4, _entitiesContext.Object.CertificateChainLinks.Count());
@@ -294,21 +370,25 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 Assert.Empty(_savedCertificates);
             }
 
-            [Fact]
-            public async Task RejectsPackageWithMultipleSignatures()
+            [Theory]
+            [InlineData(PackageSignatureType.Author, TestResources.SignedPackageLeaf1)]
+            [InlineData(PackageSignatureType.Repository, TestResources.RepoSignedPackageLeaf1)]
+            public async Task RejectsPackageWithMultipleSignatures(PackageSignatureType type, string resourceName)
             {
                 // Arrange
-                var signature = await TestResources.LoadPrimarySignatureAsync(TestResources.SignedPackageLeaf1);
+                var signature = await TestResources.LoadPrimarySignatureAsync(resourceName);
                 var existingPackageSignature1 = new PackageSignature
                 {
                     Key = 1,
                     PackageKey = _packageKey,
+                    Type = type,
                 };
 
                 var existingPackageSignature2 = new PackageSignature
                 {
                     Key = 2,
                     PackageKey = _packageKey,
+                    Type = type,
                 };
 
                 _entitiesContext
@@ -318,7 +398,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 // Act & Assert
                 var ex = await Assert.ThrowsAsync<InvalidOperationException>(
                     () => _target.ExtractAsync(_packageKey, signature, _token));
-                Assert.Equal("There should never be more than one package signature per package.", ex.Message);
+                Assert.Equal("There should never be more than one package signature per package and signature type.", ex.Message);
                 _entitiesContext.Verify(
                     x => x.SaveChangesAsync(),
                     Times.Never);
@@ -326,7 +406,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             }
 
             [Fact]
-            public async Task RejectsPackageWithChangedSigningCertificateThumbprint()
+            public async Task RejectsAuthorSignedPackageWithChangedSigningCertificateThumbprint()
             {
                 // Arrange
                 var signature = await TestResources.LoadPrimarySignatureAsync(TestResources.SignedPackageLeaf1);
@@ -337,7 +417,8 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     EndCertificate = new EndCertificate
                     {
                         Thumbprint = "something else",
-                    }
+                    },
+                    Type = PackageSignatureType.Author,
                 };
 
                 _entitiesContext
@@ -352,6 +433,53 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     x => x.SaveChangesAsync(),
                     Times.Never);
                 Assert.Empty(_savedCertificates);
+            }
+
+            [Fact]
+            public async Task AcceptsRepoSignedPackageWithChangedSigningCertificateThumbprint()
+            {
+                // Arrange
+                var signature = await TestResources.LoadPrimarySignatureAsync(TestResources.RepoSignedPackageLeaf1);
+                var existingTrustedTimestamp = new TrustedTimestamp
+                {
+                    EndCertificate = new EndCertificate
+                    {
+                        Thumbprint = "something else B",
+                    },
+                };
+                var existingPackageSignature = new PackageSignature
+                {
+                    Key = 1,
+                    PackageKey = _packageKey,
+                    EndCertificate = new EndCertificate
+                    {
+                        Thumbprint = "something else A",
+                    },
+                    Type = PackageSignatureType.Repository,
+                    TrustedTimestamps = new List<TrustedTimestamp>
+                    {
+                        existingTrustedTimestamp
+                    },
+                };
+
+                _entitiesContext
+                    .Setup(x => x.PackageSignatures)
+                    .Returns(DbSetMockFactory.Create(existingPackageSignature));
+                _entitiesContext
+                    .Setup(x => x.TrustedTimestamps)
+                    .Returns(DbSetMockFactory.Create(existingTrustedTimestamp));
+
+                // Act
+                await _target.ExtractAsync(_packageKey, signature, _token);
+
+                // Assert
+                var newPackageSignature = Assert.Single(_entitiesContext.Object.PackageSignatures);
+                Assert.NotSame(existingPackageSignature, newPackageSignature);
+                Assert.Equal(TestResources.Leaf1Thumbprint, newPackageSignature.EndCertificate.Thumbprint);
+
+                var newTrustedTimestamp = Assert.Single(_entitiesContext.Object.TrustedTimestamps);
+                Assert.NotSame(existingTrustedTimestamp, newTrustedTimestamp);
+                Assert.Equal(TestResources.Leaf1TimestampThumbprint, newTrustedTimestamp.EndCertificate.Thumbprint);
             }
 
             [Fact]
@@ -371,7 +499,8 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     {
                             new TrustedTimestamp(),
                             new TrustedTimestamp(),
-                        },
+                    },
+                    Type = PackageSignatureType.Author,
                 };
 
                 _entitiesContext
@@ -403,14 +532,15 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     },
                     TrustedTimestamps = new[]
                     {
-                            new TrustedTimestamp
+                        new TrustedTimestamp
+                        {
+                            EndCertificate = new EndCertificate
                             {
-                                EndCertificate = new EndCertificate
-                                {
-                                    Thumbprint = "something else",
-                                },
+                                Thumbprint = "something else",
                             },
                         },
+                    },
+                    Type = PackageSignatureType.Author,
                 };
 
                 _entitiesContext
@@ -451,6 +581,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                             Value = new DateTime(2010, 1, 1, 0, 0, 0, DateTimeKind.Utc),
                         },
                     },
+                    Type = PackageSignatureType.Author,
                 };
 
                 _entitiesContext
@@ -479,7 +610,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 await _target.ExtractAsync(_packageKey, signature, _token);
 
                 // Assert
-                VerifySavedCertificates(Leaf1Certificates, Leaf1TimestampValue);
+                VerifyExtractedInformation(Leaf1Certificates, Leaf1TimestampValue, PackageSignatureType.Author);
                 Assert.Equal(
                     Leaf1Certificates.Certificates.Count + 1,
                     signature.SignedCms.Certificates.Count + signature.Timestamps.Sum(x => x.SignedCms.Certificates.Count));
@@ -528,9 +659,88 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 }
             }
 
-            private void VerifySavedCertificates(ExtractedCertificatesThumbprints expected, DateTime timestampValue)
+            private void VerifyExtractedInformation(
+                ExtractedCertificatesThumbprints expected,
+                DateTime timestampValue,
+                PackageSignatureType signatureType)
             {
                 // Assert the certificates saved to the store.
+                VerifyStoredCertificates(expected);
+
+                // Assert the certificates saved to the database.
+                var trustedTimestamp = VerifyPackageSignatureRecord(expected.PrimarySignature, timestampValue, signatureType);
+
+                Assert.Equal(
+                    expected
+                        .PrimarySignature
+                        .SignatureParentCertificates
+                        .Select(x => x.Thumbprint)
+                        .OrderBy(x => x),
+                     trustedTimestamp
+                        .PackageSignature
+                        .EndCertificate
+                        .CertificateChainLinks
+                        .Select(x => x.ParentCertificate.Thumbprint)
+                        .OrderBy(x => x));
+
+                Assert.Equal(
+                    expected
+                        .PrimarySignature
+                        .TimestampParentCertificates
+                        .Select(x => x.Thumbprint)
+                        .OrderBy(x => x),
+                     trustedTimestamp
+                        .EndCertificate
+                        .CertificateChainLinks
+                        .Select(x => x.ParentCertificate.Thumbprint)
+                        .OrderBy(x => x));
+            }
+
+            private TrustedTimestamp VerifyPackageSignatureRecord(
+                SignatureCertificateThumprints expected,
+                DateTime timestampValue,
+                PackageSignatureType signatureType)
+            {
+                var signatureEndCertificate = Assert.Single(_entitiesContext
+                                    .Object
+                                    .EndCertificates
+                                    .Where(x => x.Thumbprint == expected.SignatureEndCertificate.Thumbprint));
+                Assert.Equal(EndCertificateUse.CodeSigning, signatureEndCertificate.Use);
+
+                var timestampEndCertificate = Assert.Single(_entitiesContext
+                    .Object
+                    .EndCertificates
+                    .Where(x => x.Thumbprint == expected.TimestampEndCertificate.Thumbprint));
+                Assert.Equal(EndCertificateUse.Timestamping, timestampEndCertificate.Use);
+
+                var packageSignature = Assert.Single(_entitiesContext
+                    .Object
+                    .PackageSignatures
+                    .Where(x => x.Type == signatureType));
+                Assert.Equal(_packageKey, packageSignature.PackageKey);
+                Assert.NotEqual(default(DateTime), packageSignature.CreatedAt);
+                Assert.Equal(expected.SignatureEndCertificate.Thumbprint, packageSignature.EndCertificate.Thumbprint);
+                Assert.Same(signatureEndCertificate, packageSignature.EndCertificate);
+                Assert.NotNull(packageSignature.TrustedTimestamps);
+
+                var trustedTimestamp = Assert.Single(_entitiesContext
+                    .Object
+                    .TrustedTimestamps
+                    .Where(x => x.PackageSignature == packageSignature));
+                Assert.Same(trustedTimestamp, packageSignature.TrustedTimestamps.Single());
+                Assert.Same(packageSignature, trustedTimestamp.PackageSignature);
+                Assert.Equal(expected.TimestampEndCertificate.Thumbprint, trustedTimestamp.EndCertificate.Thumbprint);
+                Assert.Same(timestampEndCertificate, trustedTimestamp.EndCertificate);
+                Assert.Equal(timestampValue, trustedTimestamp.Value);
+                Assert.Equal(TrustedTimestampStatus.Valid, trustedTimestamp.Status);
+
+                _entitiesContext.Verify(x => x.SaveChangesAsync(), Times.Once);
+
+                return trustedTimestamp;
+            }
+
+            private void VerifyStoredCertificates(ExtractedCertificatesThumbprints expected)
+            {
                 Assert.Equal(expected.Certificates.Count, _savedCertificates.Count);
                 for (var i = 0; i < _savedCertificates.Count; i++)
                 {
@@ -539,58 +749,6 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     Assert.Equal(expected.Certificates[i].Subject, subject);
                     Assert.Equal(expected.Certificates[i].Thumbprint, thumbprint);
                 }
-
-                // Assert the certificates saved to the database.
-                var signatureEndCertificate = Assert.Single(_entitiesContext
-                    .Object
-                    .EndCertificates
-                    .Where(x => x.Thumbprint == expected.SignatureEndCertificate.Thumbprint));
-
-                Assert.Equal(EndCertificateUse.CodeSigning, signatureEndCertificate.Use);
-
-                Assert.Equal(
-                    expected
-                        .SignatureParentCertificates
-                        .Select(x => x.Thumbprint)
-                        .OrderBy(x => x),
-                     signatureEndCertificate
-                        .CertificateChainLinks
-                        .Select(x => x.ParentCertificate.Thumbprint)
-                        .OrderBy(x => x));
-
-                var timestampEndCertificate = Assert.Single(_entitiesContext
-                    .Object
-                    .EndCertificates
-                    .Where(x => x.Thumbprint == expected.TimestampEndCertificate.Thumbprint));
-
-                Assert.Equal(EndCertificateUse.Timestamping, timestampEndCertificate.Use);
-
-                Assert.Equal(
-                    expected
-                        .TimestampParentCertificates
-                        .Select(x => x.Thumbprint)
-                        .OrderBy(x => x),
-                     timestampEndCertificate
-                        .CertificateChainLinks
-                        .Select(x => x.ParentCertificate.Thumbprint)
-                        .OrderBy(x => x));
-
-                _entitiesContext.Verify(x => x.SaveChangesAsync(), Times.Once);
-
-                var packageSignature = Assert.Single(_entitiesContext.Object.PackageSignatures);
-                Assert.Equal(_packageKey, packageSignature.PackageKey);
-                Assert.NotEqual(default(DateTime), packageSignature.CreatedAt);
-                Assert.Equal(expected.SignatureEndCertificate.Thumbprint, packageSignature.EndCertificate.Thumbprint);
-                Assert.Same(signatureEndCertificate, packageSignature.EndCertificate);
-                Assert.NotNull(packageSignature.TrustedTimestamps);
-
-                var trustedTimestamp = Assert.Single(_entitiesContext.Object.TrustedTimestamps);
-                Assert.Same(trustedTimestamp, packageSignature.TrustedTimestamps.Single());
-                Assert.Same(packageSignature, trustedTimestamp.PackageSignature);
-                Assert.Equal(expected.TimestampEndCertificate.Thumbprint, trustedTimestamp.EndCertificate.Thumbprint);
-                Assert.Same(timestampEndCertificate, trustedTimestamp.EndCertificate);
-                Assert.Equal(timestampValue, trustedTimestamp.Value);
-                Assert.Equal(TrustedTimestampStatus.Valid, trustedTimestamp.Status);
             }
         }
 
@@ -632,17 +790,54 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
         private class ExtractedCertificatesThumbprints
         {
+            public SignatureCertificateThumprints PrimarySignature { get; set; }
+            public SignatureCertificateThumprints Countersignature { get; set; }
+
+            public IReadOnlyList<SubjectAndThumbprint> Certificates
+            {
+                get
+                {
+                    var all = Enumerable.Empty<SubjectAndThumbprint>();
+
+                    if (PrimarySignature != null)
+                    {
+                        all = all
+                            .Concat(new[] { PrimarySignature.SignatureEndCertificate })
+                            .Concat(PrimarySignature.SignatureParentCertificates)
+                            .Concat(new[] { PrimarySignature.TimestampEndCertificate })
+                            .Concat(PrimarySignature.TimestampParentCertificates);
+                    }
+
+                    if (Countersignature != null)
+                    {
+                        all = all
+                            .Concat(new[] { Countersignature.SignatureEndCertificate })
+                            .Concat(Countersignature.SignatureParentCertificates)
+                            .Concat(new[] { Countersignature.TimestampEndCertificate })
+                            .Concat(Countersignature.TimestampParentCertificates);
+                    }
+
+                    var thumbprints = new HashSet<string>();
+                    var output = new List<SubjectAndThumbprint>();
+                    foreach (var certificate in all)
+                    {
+                        if (thumbprints.Add(certificate.Thumbprint))
+                        {
+                            output.Add(certificate);
+                        }
+                    }
+
+                    return output;
+                }
+            }
+        }
+
+        private class SignatureCertificateThumprints
+        {
             public IReadOnlyList<SubjectAndThumbprint> SignatureParentCertificates { get; set; }
             public SubjectAndThumbprint SignatureEndCertificate { get; set; }
             public IReadOnlyList<SubjectAndThumbprint> TimestampParentCertificates { get; set; }
             public SubjectAndThumbprint TimestampEndCertificate { get; set; }
-            public IReadOnlyList<SubjectAndThumbprint> Certificates => Enumerable
-                .Empty<SubjectAndThumbprint>()
-                .Concat(new[] { SignatureEndCertificate })
-                .Concat(SignatureParentCertificates)
-                .Concat(new[] { TimestampEndCertificate })
-                .Concat(TimestampParentCertificates)
-                .ToList();
         }
     }
 }

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
@@ -208,7 +208,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     results: new[]
                     {
                         new InvalidSignaturePackageVerificationResult(
-                            SignatureVerificationStatus.Invalid,
+                            SignatureVerificationStatus.Illegal,
                             new[]
                             {
                                 SignatureLog.Issue(
@@ -264,7 +264,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     results: new[]
                     {
                         new InvalidSignaturePackageVerificationResult(
-                            SignatureVerificationStatus.Invalid,
+                            SignatureVerificationStatus.Illegal,
                             new[]
                             {
                                 SignatureLog.Issue(

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestResources.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestResources.cs
@@ -10,13 +10,13 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 {
     public static class TestResources
     {
-        private const string ResourceNamespace = "Validation.PackageSigning.ProcessSignature.Tests.TestData";
-        public const string SignedPackageLeaf1 = ResourceNamespace + ".TestSigned.leaf-1.1.0.0.nupkg";
-        public const string SignedPackageLeaf2 = ResourceNamespace + ".TestSigned.leaf-2.2.0.0.nupkg";
-        public const string UnsignedPackage = ResourceNamespace + ".TestUnsigned.1.0.0.nupkg";
-        public const string Zip64Package = ResourceNamespace + ".Zip64Package.1.0.0.nupkg";
-        public const string RepoSignedPackageLeaf1 = ResourceNamespace + ".TestRepoSigned.leaf-1.1.0.0.nupkg";
-        public const string AuthorAndRepoSignedPackageLeaf1 = ResourceNamespace + ".TestAuthorAndRepoSigned.leaf-1.1.0.0.nupkg";
+        private const string ResourcePrefix = "Validation.PackageSigning.ProcessSignature.Tests.TestData.";
+        public const string SignedPackageLeaf1 = "TestSigned.leaf-1.1.0.0.nupkg";
+        public const string SignedPackageLeaf2 = "TestSigned.leaf-2.2.0.0.nupkg";
+        public const string UnsignedPackage = "TestUnsigned.1.0.0.nupkg";
+        public const string Zip64Package = "Zip64Package.1.0.0.nupkg";
+        public const string RepoSignedPackageLeaf1 = "TestRepoSigned.leaf-1.1.0.0.nupkg";
+        public const string AuthorAndRepoSignedPackageLeaf1 = "TestAuthorAndRepoSigned.leaf-1.1.0.0.nupkg";
 
         /// <summary>
         /// This is the SHA-256 thumbprint of the root CA certificate for the signing certificate of <see cref="SignedPackageLeaf1"/>.
@@ -45,7 +45,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             var resourceStream = typeof(TestResources)
                 .Assembly
-                .GetManifestResourceStream(resourceName);
+                .GetManifestResourceStream(ResourcePrefix + resourceName);
 
             if (resourceStream == null)
             {

--- a/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
@@ -36,7 +36,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/5754.

- Update to new client APIs version to get new certificate extraction APIs (thanks @dtivel!).
- Insert `PackageSignature` records with either `PackageSignatureType.Author` or `Repository`.
- If the thumbprint of an existing repository signature record changes, replace the record and its associated timestamp. This indicates that we have re-reposigned a package. Note that if the thumbprint does not change but the trusted timestamp value or thumbprint does change, an exception is thrown and ops should be involved.
- Use more product code in the integration tests.