### PR TITLE
Moved scan and sign enqueuer to the shared library.

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -159,6 +159,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.Configure<SmtpConfiguration>(configurationRoot.GetSection(SmtpConfigurationSectionName));
             services.Configure<EmailConfiguration>(configurationRoot.GetSection(EmailConfigurationSectionName));
             services.Configure<ScanAndSignConfiguration>(configurationRoot.GetSection(ScanAndSignSectionName));
+            services.Configure<ScanAndSignEnqueuerConfiguration>(configurationRoot.GetSection(ScanAndSignSectionName));
 
             services.AddTransient<ConfigurationValidator>();
             services.AddTransient<OrchestrationRunner>();

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -67,9 +67,7 @@
     <Compile Include="PackageSigning\ProcessSignature\PackageSignatureProcessor.cs" />
     <Compile Include="PackageSigning\ProcessSignature\ProcessSignatureConfiguration.cs" />
     <Compile Include="PackageSigning\ProcessSignature\ProcessSignatureEnqueuer.cs" />
-    <Compile Include="PackageSigning\ScanAndSign\IScanAndSignEnqueuer.cs" />
     <Compile Include="PackageSigning\ScanAndSign\ScanAndSignConfiguration.cs" />
-    <Compile Include="PackageSigning\ScanAndSign\ScanAndSignEnqueuer.cs" />
     <Compile Include="PackageSigning\ScanAndSign\ScanAndSignProcessor.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\IValidateCertificateEnqueuer.cs" />
     <Compile Include="PackageSigning\ValidateCertificate\PackageCertificatesValidator.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using NuGet.Jobs.Configuration;
 
 namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
@@ -12,10 +11,5 @@ namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
         /// The Service Bus configuration used to enqueue package signing validations.
         /// </summary>
         public ServiceBusConfiguration ServiceBus { get; set; }
-
-        /// <summary>
-        /// The visibility delay to apply to Service Bus messages requesting a new validation.
-        /// </summary>
-        public TimeSpan? MessageDelay { get; set; }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
@@ -105,7 +105,7 @@ namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
             // here we need to determine whether we do scan only or scan and repo sign.
             // Right now we only support scan only.
 
-            await _scanAndSignEnqueuer.EnqueueScanAsync(request);
+            await _scanAndSignEnqueuer.EnqueueScanAsync(request.ValidationId, request.NupkgUrl);
             var result = await _validatorStateService.TryAddValidatorStatusAsync(request, validatorStatus, ValidationStatus.Incomplete);
 
             return result.ToValidationResult();

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
@@ -132,7 +132,7 @@ namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
                     _configuration.V3ServiceIndexUrl,
                     owners);
 
-                await _scanAndSignEnqueuer.EnqueueScanAndSignAsync(request, _configuration.V3ServiceIndexUrl, owners);
+                await _scanAndSignEnqueuer.EnqueueScanAndSignAsync(request.ValidationId, request.NupkgUrl, _configuration.V3ServiceIndexUrl, owners);
             }
             else
             {

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.ScanAndSign;
 
 namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
 {

--- a/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
-using NuGet.Services.Validation;
 
 namespace NuGet.Jobs.Validation.ScanAndSign
 {
@@ -11,7 +11,6 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <summary>
         /// Enqueues Scan operation.
         /// </summary>
-        /// <param name="request">Request data</param>
-        Task EnqueueScanAsync(IValidationRequest request);
+        Task EnqueueScanAsync(Guid validationId, string nupkgUrl);
     }
 }

--- a/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using NuGet.Jobs.Validation.ScanAndSign;
+using NuGet.Services.Validation;
 
-namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
+namespace NuGet.Jobs.Validation.ScanAndSign
 {
     public interface IScanAndSignEnqueuer
     {

--- a/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using NuGet.Services.Validation;
 
 namespace NuGet.Jobs.Validation.ScanAndSign
 {
@@ -13,14 +12,17 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <summary>
         /// Enqueues Scan operation.
         /// </summary>
+        /// <param name="validationId">Validation ID for which scan is requested.</param>
+        /// <param name="nupkgUrl">Url of the package to scan.</param>
         Task EnqueueScanAsync(Guid validationId, string nupkgUrl);
 
         /// <summary>
         /// Enqueues Scan And Sign operation.
         /// </summary>
-        /// <param name="request">The requested package validation.</param>
+        /// <param name="validationId">Validation ID for which scan and sign is requested.</param>
+        /// <param name="nupkgUrl">Url of the package to scan and sign.</param>
         /// <param name="v3ServiceIndexUrl">The service index URL that should be put on the package's repository signature.</param>
         /// <param name="owners">The list of owners that should be put on the package's repository signature.</param>
-        Task EnqueueScanAndSignAsync(IValidationRequest request, string v3ServiceIndexUrl, List<string> owners);
+        Task EnqueueScanAndSignAsync(Guid validationId, string nupkgUrl, string v3ServiceIndexUrl, List<string> owners);
     }
 }

--- a/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
@@ -53,9 +53,13 @@ namespace NuGet.Jobs.Validation.ScanAndSign
                     new Uri(nupkgUrl)));
         }
 
