### PR TITLE
[Repository Signing] Add Signature Validator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -57,7 +57,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
         private const string VcsBindingKey = VcsSectionName;
         private const string PackageVerificationTopicClientBindingKey = "PackageVerificationTopicClient";
-        private const string PackageSigningBindingKey = PackageSigningSectionName;
+        private const string PackageSignatureBindingKey = PackageSigningSectionName;
         private const string PackageCertificatesBindingKey = PackageCertificatesSectionName;
         private const string ValidationStorageBindingKey = "ValidationStorage";
         private const string OrchestratorBindingKey = "Orchestrator";
@@ -206,7 +206,8 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<IBrokeredMessageSerializer<CertificateValidationMessage>, CertificateValidationMessageSerializer>();
             services.AddTransient<IValidatorStateService, ValidatorStateService>();
             services.AddTransient<ISimpleCloudBlobProvider, SimpleCloudBlobProvider>();
-            services.AddTransient<PackageSigningValidator>();
+            services.AddTransient<PackageSignatureProcessor>();
+            services.AddTransient<PackageSignatureValidator>();
             services.AddTransient<MailSenderConfiguration>(serviceProvider =>
             {
                 var smtpConfigurationAccessor = serviceProvider.GetRequiredService<IOptionsSnapshot<SmtpConfiguration>>();
@@ -326,21 +327,21 @@ namespace NuGet.Services.Validation.Orchestrator
                     IMessageHandler<PackageValidationMessageData>>(
                         OrchestratorBindingKey);
 
-            ConfigurePackageSigningValidator(containerBuilder);
+            ConfigurePackageSigningValidators(containerBuilder);
             ConfigurePackageCertificatesValidator(containerBuilder);
 
             return new AutofacServiceProvider(containerBuilder.Build());
         }
 
-        private static void ConfigurePackageSigningValidator(ContainerBuilder builder)
+        private static void ConfigurePackageSigningValidators(ContainerBuilder builder)
         {
             // Configure the validator state service for the package certificates validator.
             builder
                 .RegisterType<ValidatorStateService>()
                 .WithParameter(
                     (pi, ctx) => pi.ParameterType == typeof(string),
-                    (pi, ctx) => ValidatorName.PackageSigning)
-                .Keyed<IValidatorStateService>(PackageSigningBindingKey);
+                    (pi, ctx) => ValidatorName.PackageSignatureProcessor)
+                .Keyed<IValidatorStateService>(PackageSignatureBindingKey);
 
             // Configure the package signature verification enqueuer.
             builder
@@ -350,18 +351,25 @@ namespace NuGet.Services.Validation.Orchestrator
 
                     return new TopicClientWrapper(configuration.ConnectionString, configuration.TopicPath);
                 })
-                .Keyed<ITopicClient>(PackageSigningBindingKey);
+                .Keyed<ITopicClient>(PackageSignatureBindingKey);
 
             builder
                 .RegisterType<ProcessSignatureEnqueuer>()
-                .WithKeyedParameter(typeof(ITopicClient), PackageSigningBindingKey)
+                .WithKeyedParameter(typeof(ITopicClient), PackageSignatureBindingKey)
                 .As<IProcessSignatureEnqueuer>();
 
-            // Configure the package signing validator.
+            // Configure the package signature validators. The processor runs before packages are
+            // repository signed and can strip unacceptable repository signatures. The validator
+            // runs after packages are repository signed.
             builder
-                .RegisterType<PackageSigningValidator>()
-                .WithKeyedParameter(typeof(IValidatorStateService), PackageSigningBindingKey)
-                .As<PackageSigningValidator>();
+                .RegisterType<PackageSignatureProcessor>()
+                .WithKeyedParameter(typeof(IValidatorStateService), PackageSignatureBindingKey)
+                .As<PackageSignatureProcessor>();
+
+            builder
+                .RegisterType<PackageSignatureValidator>()
+                .WithKeyedParameter(typeof(IValidatorStateService), PackageSignatureBindingKey)
+                .As<PackageSignatureValidator>();
         }
 
         private static void ConfigurePackageCertificatesValidator(ContainerBuilder builder)

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -62,14 +62,16 @@
     <Compile Include="MessageService.cs" />
     <Compile Include="OrchestrationRunner.cs" />
     <Compile Include="Configuration\OrchestrationRunnerConfiguration.cs" />
+    <Compile Include="PackageSigning\ProcessSignature\BaseSignatureProcessor.cs" />
     <Compile Include="PackageSigning\ProcessSignature\IProcessSignatureEnqueuer.cs" />
-    <Compile Include="PackageSigning\ProcessSignature\PackageSigningValidator.cs" />
+    <Compile Include="PackageSigning\ProcessSignature\PackageSignatureProcessor.cs" />
     <Compile Include="PackageSigning\ProcessSignature\ProcessSignatureConfiguration.cs" />
     <Compile Include="PackageSigning\ProcessSignature\ProcessSignatureEnqueuer.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\IValidateCertificateEnqueuer.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\PackageCertificatesValidator.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\ValidateCertificateConfiguration.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\ValidateCertificateEnqueuer.cs" />
