### PR TITLE
Remove Respond JS dependency

### DIFF
--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
@@ -209,7 +209,6 @@
     <Folder Include="fonts\" />
     <Folder Include="Models\" />
     <Folder Include="Properties\PublishProfiles\" />
-    <Folder Include="Scripts\" />
     <Folder Include="Views\Home\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGetCDNRedirect/packages.config
+++ b/src/NuGetCDNRedirect/packages.config
@@ -21,7 +21,6 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NuGet.Services.Logging" version="2.2.3" targetFramework="net461" />
-  <package id="Respond" version="1.2.0" targetFramework="net461" />
   <package id="Serilog" version="2.0.0" targetFramework="net461" />
   <package id="Serilog.Enrichers.Environment" version="2.1.0" targetFramework="net461" />
   <package id="Serilog.Enrichers.Process" version="2.0.0" targetFramework="net461" />


### PR DESCRIPTION
Fixes TSA 610583, 610582 (respond.js doesn't use strict)

Note: Respond was default dependency from VS template, but isn't required for CDN redirect