-        public Task EnqueueScanAndSignAsync(IValidationRequest request, string v3ServiceIndexUrl, List<string> owners)
+        public Task EnqueueScanAndSignAsync(Guid validationId, string nupkgUrl, string v3ServiceIndexUrl, List<string> owners)
         {
-            if (request == null) throw new ArgumentNullException(nameof(request));
+            if (nupkgUrl == null)
+            {
+                throw new ArgumentNullException(nameof(nupkgUrl));
+            }
+
             if (owners == null) throw new ArgumentNullException(nameof(owners));
 
             if (string.IsNullOrEmpty(v3ServiceIndexUrl))
@@ -64,17 +68,17 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             }
 
             _logger.LogInformation(
-                "Requested scan and sign for package {PackageId} {PackageVersion} using service index {ServiceIndex} and owners {Owners}",
-                request.PackageId,
-                request.PackageVersion,
+                "Requested scan and sign for validation {ValidationId} {BlobUrl} using service index {ServiceIndex} and owners {Owners}",
+                validationId,
+                nupkgUrl,
                 v3ServiceIndexUrl,
                 owners);
 
             return SendScanAndSignMessageAsync(
                 new ScanAndSignMessage(
                     OperationRequestType.Sign,
-                    request.ValidationId,
-                    new Uri(request.NupkgUrl),
+                    validationId,
+                    new Uri(nupkgUrl),
                     v3ServiceIndexUrl,
                     owners));
         }

--- a/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
@@ -4,21 +4,21 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
-using NuGet.Jobs.Validation.ScanAndSign;
 using NuGet.Services.ServiceBus;
+using NuGet.Services.Validation;
 
-namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
+namespace NuGet.Jobs.Validation.ScanAndSign
 {
     public class ScanAndSignEnqueuer : IScanAndSignEnqueuer
     {
         private readonly ITopicClient _topicClient;
         private readonly IBrokeredMessageSerializer<ScanAndSignMessage> _serializer;
-        private readonly ScanAndSignConfiguration _configuration;
+        private readonly ScanAndSignEnqueuerConfiguration _configuration;
 
         public ScanAndSignEnqueuer(
             ITopicClient topicClient,
             IBrokeredMessageSerializer<ScanAndSignMessage> serializer,
-            IOptionsSnapshot<ScanAndSignConfiguration> configurationAccessor)
+            IOptionsSnapshot<ScanAndSignEnqueuerConfiguration> configurationAccessor)
         {
             _topicClient = topicClient ?? throw new ArgumentNullException(nameof(topicClient));
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));

--- a/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using NuGet.Services.ServiceBus;
-using NuGet.Services.Validation;
 
 namespace NuGet.Jobs.Validation.ScanAndSign
 {
@@ -33,17 +32,17 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             _configuration = configurationAccessor.Value;
         }
 
-        public Task EnqueueScanAsync(IValidationRequest request)
+        public Task EnqueueScanAsync(Guid validationId, string nupkgUrl)
         {
-            if (request == null)
+            if (nupkgUrl == null)
             {
-                throw new ArgumentNullException(nameof(request));
+                throw new ArgumentNullException(nameof(nupkgUrl));
             }
 
             var message = new ScanAndSignMessage(
                 OperationRequestType.Scan,
-                request.ValidationId,
-                new Uri(request.NupkgUrl));
+                validationId,
+                new Uri(nupkgUrl));
             var brokeredMessage = _serializer.Serialize(message);
 
             var visibleAt = DateTimeOffset.UtcNow + (_configuration.MessageDelay ?? TimeSpan.Zero);