+    <Compile Include="PackageSigning\ProcessSignature\PackageSignatureValidator.cs" />
     <Compile Include="PackageStatusProcessor.cs" />
     <Compile Include="PackageValidationMessageDataSerializer.cs" />
     <Compile Include="Program.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/IProcessSignatureEnqueuer.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/IProcessSignatureEnqueuer.cs
@@ -11,13 +11,19 @@ namespace NuGet.Services.Validation.PackageSigning.ProcessSignature
     public interface IProcessSignatureEnqueuer
     {
         /// <summary>
-        /// Kicks off the package verification process for the given request. Verification will begin when the
-        /// <see cref="ValidationEntitiesContext"/> has a <see cref="ValidatorStatus"/> that matches the
-        /// <see cref="IValidationRequest"/>'s validationId. Once verification completes, the <see cref="ValidatorStatus"/>'s
-        /// State will be updated to "Succeeded" or "Failed".
+        /// Processes the package's signatures, if any. Unacceptable repository signatures will be stripped off.
+        /// Author signatures that fail trust or integrity verification will fail the validation.
         /// </summary>
+        /// <remarks>
+        /// Verification will begin when the <see cref="ValidationEntitiesContext"/> has a <see cref="ValidatorStatus"/>
+        /// that matches the <see cref="IValidationRequest"/>'s validationId. Once verification completes,
+        /// the <see cref="ValidatorStatus"/>'s State will be updated to "Succeeded" or "Failed".
+        /// </remarks>
         /// <param name="request">The request that details the package to be verified.</param>
+        /// <param name="requireRepositorySignature">
+        /// If true, the package must have an acceptable repository signature to pass validation.
+        /// </param>
         /// <returns>A task that will complete when the verification process has been queued.</returns>
-        Task EnqueueVerificationAsync(IValidationRequest request);
+        Task EnqueueProcessSignatureAsync(IValidationRequest request, bool requireRepositorySignature);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureProcessor.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.Storage;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+
+namespace NuGet.Services.Validation.PackageSigning.ProcessSignature
+{
+    /// <summary>
+    /// The processor that strips unacceptable repository signatures and then validates signed packages.
+    /// This runs before a package is repository signed.
+    /// </summary>
+    [ValidatorName(ValidatorName.PackageSignatureProcessor)]
+    public class PackageSignatureProcessor : BaseSignatureProcessor, IProcessor
+    {
+        private readonly IValidatorStateService _validatorStateService;
+        private readonly IProcessSignatureEnqueuer _signatureVerificationEnqueuer;
+        private readonly ISimpleCloudBlobProvider _blobProvider;
+        private readonly ITelemetryService _telemetryService;
+        private readonly ILogger<PackageSignatureProcessor> _logger;
+
+        public PackageSignatureProcessor(
+            IValidatorStateService validatorStateService,
+            IProcessSignatureEnqueuer signatureVerificationEnqueuer,
+            ISimpleCloudBlobProvider blobProvider,
+            ITelemetryService telemetryService,
+            ILogger<PackageSignatureProcessor> logger)
+          : base(validatorStateService, signatureVerificationEnqueuer, blobProvider, telemetryService, logger)
+        {
+            _validatorStateService = validatorStateService ?? throw new ArgumentNullException(nameof(validatorStateService));
+            _signatureVerificationEnqueuer = signatureVerificationEnqueuer ?? throw new ArgumentNullException(nameof(signatureVerificationEnqueuer));
+            _blobProvider = blobProvider ?? throw new ArgumentNullException(nameof(blobProvider));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// This processor runs before packages are repository signed. Unacceptable
+        /// repository signatures, if present, will be stripped.
+        /// </summary>
+        protected override bool RequiresRepositorySignature => false;
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureValidator.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.Storage;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+
+namespace NuGet.Services.Validation.PackageSigning.ProcessSignature
+{
+    /// <summary>
+    /// The validator that ensures the package's repository signature is valid. This does the
+    /// final signature validation after a package has been repository signed.
+    /// </summary>
+    [ValidatorName(ValidatorName.PackageSignatureValidator)]
+    public class PackageSignatureValidator : BaseSignatureProcessor, IValidator
+    {
+        private readonly IValidatorStateService _validatorStateService;
+        private readonly IProcessSignatureEnqueuer _signatureVerificationEnqueuer;
+        private readonly ISimpleCloudBlobProvider _blobProvider;
+        private readonly ITelemetryService _telemetryService;
+        private readonly ILogger<PackageSignatureValidator> _logger;
+
+        public PackageSignatureValidator(
+            IValidatorStateService validatorStateService,
+            IProcessSignatureEnqueuer signatureVerificationEnqueuer,
+            ISimpleCloudBlobProvider blobProvider,
+            ITelemetryService telemetryService,
+            ILogger<PackageSignatureValidator> logger)
+          : base(validatorStateService, signatureVerificationEnqueuer, blobProvider, telemetryService, logger)
+        {
+            _validatorStateService = validatorStateService ?? throw new ArgumentNullException(nameof(validatorStateService));
+            _signatureVerificationEnqueuer = signatureVerificationEnqueuer ?? throw new ArgumentNullException(nameof(signatureVerificationEnqueuer));
+            _blobProvider = blobProvider ?? throw new ArgumentNullException(nameof(blobProvider));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// This validator runs after packages are repository signed. It will verify that the repository
+        /// signature is acceptable.
+        /// </summary>
+        protected override bool RequiresRepositorySignature => true;
+
+        public override async Task<IValidationResult> GetResultAsync(IValidationRequest request)
+        {
+            var result = await base.GetResultAsync(request);
+
+            return Validate(result);
+        }
+
+        public override async Task<IValidationResult> StartAsync(IValidationRequest request)
+        {
+            var result = await base.StartAsync(request);
+
+            return Validate(result);
+        }
+
+        private IValidationResult Validate(IValidationResult result)
+        {
+            /// The package signature validator runs after the <see cref="PackageSignatureProcessor" />.
+            /// All signature validation issues should be caught and handled by the processor.
+            if (result.Status == ValidationStatus.Failed || result.NupkgUrl != null)
+            {
+                _logger.LogCritical(
+                    "Unexpected validation result in package signature validator. This may be caused by an invalid repository " +
+                    "signature. Status = {ValidationStatus}, Nupkg URL = {NupkgUrl}, validation issues = {Issues}",
+                    result.Status,
+                    result.NupkgUrl,
+                    result.Issues.Select(i => i.IssueCode));
+
+                throw new InvalidOperationException("Package signature validator has an unexpected validation result");
+            }
+
+            /// Suppress all validation issues. The <see cref="PackageSignatureProcessor"/> should
+            /// have already reported any issues related to the author signature. Customers should
+            /// not be notified of validation issues due to the repository signature.
+            if (result.Issues.Count != 0)
+            {
+                _logger.LogWarning(
+                    "Ignoring {ValidationIssueCount} validation issues from result. Issues: {Issues}",
+                    result.Issues.Count,
+                    result.Issues.Select(i => i.IssueCode));
+
+                return new ValidationResult(result.Status);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/ProcessSignatureConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/ProcessSignatureConfiguration.cs
@@ -7,7 +7,7 @@ using NuGet.Jobs.Configuration;
 namespace NuGet.Services.Validation.PackageSigning.ProcessSignature
 {
     /// <summary>
-    /// Configuration for initializing the <see cref="PackageSigningValidator"/>.
+    /// Configuration for initializing the <see cref="ProcessSignatureEnqueuer"/>.
     /// </summary>
     public class ProcessSignatureConfiguration
     {

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/ProcessSignatureEnqueuer.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/ProcessSignatureEnqueuer.cs
@@ -28,21 +28,14 @@ namespace NuGet.Services.Validation.PackageSigning.ProcessSignature
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
-        /// <summary>
-        /// Kicks off the package verification process for the given request. Verification will begin when the
-        /// <see cref="ValidationEntitiesContext"/> has a <see cref="ValidatorStatus"/> that matches the
-        /// <see cref="IValidationRequest"/>'s validationId. Once verification completes, the <see cref="ValidatorStatus"/>'s
-        /// State will be updated to "Succeeded" or "Failed".
-        /// </summary>
-        /// <param name="request">The request that details the package to be verified.</param>
-        /// <returns>A task that will complete when the verification process has been queued.</returns>
-        public Task EnqueueVerificationAsync(IValidationRequest request)
+        public Task EnqueueProcessSignatureAsync(IValidationRequest request, bool requireRepositorySignature)
         {
             var message = new SignatureValidationMessage(
                 request.PackageId,
                 request.PackageVersion,
                 new Uri(request.NupkgUrl),
-                request.ValidationId);
+                request.ValidationId,
+                requireRepositorySignature);
             var brokeredMessage = _serializer.Serialize(message);
 
             var visibleAt = DateTimeOffset.UtcNow + (_configuration.Value.MessageDelay ?? TimeSpan.Zero);

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -202,15 +201,12 @@ namespace NuGet.Services.Validation.PackageSigning.ValidateCertificate
 
             if (certificates.Any())
             {
-                var stopwatch = Stopwatch.StartNew();
+                using (_telemetryService.TrackDurationToStartPackageCertificatesValidator())
+                {
+                    await StartCertificateValidationsAsync(request, certificates);
 
-                await StartCertificateValidationsAsync(request, certificates);
-
-                var result = await _validatorStateService.TryAddValidatorStatusAsync(request, status, ValidationStatus.Incomplete);
-
-                _telemetryService.TrackDurationToStartPackageCertificatesValidator(stopwatch.Elapsed);
-
-                return result;
+                    return await _validatorStateService.TryAddValidatorStatusAsync(request, status, ValidationStatus.Incomplete);
+                }
             }
             else
             {

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -68,15 +68,13 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <summary>
         /// The duration to start the package signing validator. This includes both the enqueue and DB commit time.
         /// </summary>
-        /// <param name="duration">The duration.</param>
-        void TrackDurationToStartPackageSigningValidator(TimeSpan duration);
+        IDisposable TrackDurationToStartPackageSigningValidator();
 
         /// <summary>
-        /// The duration to star the package certificates validator. This includes all enqueue times and the DB commit
+        /// The duration to start the package certificates validator. This includes all enqueue times and the DB commit
         /// time.
         /// </summary>
-        /// <param name="duration">The duration.</param>
-        void TrackDurationToStartPackageCertificatesValidator(TimeSpan duration);
+        IDisposable TrackDurationToStartPackageCertificatesValidator();
 
         /// <summary>
         /// A counter metric emmitted when a validator reaches a terminal state and potentially persists validation

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -213,18 +213,10 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                         { ValidationTrackingId, validationTrackingId },
                     });
 
-        public void TrackDurationToStartPackageSigningValidator(TimeSpan duration)
-        {
-            _telemetryClient.TrackMetric(
-                DurationToStartPackageSigningValidatorSeconds,
-                duration.TotalSeconds);
-        }
+        public IDisposable TrackDurationToStartPackageSigningValidator()
+            => _telemetryClient.TrackDuration(DurationToStartPackageSigningValidatorSeconds);
 
-        public void TrackDurationToStartPackageCertificatesValidator(TimeSpan duration)
-        {
-            _telemetryClient.TrackMetric(
-                DurationToStartPackageCertificatesValidatorSeconds,
-                duration.TotalSeconds);
-        }
+        public IDisposable TrackDurationToStartPackageCertificatesValidator()
+            => _telemetryClient.TrackDuration(DurationToStartPackageCertificatesValidatorSeconds);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/settings.json
+++ b/src/NuGet.Services.Validation.Orchestrator/settings.json
@@ -16,9 +16,16 @@
         "FailureBehavior": "MustSucceed"
       },
       {
-        "name": "PackageCertificatesValidator",
+        "name": "PackageSigningValidator2",
         "TrackAfter": "00:10:00",
         "requiredValidations": [ "PackageSigningValidator" ],
+        "ShouldStart": true,
+        "FailureBehavior": "AllowedToFail"
+      },
+      {
+        "name": "PackageCertificatesValidator",
+        "TrackAfter": "00:10:00",
+        "requiredValidations": [ "PackageSigningValidator2" ],
         "ShouldStart": true,
         "FailureBehavior": "MustSucceed"
       }

--- a/src/Validation.Common.Job/Validation/ValidatorName.cs
+++ b/src/Validation.Common.Job/Validation/ValidatorName.cs
@@ -7,6 +7,7 @@ namespace NuGet.Jobs.Validation
     {
         public const string Vcs = "VcsValidator";
         public const string PackageCertificate = "PackageCertificatesValidator";
-        public const string PackageSigning = "PackageSigningValidator";
+        public const string PackageSignatureProcessor = "PackageSigningValidator";
+        public const string PackageSignatureValidator = "PackageSigningValidator2";
     }
 }

--- a/src/Validation.PackageSigning.Core/Messages/SignatureValidationMessage.cs
+++ b/src/Validation.PackageSigning.Core/Messages/SignatureValidationMessage.cs
@@ -7,7 +7,12 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
 {
     public class SignatureValidationMessage
     {
-        public SignatureValidationMessage(string packageId, string packageVersion, Uri nupkgUri, Guid validationId)
+        public SignatureValidationMessage(
+            string packageId,
+            string packageVersion,
+            Uri nupkgUri,
+            Guid validationId,
+            bool requireRepositorySignature = false)
         {
             if (validationId == Guid.Empty)
             {
@@ -18,11 +23,13 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
             PackageVersion = packageVersion ?? throw new ArgumentNullException(nameof(packageVersion));
             NupkgUri = nupkgUri ?? throw new ArgumentNullException(nameof(nupkgUri));
             ValidationId = validationId;
+            RequireRepositorySignature = requireRepositorySignature;
         }
 
         public string PackageId { get; }
         public string PackageVersion { get; }
         public Uri NupkgUri { get; }
         public Guid ValidationId { get; }
+        public bool RequireRepositorySignature { get; }
     }
 }

--- a/src/Validation.PackageSigning.Core/Messages/SignatureValidationMessageSerializer.cs
+++ b/src/Validation.PackageSigning.Core/Messages/SignatureValidationMessageSerializer.cs
@@ -21,7 +21,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
                 PackageId = message.PackageId,
                 PackageVersion = message.PackageVersion,
                 NupkgUri = message.NupkgUri,
-                ValidationId = message.ValidationId
+                ValidationId = message.ValidationId,
+                RequireReopsitorySignature = message.RequireRepositorySignature,
             });
         }
 
@@ -33,7 +34,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
                 deserializedMessage.PackageId,
                 deserializedMessage.PackageVersion,
                 deserializedMessage.NupkgUri,
-                deserializedMessage.ValidationId);
+                deserializedMessage.ValidationId,
+                deserializedMessage.RequireReopsitorySignature);
         }
 
         [Schema(Name = SignatureValidationSchemaName, Version = 1)]
@@ -43,6 +45,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
             public string PackageVersion { get; set; }
             public Uri NupkgUri { get; set; }
             public Guid ValidationId { get; set; }
+            public bool RequireReopsitorySignature { get; set; }
         }
     }
 }

