### PR TITLE
ScanAndSignMessage constructor fix

### DIFF
--- a/src/Validation.ScanAndSign.Core/ScanAndSignMessage.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignMessage.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace NuGet.Jobs.Validation.ScanAndSign
 {
@@ -31,17 +30,14 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             string v3ServiceIndexUrl,
             IReadOnlyList<string> owners)
         {
-            if (operationRequestType == OperationRequestType.Scan &&
-                (!string.IsNullOrEmpty(v3ServiceIndexUrl) || owners != null))
-            {
-                throw new ArgumentException($"{nameof(OperationRequestType.Scan)} operations do not accept a V3 service index URL or a list of owners");
-            }
-
             OperationRequestType = operationRequestType;
             PackageValidationId = packageValidationId;
             BlobUri = blobUri ?? throw new ArgumentNullException(nameof(blobUri));
-            V3ServiceIndexUrl = v3ServiceIndexUrl ?? throw new ArgumentNullException(nameof(v3ServiceIndexUrl));
-            Owners = owners ?? throw new ArgumentNullException(nameof(owners));
+            if (operationRequestType == OperationRequestType.Sign)
+            {
+                V3ServiceIndexUrl = v3ServiceIndexUrl ?? throw new ArgumentNullException(nameof(v3ServiceIndexUrl));
+                Owners = owners ?? throw new ArgumentNullException(nameof(owners));
+            }
         }
 
         public OperationRequestType OperationRequestType { get; }

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignMessageFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignMessageFacts.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Jobs.Validation.ScanAndSign;
+using Xunit;
+
+namespace Validation.PackageSigning.ScanAndSign.Tests
+{
+    public class ScanAndSignMessageFacts
+    {
+        [Fact]
+        public void ConstructorDoesNotThrowWhenIndexUrlIsNullForScanOperation()
+        {
+            var ex = Record.Exception(() => new ScanAndSignMessage(
+                OperationRequestType.Scan,
+                Guid.NewGuid(),
+                new Uri("https://example.com/aaa.nupkg"),
+                v3ServiceIndexUrl: null,
+                owners: new List<string> { "owner1" }));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ConstructorDoesNotThrowWhenOwnersIsNullForScanOperation()
+        {
+            var ex = Record.Exception(() => new ScanAndSignMessage(
+                OperationRequestType.Scan,
+                Guid.NewGuid(),
+                new Uri("https://example.com/aaa.nupkg"),
+                v3ServiceIndexUrl: "https://example.com/index.json",
+                owners: null));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ShortConstructorCannotBeUsedForSignOperation()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new ScanAndSignMessage(
+                OperationRequestType.Sign,
+                Guid.NewGuid(),
+                new Uri("https://example.com/aaa.nupkg")));
+
+            Assert.Contains(nameof(OperationRequestType.Sign), ex.Message);
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScanAndSignEnqueuerFacts.cs" />
+    <Compile Include="ScanAndSignMessageFacts.cs" />
     <Compile Include="ScanAndSignProcessorFacts.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixed ScanAndSignMessage constructor to ignore values of `V3ServiceIndexUrl` and `Owners` unless operation is `Scan` instead of throwing exception.

Currently deserializer always uses "long" constructor which fails for `Scan` messages.