### PR TITLE
Filter out repository signatures from Validate Certificate and Revalidate jobs

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
@@ -236,6 +236,7 @@ namespace NuGet.Services.Validation.PackageSigning.ValidateCertificate
                         .PackageSignatures
                         .Include(s => s.EndCertificate)
                         .Include(s => s.TrustedTimestamps.Select(t => t.EndCertificate))
+                        .Where(s => s.Type == PackageSignatureType.Author)
                         .SingleAsync(s => s.PackageKey == request.PackageKey);
         }
 

--- a/src/Validation.PackageSigning.RevalidateCertificate/CertificateRevalidator.cs
+++ b/src/Validation.PackageSigning.RevalidateCertificate/CertificateRevalidator.cs
@@ -73,6 +73,7 @@ namespace Validation.PackageSigning.RevalidateCertificate
 
                 var potentialSignatures = await _context.PackageSignatures
                     .Where(s => s.Status == PackageSignatureStatus.InGracePeriod)
+                    .Where(s => s.Type == PackageSignatureType.Author)
                     .Include(s => s.EndCertificate)
                     .Include(s => s.TrustedTimestamps.Select(t => t.EndCertificate))
                     .OrderBy(s => s.CreatedAt)

--- a/src/Validation.PackageSigning.ValidateCertificate/CertificateValidationService.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/CertificateValidationService.cs
@@ -286,11 +286,13 @@ namespace Validation.PackageSigning.ValidateCertificate
             {
                 case EndCertificateUse.CodeSigning:
                     packageSignatures = _context.PackageSignatures
+                                                .Where(s => s.Type == PackageSignatureType.Author)
                                                 .Where(s => s.EndCertificate.Thumbprint == certificate.Thumbprint);
                     break;
 
                 case EndCertificateUse.Timestamping:
                     packageSignatures = _context.PackageSignatures
+                                                .Where(s => s.Type == PackageSignatureType.Author)
                                                 .Where(s => s.TrustedTimestamps.Any(t => t.EndCertificate.Thumbprint == certificate.Thumbprint));
 
                     break;

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
@@ -160,6 +160,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     PackageKey = PackageKey,
                     Status = PackageSignatureStatus.Unknown,
                     EndCertificate = certificate,
+                    Type = PackageSignatureType.Author,
                 };
 
                 certificate.PackageSignatures = new[] { packageSignature };
@@ -271,6 +272,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     Status = packageSignatureStatus,
                     PackageSigningState = packageSigningState,
                     EndCertificate = certificate,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -335,6 +337,7 @@ namespace NuGet.Services.Validation.PackageSigning
                                 EndCertificate = cert1SecondAgo,
                             }
                         },
+                        Type = PackageSignatureType.Author,
                     },
                 };
 
@@ -354,6 +357,7 @@ namespace NuGet.Services.Validation.PackageSigning
                                 EndCertificate = cert1SecondAgo,
                             }
                         },
+                        Type = PackageSignatureType.Author,
                     },
                 };
 
@@ -373,6 +377,7 @@ namespace NuGet.Services.Validation.PackageSigning
                                 EndCertificate = cert1YearAgo,
                             }
                         },
+                        Type = PackageSignatureType.Author,
                     },
                 };
 
@@ -396,6 +401,7 @@ namespace NuGet.Services.Validation.PackageSigning
                                 EndCertificate = cert1YearAgo,
                             }
                         },
+                        Type = PackageSignatureType.Author,
                     },
                 };
 
@@ -415,6 +421,7 @@ namespace NuGet.Services.Validation.PackageSigning
                                 EndCertificate = cert1SecondAgo,
                             }
                         },
+                        Type = PackageSignatureType.Author,
                     },
                 };
             }