--- a/src/Validation.PackageSigning.ProcessSignature/Job.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Job.cs
@@ -54,7 +54,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
             services.AddTransient<IProcessorPackageFileService, ProcessorPackageFileService>(p => new ProcessorPackageFileService(
                 p.GetRequiredService<ICoreFileStorageService>(),
-                typeof(PackageSigningValidator),
+                typeof(PackageSignatureProcessor),
                 p.GetRequiredService<ILogger<ProcessorPackageFileService>>()));
 
             services.AddTransient<IBrokeredMessageSerializer<SignatureValidationMessage>, SignatureValidationMessageSerializer>();
@@ -74,7 +74,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                 .RegisterType<ValidatorStateService>()
                 .WithParameter(
                     (pi, ctx) => pi.ParameterType == typeof(string),
-                    (pi, ctx) => ValidatorName.PackageSigning)
+                    (pi, ctx) => ValidatorName.PackageSignatureProcessor)
                 .As<IValidatorStateService>();
 
             containerBuilder

--- a/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
@@ -98,6 +98,17 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                 return await RejectAsync(context, ValidationIssue.PackageIsNotSigned);
             }
 
+            if (context.Message.RequireRepositorySignature)
+            {
+                _logger.LogCritical(
+                    "Package {PackageId} {PackageVersion} for validation {ValidationId} is expected to be repository signed but is unsigned.",
+                    context.Message.PackageId,
+                    context.Message.PackageVersion,
+                    context.Message.ValidationId);
+
+                return await RejectAsync(context);
+            }
+
             _logger.LogInformation(
                 "Package {PackageId} {PackageVersion} is unsigned, no additional validations necessary for " +
                 "{ValidationId}.",
@@ -471,6 +482,17 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                     context.Signature.Type);
 
                 return await RejectAsync(context, ValidationIssue.OnlyAuthorSignaturesSupported);
