### PR TITLE
Revert "SQL AAD config for validation jobs (#465)"

### DIFF
--- a/src/NuGet.Services.Revalidate/Settings/dev.json
+++ b/src/NuGet.Services.Revalidate/Settings/dev.json
@@ -12,10 +12,10 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Revalidate;AadTenant=#{Jobs.validation.GalleryDatabaseAadTenant};AadClientId=#{Jobs.validation.GalleryDatabaseAadClientId};AadCertificate=$$dev-gallerydb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Revalidate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$dev-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Integrated Security=False;User ID=$$Dev-ValidationDBWriter-UserName$$;Password=$$Dev-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetdev.servicebus.windows.net/;SharedAccessKeyName=package-certificates-validator;SharedAccessKey=$$Dev-ServiceBus-SharedAccessKey-Validation-CertificatesValidator$$",

--- a/src/NuGet.Services.Revalidate/Settings/int.json
+++ b/src/NuGet.Services.Revalidate/Settings/int.json
@@ -12,10 +12,10 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Revalidate;AadTenant=#{Jobs.validation.GalleryDatabaseAadTenant};AadClientId=#{Jobs.validation.GalleryDatabaseAadClientId};AadCertificate=$$int-gallerydb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;Integrated Security=False;User ID=$$Int-GalleryDBReadOnly-UserName$$;Password=$$Int-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Revalidate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$int-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Integrated Security=False;User ID=$$Int-ValidationDBWriter-UserName$$;Password=$$Int-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetint.servicebus.windows.net/;SharedAccessKeyName=package-certificates-validator;SharedAccessKey=$$Int-ServiceBus-SharedAccessKey-Validation-CertificatesValidator$$",

--- a/src/NuGet.Services.Revalidate/Settings/prod.json
+++ b/src/NuGet.Services.Revalidate/Settings/prod.json
@@ -12,10 +12,10 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Revalidate;AadTenant=#{Jobs.validation.GalleryDatabaseAadTenant};AadClientId=#{Jobs.validation.GalleryDatabaseAadClientId};AadCertificate=$$prod-gallerydb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;Integrated Security=False;User ID=$$Prod-GalleryDBReadOnly-UserName$$;Password=$$Prod-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Revalidate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$prod-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Integrated Security=False;User ID=$$Prod-ValidationDBWriter-UserName$$;Password=$$Prod-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetprod.servicebus.windows.net/;SharedAccessKeyName=package-certificates-validator;SharedAccessKey=$$Prod-ServiceBus-SharedAccessKey-Validation-CertificatesValidator$$",

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
@@ -1,9 +1,9 @@
 ﻿{
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ProcessSignature;AadTenant=#{Jobs.validation.GalleryDatabaseAadTenant};AadClientId=#{Jobs.validation.GalleryDatabaseAadClientId};AadCertificate=$$dev-gallerydb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBWriter-UserName$$;Password=$$Dev-GalleryDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ProcessSignature;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$dev-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Integrated Security=False;User ID=$$Dev-ValidationDBWriter-UserName$$;Password=$$Dev-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetdev.servicebus.windows.net/;SharedAccessKeyName=extract-and-validate-signature;SharedAccessKey=$$Dev-ServiceBus-SharedAccessKey-Validation-ExtractAndValidatePackageSignature$$",

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
@@ -1,9 +1,9 @@
 ﻿{
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ProcessSignature;AadTenant=#{Jobs.validation.GalleryDatabaseAadTenant};AadClientId=#{Jobs.validation.GalleryDatabaseAadClientId};AadCertificate=$$int-gallerydb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;Integrated Security=False;User ID=$$Int-GalleryDBWriter-UserName$$;Password=$$Int-GalleryDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ProcessSignature;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$int-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Integrated Security=False;User ID=$$Int-ValidationDBWriter-UserName$$;Password=$$Int-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetint.servicebus.windows.net/;SharedAccessKeyName=extract-and-validate-signature;SharedAccessKey=$$Int-ServiceBus-SharedAccessKey-Validation-ExtractAndValidatePackageSignature$$",

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
@@ -1,9 +1,9 @@
 ﻿{
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ProcessSignature;AadTenant=#{Jobs.validation.GalleryDatabaseAadTenant};AadClientId=#{Jobs.validation.GalleryDatabaseAadClientId};AadCertificate=$$prod-gallerydb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;Integrated Security=False;User ID=$$Prod-GalleryDBWriter-UserName$$;Password=$$Prod-GalleryDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ProcessSignature;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$prod-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Integrated Security=False;User ID=$$Prod-ValidationDBWriter-UserName$$;Password=$$Prod-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetprod.servicebus.windows.net/;SharedAccessKeyName=extract-and-validate-signature;SharedAccessKey=$$Prod-ServiceBus-SharedAccessKey-Validation-ExtractAndValidatePackageSignature$$",

--- a/src/Validation.PackageSigning.RevalidateCertificate/Settings/dev.json
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Settings/dev.json
@@ -10,7 +10,7 @@
   },
 
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=RevalidateCertificate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$dev-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Integrated Security=False;User ID=$$Dev-ValidationDBWriter-UserName$$;Password=$$Dev-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetdev.servicebus.windows.net/;SharedAccessKeyName=package-certificates-validator;SharedAccessKey=$$Dev-ServiceBus-SharedAccessKey-Validation-CertificatesValidator$$",

--- a/src/Validation.PackageSigning.RevalidateCertificate/Settings/int.json
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Settings/int.json
@@ -10,7 +10,7 @@
   },
 
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=RevalidateCertificate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$int-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Integrated Security=False;User ID=$$Int-ValidationDBWriter-UserName$$;Password=$$Int-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetint.servicebus.windows.net/;SharedAccessKeyName=package-certificates-validator;SharedAccessKey=$$Int-ServiceBus-SharedAccessKey-Validation-CertificatesValidator$$",

--- a/src/Validation.PackageSigning.RevalidateCertificate/Settings/prod.json
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Settings/prod.json
@@ -10,7 +10,7 @@
   },
 
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=RevalidateCertificate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$prod-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Integrated Security=False;User ID=$$Prod-ValidationDBWriter-UserName$$;Password=$$Prod-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetprod.servicebus.windows.net/;SharedAccessKeyName=package-certificates-validator;SharedAccessKey=$$Prod-ServiceBus-SharedAccessKey-Validation-CertificatesValidator$$",