--- a/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuerConfiguration.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuerConfiguration.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Jobs.Validation.ScanAndSign
+{
+    public class ScanAndSignEnqueuerConfiguration
+    {
+        /// <summary>
+        /// The visibility delay to apply to Service Bus messages requesting a new validation.
+        /// </summary>
+        public TimeSpan? MessageDelay { get; set; }
+    }
+}

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -37,17 +37,22 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IScanAndSignEnqueuer.cs" />
     <Compile Include="OperationRequestType.cs" />
+    <Compile Include="ScanAndSignEnqueuer.cs" />
+    <Compile Include="ScanAndSignEnqueuerConfiguration.cs" />
     <Compile Include="ScanAndSignMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
     <Compile Include="ScanAndSignMessageSerializer.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options">
+      <Version>1.1.2</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
       <Version>2.22.0</Version>
     </PackageReference>

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignEnqueuerFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignEnqueuerFacts.cs
@@ -53,7 +53,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
         {
             _configurationAccessorMock
                 .SetupGet(ca => ca.Value)
-                .Returns((ScanAndSignConfiguration)null);
+                .Returns((ScanAndSignEnqueuerConfiguration)null);
 
 
             var ex = Assert.Throws<ArgumentException>(() => new ScanAndSignEnqueuer(
@@ -133,17 +133,17 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
     {
         protected Mock<ITopicClient> _topicClientMock;
         protected Mock<IBrokeredMessageSerializer<ScanAndSignMessage>> _serializerMock;
-        protected Mock<IOptionsSnapshot<ScanAndSignConfiguration>> _configurationAccessorMock;
-        protected ScanAndSignConfiguration _configuration;
+        protected Mock<IOptionsSnapshot<ScanAndSignEnqueuerConfiguration>> _configurationAccessorMock;
+        protected ScanAndSignEnqueuerConfiguration _configuration;
         protected ScanAndSignEnqueuer _target;
 
         public ScanAndSignEnqueuerFactsBase()
         {
             _topicClientMock = new Mock<ITopicClient>();
             _serializerMock = new Mock<IBrokeredMessageSerializer<ScanAndSignMessage>>();
-            _configurationAccessorMock = new Mock<IOptionsSnapshot<ScanAndSignConfiguration>>();
+            _configurationAccessorMock = new Mock<IOptionsSnapshot<ScanAndSignEnqueuerConfiguration>>();
 
-            _configuration = new ScanAndSignConfiguration();
+            _configuration = new ScanAndSignEnqueuerConfiguration();
             _configurationAccessorMock
                 .SetupGet(ca => ca.Value)
                 .Returns(_configuration);

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignEnqueuerFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignEnqueuerFacts.cs
@@ -134,11 +134,14 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
         [Fact]
         public async Task ThrowsWhenParametersAreMissing()
         {
-            var ex1 = await Assert.ThrowsAsync<ArgumentNullException>(() => _target.EnqueueScanAndSignAsync(null, V3ServiceIndexUrl, _owners));
-            var ex2 = await Assert.ThrowsAsync<ArgumentException>(() => _target.EnqueueScanAndSignAsync(_validationRequest, null, _owners));
-            var ex3 = await Assert.ThrowsAsync<ArgumentNullException>(() => _target.EnqueueScanAndSignAsync(_validationRequest, V3ServiceIndexUrl, null));
+            var ex1 = await Assert.ThrowsAsync<ArgumentNullException>(()
+                => _target.EnqueueScanAndSignAsync(_validationRequest.ValidationId, null, V3ServiceIndexUrl, _owners));
+            var ex2 = await Assert.ThrowsAsync<ArgumentException>(()
+                => _target.EnqueueScanAndSignAsync(_validationRequest.ValidationId, _validationRequest.NupkgUrl, null, _owners));
+            var ex3 = await Assert.ThrowsAsync<ArgumentNullException>(()
+                => _target.EnqueueScanAndSignAsync(_validationRequest.ValidationId, _validationRequest.NupkgUrl, V3ServiceIndexUrl, null));
 
-            Assert.Equal("request", ex1.ParamName);
+            Assert.Equal("nupkgUrl", ex1.ParamName);
             Assert.Equal("v3ServiceIndexUrl", ex2.ParamName);
             Assert.Equal("owners", ex3.ParamName);
         }
@@ -146,7 +149,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
         [Fact]
         public async Task PassesDataToSerializedMessage()
         {
-            await _target.EnqueueScanAndSignAsync(_validationRequest, V3ServiceIndexUrl, _owners);
+            await _target.EnqueueScanAndSignAsync(_validationRequest.ValidationId, _validationRequest.NupkgUrl, V3ServiceIndexUrl, _owners);
 
             _serializerMock
                 .Verify(s => s.Serialize(It.IsAny<ScanAndSignMessage>()), Times.Once);
@@ -164,7 +167,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             const int messageDelayDays = 137;
             _configuration.MessageDelay = TimeSpan.FromDays(messageDelayDays);
 
-            await _target.EnqueueScanAndSignAsync(_validationRequest, V3ServiceIndexUrl, _owners);
+            await _target.EnqueueScanAndSignAsync(_validationRequest.ValidationId, _validationRequest.NupkgUrl, V3ServiceIndexUrl, _owners);
 
             Assert.Equal(messageDelayDays, (_serializedMessage.ScheduledEnqueueTimeUtc - DateTimeOffset.UtcNow).TotalDays, 0);
         }
@@ -172,7 +175,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
         [Fact]
         public async Task SendsMessage()
         {
-            await _target.EnqueueScanAndSignAsync(_validationRequest, V3ServiceIndexUrl, _owners);
+            await _target.EnqueueScanAndSignAsync(_validationRequest.ValidationId, _validationRequest.NupkgUrl, V3ServiceIndexUrl, _owners);
 
             Assert.Same(_serializedMessage, _capturedBrokeredMessage);
         }

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
@@ -210,7 +210,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             var result = await _target.StartAsync(_request);
 
             _enqueuerMock
-                .Verify(e => e.EnqueueScanAsync(It.IsAny<IValidationRequest>()), Times.Never);
+                .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
             _validatorStateServiceMock
                 .Verify(vss => vss.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
             _validatorStateServiceMock
@@ -229,9 +229,9 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
         {
             var result = await _target.StartAsync(_request);
             _enqueuerMock
-                .Verify(e => e.EnqueueScanAsync(_request), Times.Once);
+                .Verify(e => e.EnqueueScanAsync(_request.ValidationId, _request.NupkgUrl), Times.Once);
             _enqueuerMock
-                .Verify(e => e.EnqueueScanAsync(It.IsAny<IValidationRequest>()), Times.Once);
+                .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
 
             _validatorStateServiceMock
                 .Verify(vss => vss.TryAddValidatorStatusAsync(_request, _status, ValidationStatus.Incomplete), Times.Once);
@@ -255,7 +255,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             _validatorStateServiceMock
                 .Verify(vss => vss.GetStatusAsync(It.IsAny<Guid>()), Times.Never);
             _enqueuerMock
-                .Verify(e => e.EnqueueScanAsync(It.IsAny<IValidationRequest>()), Times.Never);
+                .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
             _validatorStateServiceMock
                 .Verify(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Never);
         }

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.ScanAndSign;
 using NuGet.Services.Validation;
 using NuGet.Services.Validation.Orchestrator;
 using NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign;

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
@@ -205,7 +205,8 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             _enqueuerMock
                 .Verify(e =>
                     e.EnqueueScanAndSignAsync(
-                        _request,
+                        _request.ValidationId,
+                        _request.NupkgUrl,
                         _config.V3ServiceIndexUrl,
                         It.Is<List<string>>(l =>
                             l.Count() == 2 &&
@@ -258,7 +259,8 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             _enqueuerMock
                 .Verify(e =>
                     e.EnqueueScanAndSignAsync(
-                        It.IsAny<IValidationRequest>(),
+                        It.IsAny<Guid>(),
+                        It.IsAny<string>(),
                         It.IsAny<string>(),
                         It.IsAny<List<string>>()),
                     Times.Never);
@@ -336,7 +338,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             await _target.StartAsync(_request);
 
             _enqueuerMock
-                .Verify(e => e.EnqueueScanAndSignAsync(_request, _config.V3ServiceIndexUrl, It.IsAny<List<string>>()), Times.Once);
+                .Verify(e => e.EnqueueScanAndSignAsync(_request.ValidationId, _request.NupkgUrl, _config.V3ServiceIndexUrl, It.IsAny<List<string>>()), Times.Once);
 
             _validatorStateServiceMock
                 .Verify(v =>


### PR DESCRIPTION
Scan and sign jobs needs a way to send messages, too, hence the move.

Split the scan and sign configuration in two objects to allow enqueuer have message delay specified without having to carry unrelated settings.