+            }
+
+            if (context.Message.RequireRepositorySignature && !context.HasRepositorySignature)
+            {
+                _logger.LogCritical(
+                    "Package {PackageId} {PackageVersion} for validation {ValidationId} is expected to be repository signed.",
+                    context.Message.PackageId,
+                    context.Message.PackageVersion,
+                    context.Message.ValidationId);
+
+                return await RejectAsync(context);
             }
 
             // Call the "verify" API, which does the main logic of signature validation.

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -46,10 +46,11 @@
     <Compile Include="Configuration\TopologicalSortFacts.cs" />
     <Compile Include="MessageServiceFacts.cs" />
     <Compile Include="OrchestrationRunnerFacts.cs" />
+    <Compile Include="PackageSigning\ProcessSignature\PackageSignatureValidatorFacts.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\CertificateVerificationEnqueuerFacts.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\PackageCertificatesValidatorFacts.cs" />
     <Compile Include="PackageSigning\ProcessSignature\PackageSignatureVerificationEnqueuerFacts.cs" />
-    <Compile Include="PackageSigning\ProcessSignature\PackageSigningValidatorFacts.cs" />
+    <Compile Include="PackageSigning\ProcessSignature\PackageSignatureProcessorFacts.cs" />
     <Compile Include="PackageStatusProcessorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ValidationMessageHandlerFacts.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