--- a/src/Validation.PackageSigning.ValidateCertificate/Settings/dev.json
+++ b/src/Validation.PackageSigning.ValidateCertificate/Settings/dev.json
@@ -1,6 +1,6 @@
 ﻿{
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ValidateCertificate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$dev-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-dev-validation;Integrated Security=False;User ID=$$Dev-ValidationDBWriter-UserName$$;Password=$$Dev-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetdev.servicebus.windows.net/;SharedAccessKeyName=validate-certificate;SharedAccessKey=$$Dev-ServiceBus-SharedAccessKey-Validation-ValidateCertificate$$",

--- a/src/Validation.PackageSigning.ValidateCertificate/Settings/int.json
+++ b/src/Validation.PackageSigning.ValidateCertificate/Settings/int.json
@@ -1,6 +1,6 @@
 ﻿{
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ValidateCertificate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$int-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-int-validation;Integrated Security=False;User ID=$$Int-ValidationDBWriter-UserName$$;Password=$$Int-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetint.servicebus.windows.net/;SharedAccessKeyName=validate-certificate;SharedAccessKey=$$Int-ServiceBus-SharedAccessKey-Validation-ValidateCertificate$$",

--- a/src/Validation.PackageSigning.ValidateCertificate/Settings/prod.json
+++ b/src/Validation.PackageSigning.ValidateCertificate/Settings/prod.json
@@ -1,6 +1,6 @@
 ﻿{
   "ValidationDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ValidateCertificate;AadTenant=#{Jobs.validation.DatabaseAadTenant};AadClientId=#{Jobs.validation.DatabaseAadClientId};AadCertificate=$$prod-validationdb-writer$$"
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.DatabaseAddress};Initial Catalog=nuget-prod-validation;Integrated Security=False;User ID=$$Prod-ValidationDBWriter-UserName$$;Password=$$Prod-ValidationDBWriter-Password$$;Connect Timeout=30;Encrypt=True"
   },
   "ServiceBus": {
     "ConnectionString": "Endpoint=sb://nugetprod.servicebus.windows.net/;SharedAccessKeyName=validate-certificate;SharedAccessKey=$$Prod-ServiceBus-SharedAccessKey-Validation-ValidateCertificate$$",


### PR DESCRIPTION
This reverts commit 2b66b620e9ffafa194830ba7064f0f9d30a68537.

A couple of hours after deploying the 5th validation job to dev, SQL logins started failing for AAD auth (error_code=18456, state=132). I suggest rolling back config (continue with original SQL auth) while the AAD issue is investigated.

Note, Orchestrator and ESRP config were not merged. I'll redeploy validation jobs to dev to revert SQL connection strings.