### PR TITLE
Certificates:  add new validation issue

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.25.0-master-29664</Version>
+      <Version>2.25.0-master-30191</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
@@ -330,10 +330,10 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             }
 
             // Block packages with any unknown signing certificates.
-            var signingFingerprint = context.Signature
+            var signingCertificate = context.Signature
                 .SignerInfo
-                .Certificate
-                .ComputeSHA256Thumbprint();
+                .Certificate;
+            var signingFingerprint = signingCertificate.ComputeSHA256Thumbprint();
 
             var packageRegistration = _corePackageService.FindPackageRegistrationById(context.Message.PackageId);
 
@@ -348,7 +348,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
                 return await RejectAsync(
                     context,
-                    ValidationIssue.PackageIsSigned);
+                    new UnauthorizedCertificateFailure(signingCertificate.Thumbprint.ToLowerInvariant()));
             }
 
             // Call the "verify" API, which does the main logic of signature validation.

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
@@ -380,8 +380,10 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
                 // Assert
                 Validate(result, ValidationStatus.Failed, PackageSigningStatus.Invalid);
-                var issue = Assert.Single(result.Issues);
-                Assert.Equal(ValidationIssueCode.PackageIsSigned, issue.IssueCode);
+                Assert.Single(result.Issues);
+                var issue = Assert.IsType<UnauthorizedCertificateFailure>(result.Issues[0]);
+                Assert.Equal(ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, issue.IssueCode);
+                Assert.Equal(TestResources.Leaf2Sha1Thumbprint, issue.Sha1Thumbprint);
             }
 
             [Fact]
@@ -514,9 +516,10 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     _cancellationToken);
 
                 Validate(result, ValidationStatus.Failed, PackageSigningStatus.Invalid);
-                Assert.Equal(1, result.Issues.Count);
-                var issue = Assert.IsType<NoDataValidationIssue>(result.Issues[0]);
-                Assert.Equal(ValidationIssueCode.PackageIsSigned, issue.IssueCode);
+                Assert.Single(result.Issues);
+                var issue = Assert.IsType<UnauthorizedCertificateFailure>(result.Issues[0]);
+                Assert.Equal(ValidationIssueCode.PackageIsSignedWithUnauthorizedCertificate, issue.IssueCode);
+                Assert.Equal(TestResources.Leaf2Sha1Thumbprint, issue.Sha1Thumbprint);
             }
 
             [Fact]

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestResources.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestResources.cs
@@ -42,6 +42,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         public const string Leaf2Thumbprint = "a8cc70dbbd8bc61410231805b690cca7c5a8d07553c1c49b299a6aabaeb7ff9a";
 
         /// <summary>
+        /// This is the SHA-1 thumbprint of the signing certificate in <see cref="SignedPackageLeaf2"/>.
+        /// </summary>
+        public const string Leaf2Sha1Thumbprint = "8e1b5dadf388dee204bcfd27b53f00b585fdca07";
+
+        /// <summary>
         /// This is the SHA-256 thumbprint of the timestamp certificate in <see cref="SignedPackageLeaf1"/>.
         /// </summary>
         public const string Leaf1TimestampThumbprint = "cf7ac17ad047ecd5fdc36822031b12d4ef078b6f2b4c5e6ba41f8ff2cf4bad67";


### PR DESCRIPTION
Add a new validation issue for when an unauthorized certificate is used in a signed package.

This information will be used in gallery when displaying validation failures.