@@ -139,7 +139,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 await _target.StartAsync(_validationRequest.Object);
 
                 _packageSignatureVerifier
-                    .Verify(x => x.EnqueueProcessSignatureAsync(It.IsAny<IValidationRequest>(), false), Times.Never);
+                    .Verify(x => x.EnqueueProcessSignatureAsync(It.IsAny<IValidationRequest>(), It.IsAny<bool>()), Times.Never);
 
                 _validatorStateService
                     .Verify(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Jobs.Validation.Storage;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
@@ -50,7 +51,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = status,
                         ValidatorIssues = new List<ValidatorIssue>(),
                     });
@@ -71,7 +72,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = ValidationStatus.Failed,
                         ValidatorIssues = new List<ValidatorIssue>
                         {
@@ -129,7 +130,7 @@ namespace NuGet.Services.Validation.PackageSigning
                      {
                          ValidationId = ValidationId,
                          PackageKey = PackageKey,
-                         ValidatorName = nameof(PackageSignatureProcessor),
+                         ValidatorName = ValidatorName.PackageSignatureProcessor,
                          State = status,
                          ValidatorIssues = new List<ValidatorIssue>(),
                      });
@@ -162,7 +163,7 @@ namespace NuGet.Services.Validation.PackageSigning
                      {
                          ValidationId = ValidationId,
                          PackageKey = PackageKey,
-                         ValidatorName = nameof(PackageSignatureProcessor),
+                         ValidatorName = ValidatorName.PackageSignatureProcessor,
                          State = ValidationStatus.NotStarted,
                          ValidatorIssues = new List<ValidatorIssue>(),
                      });

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
@@ -1,0 +1,297 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.Storage;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+using NuGet.Services.Validation.PackageSigning.ProcessSignature;
+using NuGetGallery;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.Validation.PackageSigning
+{
+    public class PackageSignatureProcessorFacts
+    {
+        private const int PackageKey = 1001;
+        private const string PackageId = "NuGet.Versioning";
+        private const string PackageVersion = "4.3.0.0-ALPHA+git";
+        private static readonly Guid ValidationId = new Guid("fb9c0bac-3d4d-4cc7-ac2d-b3940e15b94d");
+        private const string NupkgUrl = "https://example/nuget.versioning/4.3.0/package.nupkg";
+
+        public class TheGetStatusMethod : FactsBase
+        {
+            private static readonly ValidationStatus[] possibleValidationStatuses = new ValidationStatus[]
+            {
+                ValidationStatus.Failed,
+                ValidationStatus.Incomplete,
+                ValidationStatus.NotStarted,
+                ValidationStatus.Succeeded,
+            };
+
+            public TheGetStatusMethod(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Theory]
+            [MemberData(nameof(PossibleValidationStatuses))]
+            public async Task ReturnsPersistedStatus(ValidationStatus status)
+            {
+                // Arrange
+                _validatorStateService
+                    .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
+                    .ReturnsAsync(new ValidatorStatus
+                    {
+                        ValidationId = ValidationId,
+                        PackageKey = PackageKey,
+                        ValidatorName = nameof(PackageSignatureProcessor),
+                        State = status,
+                        ValidatorIssues = new List<ValidatorIssue>(),
+                    });
+
+                // Act & Assert
+                var actual = await _target.GetResultAsync(_validationRequest.Object);
+
+                Assert.Equal(status, actual.Status);
+            }
+
+            [Fact]
+            public async Task ReturnsValidatorIssues()
+            {
+                // Arrange
+                _validatorStateService
+                    .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
+                    .ReturnsAsync(new ValidatorStatus
+                    {
+                        ValidationId = ValidationId,
+                        PackageKey = PackageKey,
+                        ValidatorName = nameof(PackageSignatureProcessor),
+                        State = ValidationStatus.Failed,
+                        ValidatorIssues = new List<ValidatorIssue>
+                        {
+                            new ValidatorIssue
+                            {
+                                IssueCode = (ValidationIssueCode)987,
+                                Data = "{}",
+                            },
+                            new ValidatorIssue
+                            {
+                                IssueCode = ValidationIssueCode.ClientSigningVerificationFailure,
+                                Data = "unknown contract",
+                            },
+                        },
+                    });
+
+                // Act
+                var actual = await _target.GetResultAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Equal(ValidationStatus.Failed, actual.Status);
+                Assert.Equal(2, actual.Issues.Count);
+
+                Assert.Equal((ValidationIssueCode)987, actual.Issues[0].IssueCode);
+                Assert.Equal("{}", actual.Issues[0].Serialize());
+
+                Assert.Equal(ValidationIssueCode.ClientSigningVerificationFailure, actual.Issues[1].IssueCode);
+                Assert.Equal("unknown contract", actual.Issues[1].Serialize());
+            }
+
+            public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
+        }
+
+        public class TheStartValidationAsyncMethod : FactsBase
+        {
+            private static readonly ValidationStatus[] startedValidationStatuses = new ValidationStatus[]
+            {
+                ValidationStatus.Failed,
+                ValidationStatus.Incomplete,
+                ValidationStatus.Succeeded,
+            };
+
+            public TheStartValidationAsyncMethod(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            [Theory]
+            [MemberData(nameof(StartedValidationStatuses))]
+            public async Task ReturnsPersistedStatusesIfValidationAlreadyStarted(ValidationStatus status)
+            {
+                // Arrange
+                _validatorStateService
+                     .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
+                     .ReturnsAsync(new ValidatorStatus
+                     {
+                         ValidationId = ValidationId,
+                         PackageKey = PackageKey,
+                         ValidatorName = nameof(PackageSignatureProcessor),
+                         State = status,
+                         ValidatorIssues = new List<ValidatorIssue>(),
+                     });
+
+                // Act & Assert
+                await _target.StartAsync(_validationRequest.Object);
+
+                _packageSignatureVerifier
+                    .Verify(x => x.EnqueueProcessSignatureAsync(It.IsAny<IValidationRequest>(), false), Times.Never);
+
+                _validatorStateService
+                    .Verify(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
+
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageSigningValidator(),
+                    Times.Never);
+            }
+
+            [Fact]
+            public async Task StartsValidationIfNotStarted()
+            {
+                // Arrange
+                // The order of operations is important! The state MUST be persisted AFTER verification has been queued.
+                var statePersisted = false;
+                bool verificationQueuedBeforeStatePersisted = false;
+
+                _validatorStateService
+                     .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
+                     .ReturnsAsync(new ValidatorStatus
+                     {
+                         ValidationId = ValidationId,
+                         PackageKey = PackageKey,
+                         ValidatorName = nameof(PackageSignatureProcessor),
+                         State = ValidationStatus.NotStarted,
+                         ValidatorIssues = new List<ValidatorIssue>(),
+                     });
+
+                _packageSignatureVerifier
+                    .Setup(x => x.EnqueueProcessSignatureAsync(It.IsAny<IValidationRequest>(), false))
+                    .Callback(() =>
+                    {
+                        verificationQueuedBeforeStatePersisted = !statePersisted;
+                    })
+                    .Returns(Task.FromResult(0));
+
+                _validatorStateService
+                    .Setup(x => x.TryAddValidatorStatusAsync(
+                                    It.IsAny<IValidationRequest>(),
+                                    It.IsAny<ValidatorStatus>(),
+                                    It.IsAny<ValidationStatus>()))
+                    .Callback(() =>
+                    {
+                        statePersisted = true;
+                    })
+                    .ReturnsAsync(new ValidatorStatus
+                    {
+                        State = ValidationStatus.Incomplete,
+                        ValidatorIssues = new List<ValidatorIssue>(),
+                    });
+
+                // Act
+                await _target.StartAsync(_validationRequest.Object);
+
+                // Assert
+                _packageSignatureVerifier
+                    .Verify(x => x.EnqueueProcessSignatureAsync(It.IsAny<IValidationRequest>(), false), Times.Once);
+
+                _validatorStateService
+                    .Verify(
+                        x => x.TryAddValidatorStatusAsync(
+                                It.IsAny<IValidationRequest>(),
+                                It.IsAny<ValidatorStatus>(),
+                                It.Is<ValidationStatus>(s => s == ValidationStatus.Incomplete)),
+                        Times.Once);
+
+                _telemetryService.Verify(
+                    x => x.TrackDurationToStartPackageSigningValidator(),
+                    Times.Once);
+
+                Assert.True(verificationQueuedBeforeStatePersisted);
+            }
+
+            public static IEnumerable<object[]> StartedValidationStatuses => startedValidationStatuses.Select(s => new object[] { s });
+        }
+
+        public class TheCleanUpAsyncMethod : FactsBase
+        {
+            private readonly ValidatorStatus _validatorStatus;
+            private readonly Mock<ISimpleCloudBlob> _blob;
+
+            public TheCleanUpAsyncMethod(ITestOutputHelper output) : base(output)
+            {
+                _validatorStatus = new ValidatorStatus();
+                _validatorStateService
+                    .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
+                    .ReturnsAsync(() => _validatorStatus);
+
+                _blob = new Mock<ISimpleCloudBlob>(MockBehavior.Strict);
+                _blobProvider
+                    .Setup(x => x.GetBlobFromUrl(It.IsAny<string>()))
+                    .Returns(() => _blob.Object);
+            }
+
+            [Fact]
+            public async Task DeletesNothingWhenThereIsNoNupkgUrl()
+            {
+                await _target.CleanUpAsync(_validationRequest.Object);
+
+                _validatorStateService.Verify(x => x.GetStatusAsync(_validationRequest.Object), Times.Once);
+                _blobProvider.Verify(x => x.GetBlobFromUrl (It.IsAny<string>()), Times.Never);
+            }
+
+            [Fact]
+            public async Task DeletesTheBlobWhenThereIsNupkgUrl()
+            {
+                var nupkgUrl = "http://example/packages/nuget.versioning.4.6.0.nupkg";
+                _validatorStatus.NupkgUrl = nupkgUrl;
+                _blob
+                    .Setup(x => x.DeleteIfExistsAsync())
+                    .Returns(Task.CompletedTask);
+
+                await _target.CleanUpAsync(_validationRequest.Object);
+
+                _validatorStateService.Verify(x => x.GetStatusAsync(_validationRequest.Object), Times.Once);
+                _blobProvider.Verify(x => x.GetBlobFromUrl(nupkgUrl), Times.Once);
+                _blob.Verify(x => x.DeleteIfExistsAsync(), Times.Once);
+            }
+        }
+
+        public abstract class FactsBase
+        {
+            protected readonly Mock<IValidatorStateService> _validatorStateService;
+            protected readonly Mock<IProcessSignatureEnqueuer> _packageSignatureVerifier;
+            protected readonly Mock<ISimpleCloudBlobProvider> _blobProvider;
+            protected readonly Mock<ITelemetryService> _telemetryService;
+            protected readonly ILogger<PackageSignatureProcessor> _logger;
+            protected readonly Mock<IValidationRequest> _validationRequest;
+            protected readonly PackageSignatureProcessor _target;
+
+            public FactsBase(ITestOutputHelper output)
+            {
+                _validatorStateService = new Mock<IValidatorStateService>();
+                _packageSignatureVerifier = new Mock<IProcessSignatureEnqueuer>();
+                _blobProvider = new Mock<ISimpleCloudBlobProvider>();
+                _telemetryService = new Mock<ITelemetryService>();
+                var loggerFactory = new LoggerFactory().AddXunit(output);
+                _logger = loggerFactory.CreateLogger<PackageSignatureProcessor>();
+
+                _validationRequest = new Mock<IValidationRequest>();
+                _validationRequest.Setup(x => x.NupkgUrl).Returns(NupkgUrl);
+                _validationRequest.Setup(x => x.PackageId).Returns(PackageId);
+                _validationRequest.Setup(x => x.PackageKey).Returns(PackageKey);
+                _validationRequest.Setup(x => x.PackageVersion).Returns(PackageVersion);
+                _validationRequest.Setup(x => x.ValidationId).Returns(ValidationId);
+
+                _target = new PackageSignatureProcessor(
+                    _validatorStateService.Object,
+                    _packageSignatureVerifier.Object,
+                    _blobProvider.Object,
+                    _telemetryService.Object,
+                    _logger);
+            }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
@@ -170,7 +170,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 await _target.StartAsync(_validationRequest.Object);
 
                 _packageSignatureVerifier
-                    .Verify(x => x.EnqueueProcessSignatureAsync(It.IsAny<IValidationRequest>(), false), Times.Never);
+                    .Verify(x => x.EnqueueProcessSignatureAsync(It.IsAny<IValidationRequest>(), It.IsAny<bool>()), Times.Never);
 
                 _validatorStateService
                     .Verify(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
 using NuGet.Jobs.Validation.Storage;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
@@ -49,7 +50,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = status,
                         ValidatorIssues = new List<ValidatorIssue>(),
                     });
@@ -70,7 +71,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = ValidationStatus.Succeeded,
                         ValidatorIssues = new List<ValidatorIssue>
                         {
@@ -105,7 +106,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = ValidationStatus.Failed,
                         ValidatorIssues = new List<ValidatorIssue>(),
                     });
@@ -124,7 +125,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = ValidationStatus.Succeeded,
                         ValidatorIssues = new List<ValidatorIssue>(),
                         NupkgUrl = "https://nuget.org/a.nupkg"
@@ -160,7 +161,7 @@ namespace NuGet.Services.Validation.PackageSigning
                      {
                          ValidationId = ValidationId,
                          PackageKey = PackageKey,
-                         ValidatorName = nameof(PackageSignatureProcessor),
+                         ValidatorName = ValidatorName.PackageSignatureProcessor,
                          State = status,
                          ValidatorIssues = new List<ValidatorIssue>(),
                      });
@@ -193,7 +194,7 @@ namespace NuGet.Services.Validation.PackageSigning
                      {
                          ValidationId = ValidationId,
                          PackageKey = PackageKey,
-                         ValidatorName = nameof(PackageSignatureProcessor),
+                         ValidatorName = ValidatorName.PackageSignatureProcessor,
                          State = ValidationStatus.NotStarted,
                          ValidatorIssues = new List<ValidatorIssue>(),
                      });