@@ -489,7 +496,8 @@ namespace NuGet.Services.Validation.PackageSigning
                 var signature = new PackageSignature
                 {
                     PackageKey = PackageKey,
-                    Status = PackageSignatureStatus.Unknown
+                    Status = PackageSignatureStatus.Unknown,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -630,7 +638,8 @@ namespace NuGet.Services.Validation.PackageSigning
                 var packageSignature = new PackageSignature
                 {
                     PackageKey = PackageKey,
-                    Status = PackageSignatureStatus.Valid
+                    Status = PackageSignatureStatus.Valid,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -712,7 +721,8 @@ namespace NuGet.Services.Validation.PackageSigning
                 var packageSignature = new PackageSignature
                 {
                     PackageKey = PackageKey,
-                    Status = PackageSignatureStatus.Valid
+                    Status = PackageSignatureStatus.Valid,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -792,7 +802,8 @@ namespace NuGet.Services.Validation.PackageSigning
                 var packageSignature = new PackageSignature
                 {
                     PackageKey = PackageKey,
-                    Status = PackageSignatureStatus.Valid
+                    Status = PackageSignatureStatus.Valid,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -875,7 +886,8 @@ namespace NuGet.Services.Validation.PackageSigning
                 var packageSignature = new PackageSignature
                 {
                     PackageKey = PackageKey,
-                    Status = PackageSignatureStatus.Valid
+                    Status = PackageSignatureStatus.Valid,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -1051,7 +1063,8 @@ namespace NuGet.Services.Validation.PackageSigning
                 var packageSignature = new PackageSignature
                 {
                     PackageKey = PackageKey,
-                    Status = PackageSignatureStatus.Valid
+                    Status = PackageSignatureStatus.Valid,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -1122,6 +1135,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 {
                     PackageKey = PackageKey,
                     Status = PackageSignatureStatus.Valid,
+                    Type = PackageSignatureType.Author,
                 };
 
                 var timestamp = new TrustedTimestamp
@@ -1165,6 +1179,98 @@ namespace NuGet.Services.Validation.PackageSigning
                 Assert.Equal(ValidationStatus.Failed, validatorStatus.State);
                 Assert.Equal(PackageSignatureStatus.Invalid, packageSignature.Status);
                 Assert.Equal(PackageSigningStatus.Invalid, packageSigningState.SigningStatus);
+            }
+
+            [Theory]
+            [InlineData(PackageSignatureType.Repository)]
+            [InlineData((PackageSignatureType)0)]
+            public async Task NonAuthorSignaturesAreIgnored(PackageSignatureType type)
+            {
+                // Arrange
+                var validatorStatus = new ValidatorStatus
+                {
+                    ValidationId = ValidationId,
+                    ValidatorName = nameof(PackageCertificatesValidator),
+                    PackageKey = PackageKey,
+                    State = ValidationStatus.NotStarted,
+                    ValidatorIssues = new List<ValidatorIssue>(),
+                };
+
+                var packageSigningState = new PackageSigningState
+                {
+                    PackageKey = PackageKey,
+                    PackageId = PackageId,
+                    PackageNormalizedVersion = PackageNormalizedVersion,
+                    SigningStatus = PackageSigningStatus.Valid,
+                };
+
+                var authorPackageSignature = new PackageSignature
+                {
+                    PackageKey = PackageKey,
+                    Status = PackageSignatureStatus.Valid,
+                    Type = PackageSignatureType.Author,
+                };
+
+                var repositoryPackageSignature = new PackageSignature
+                {
+                    PackageKey = PackageKey,
+                    Status = PackageSignatureStatus.Unknown,
+                    Type = type,
+                };
+
+                var timestamp = new TrustedTimestamp
+                {
+                    Value = DateTime.UtcNow.AddDays(-10)
+                };
+
+                var signatureCertificate = new EndCertificate
+                {
+                    Key = 123,
+                    Status = EndCertificateStatus.Good,
+                    StatusUpdateTime = DateTime.UtcNow.AddSeconds(-10),
+                    NextStatusUpdateTime = DateTime.UtcNow.AddDays(1),
+                    LastVerificationTime = DateTime.UtcNow.AddSeconds(-10),
+                    RevocationTime = null,
+                    ValidationFailures = 0,
+                };
+
+                var timestampCertificate = new EndCertificate
+                {
+                    Key = 456,
+                    Status = EndCertificateStatus.Good,
+                    StatusUpdateTime = DateTime.UtcNow.AddSeconds(-10),
+                    NextStatusUpdateTime = DateTime.UtcNow.AddDays(1),
+                    LastVerificationTime = DateTime.UtcNow.AddSeconds(-10),
+                    RevocationTime = null,
+                    ValidationFailures = 0,
+                };
+
+                packageSigningState.PackageSignatures = new[] { authorPackageSignature, repositoryPackageSignature };
+                authorPackageSignature.PackageSigningState = packageSigningState;
+                authorPackageSignature.TrustedTimestamps = new[] { timestamp };
+                authorPackageSignature.EndCertificate = signatureCertificate;
+                timestamp.EndCertificate = timestampCertificate;
+                signatureCertificate.PackageSignatures = new[] { authorPackageSignature };
+                timestampCertificate.TrustedTimestamps = new[] { timestamp };
+
+                _validationContext.Mock(
+                    validatorStatuses: new[] { validatorStatus },
+                    packageSigningStates: new[] { packageSigningState },
+                    packageSignatures: new[] { authorPackageSignature, repositoryPackageSignature },
+                    trustedTimestamps: new[] { timestamp },
+                    endCertificates: new[] { signatureCertificate, timestampCertificate });
+
+                // Act & Assert
+                var actual = await _target.StartAsync(_validationRequest.Object);
+
+                _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
+                _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    Times.Never);
+
+                Assert.Equal(ValidationStatus.Succeeded, actual.Status);
+                Assert.Equal(ValidationStatus.Succeeded, validatorStatus.State);
             }
 
             public static IEnumerable<object[]> ValidationStatusesThatAreStarted = validationStatusesThatAreStarted.Select(s => new object[] { s });

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationMessageHandlerIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationMessageHandlerIntegrationTests.cs
@@ -72,9 +72,21 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
             var packageSigningState2 = new PackageSigningState { SigningStatus = PackageSigningStatus.Valid };
             var packageSigningState3 = new PackageSigningState { SigningStatus = PackageSigningStatus.Valid };
 
-            var signatureAtIngestion = new PackageSignature { Status = PackageSignatureStatus.Unknown };
-            var signatureInGracePeriod = new PackageSignature { Status = PackageSignatureStatus.InGracePeriod };
-            var signatureAfterGracePeriod = new PackageSignature { Status = PackageSignatureStatus.Valid };
+            var signatureAtIngestion = new PackageSignature
+            {
+                Status = PackageSignatureStatus.Unknown,
+                Type = PackageSignatureType.Author,
+            };
+            var signatureInGracePeriod = new PackageSignature
+            {
+                Status = PackageSignatureStatus.InGracePeriod,
+                Type = PackageSignatureType.Author,
+            };
+            var signatureAfterGracePeriod = new PackageSignature
+            {
+                Status = PackageSignatureStatus.Valid,
+                Type = PackageSignatureType.Author,
+            };
 
             var trustedTimestamp1 = new TrustedTimestamp { Status = TrustedTimestampStatus.Valid, Value = signatureTime };
             var trustedTimestamp2 = new TrustedTimestamp { Status = TrustedTimestampStatus.Valid, Value = signatureTime };
@@ -212,9 +224,21 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
 
             var packageSigningState = new PackageSigningState { SigningStatus = PackageSigningStatus.Valid };
 
-            var signatureAtIngestion = new PackageSignature { Status = PackageSignatureStatus.Unknown };
-            var signatureInGracePeriod = new PackageSignature { Status = PackageSignatureStatus.InGracePeriod };
-            var signatureAfterGracePeriod = new PackageSignature { Status = PackageSignatureStatus.Valid };
+            var signatureAtIngestion = new PackageSignature
+            {
+                Status = PackageSignatureStatus.Unknown,
+                Type = PackageSignatureType.Author,
+            };
+            var signatureInGracePeriod = new PackageSignature
+            {
+                Status = PackageSignatureStatus.InGracePeriod,
+                Type = PackageSignatureType.Author,
+            };
+            var signatureAfterGracePeriod = new PackageSignature
+            {
+                Status = PackageSignatureStatus.Valid,
+                Type = PackageSignatureType.Author,
+            };
 
             var endCertificate = new EndCertificate
             {


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/1198.
Depends on https://github.com/NuGet/NuGet.Jobs/pull/401.

Repository signatures are validated at push time using https://github.com/NuGet/NuGetGallery/issues/5753 and periodically using https://github.com/NuGet/Engineering/issues/1208.