@@ -253,7 +254,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = ValidationStatus.Succeeded,
                         ValidatorIssues = new List<ValidatorIssue>
                         {
@@ -288,7 +289,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = ValidationStatus.Failed,
                         ValidatorIssues = new List<ValidatorIssue>(),
                     });
@@ -307,7 +308,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     {
                         ValidationId = ValidationId,
                         PackageKey = PackageKey,
-                        ValidatorName = nameof(PackageSignatureProcessor),
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
                         State = ValidationStatus.Succeeded,
                         ValidatorIssues = new List<ValidatorIssue>(),
                         NupkgUrl = "https://nuget.org/a.nupkg"

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureVerificationEnqueuerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureVerificationEnqueuerFacts.cs
@@ -21,7 +21,7 @@ namespace NuGet.Services.Validation.PackageSigning
             _configuration.MessageDelay = messageDelay;
 
             var before = DateTimeOffset.UtcNow;
-            await _target.EnqueueVerificationAsync(_validationRequest.Object);
+            await _target.EnqueueProcessSignatureAsync(_validationRequest.Object, requireRepositorySignature: false);
             var after = DateTimeOffset.UtcNow;
 
             Assert.InRange(_brokeredMessage.Object.ScheduledEnqueueTimeUtc, before.Add(messageDelay), after.Add(messageDelay));
@@ -31,7 +31,7 @@ namespace NuGet.Services.Validation.PackageSigning
         public async Task DefaultsNullMessageDelayToZero()
         {
             var before = DateTimeOffset.UtcNow;
-            await _target.EnqueueVerificationAsync(_validationRequest.Object);
+            await _target.EnqueueProcessSignatureAsync(_validationRequest.Object, requireRepositorySignature: false);
             var after = DateTimeOffset.UtcNow;
 
             Assert.InRange(_brokeredMessage.Object.ScheduledEnqueueTimeUtc, before, after);
@@ -46,7 +46,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 .Returns(() => _brokeredMessage.Object)
                 .Callback<SignatureValidationMessage>(x => message = x);
 
-            await _target.EnqueueVerificationAsync(_validationRequest.Object);
+            await _target.EnqueueProcessSignatureAsync(_validationRequest.Object, requireRepositorySignature: false);
 
             Assert.Equal(_validationRequest.Object.ValidationId, message.ValidationId);
             Assert.Equal(_validationRequest.Object.PackageId, message.PackageId);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
@@ -634,7 +634,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Never);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Never);
 
                 Assert.Equal(status, actual.Status);
@@ -671,7 +671,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
@@ -717,7 +717,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
@@ -800,7 +800,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
@@ -881,7 +881,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Exactly(2));
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
@@ -965,7 +965,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Once);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
@@ -1047,7 +1047,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Failed, actual.Status);
@@ -1213,7 +1213,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Exactly(expectedCertificateValidations));
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
@@ -1282,7 +1282,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Failed, actual.Status);
@@ -1376,7 +1376,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(It.IsAny<TimeSpan>()),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);


### PR DESCRIPTION
Introduces the validator that runs after a package is repository signed. Its purpose is to run all validations on the package's signature.

See https://github.com/NuGet/NuGetGallery/issues/5753