### PR TITLE
[Package Signing] Verify the author signature independently of the repository signature

### DIFF
--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -90,7 +90,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.8.0-preview1.5195</Version>
+      <Version>4.8.0-preview4.5289</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.25.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.nuspec
+++ b/src/Validation.Common.Job/Validation.Common.Job.nuspec
@@ -15,7 +15,7 @@
         <dependency id="Microsoft.ApplicationInsights" version="2.2.0" />
         <dependency id="Microsoft.Extensions.DependencyInjection" version="1.1.1" />
         <dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="1.1.2" />
-        <dependency id="NuGet.Packaging" version="4.8.0-preview1.5195" />
+        <dependency id="NuGet.Packaging" version="4.8.0-preview4.5289" />
         <dependency id="NuGet.Services.Configuration" version="2.25.0" />
         <dependency id="NuGet.Services.Logging" version="2.25.0" />
         <dependency id="NuGet.Services.Sql" version="2.26.0-master-33196" />

--- a/src/Validation.PackageSigning.ProcessSignature/ISignatureFormatValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/ISignatureFormatValidator.cs
@@ -20,12 +20,22 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             CancellationToken token);
 
         /// <summary>
+        /// Run all validations on the package's author signature. This includes integrity and trust validations.
+        /// </summary>
+        /// <param name="package">The package whose repository signature should be validated.</param>
+        /// <param name="token"></param>
+        /// <returns>The result of the author signature's verification.</returns>
+        Task<VerifySignaturesResult> ValidateAuthorSignatureAsync(
+            ISignedPackageReader package,
+            CancellationToken token);
+
+        /// <summary>
         /// Run all validations on the package's repository signature. This includes integrity and trust validations.
         /// </summary>
         /// <param name="package">The package whose repository signature should be validated.</param>
         /// <param name="token"></param>
-        /// <returns>Whether the package's signature is readable.</returns>
-        Task<SignatureVerificationStatus> VerifyRepositorySignatureAsync(
+        /// <returns>The result of the repository signature's verification.</returns>
+        Task<VerifySignaturesResult> ValidateRepositorySignatureAsync(
             ISignedPackageReader package,
             CancellationToken token);
 
@@ -35,10 +45,10 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
         /// <param name="package">The package to validate.</param>
         /// <param name="hasRepositorySignature">If false, skips the certificate allow list verification of the repository signature.</param>
         /// <param name="token"></param>
-        /// <returns>Whether the package's signature is valid.</returns>
+        /// <returns>The result of the package's signature(s) verification.</returns>
         Task<VerifySignaturesResult> ValidateFullAsync(
             ISignedPackageReader package,
-            bool hasRepositorySignature,
+            bool hasRepositorySignature, // TODO: Remove parameter once this is fixed: https://github.com/NuGet/Home/issues/7042
             CancellationToken token);
     }
 }

--- a/src/Validation.PackageSigning.ProcessSignature/SignatureFormatValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureFormatValidator.cs
@@ -22,34 +22,38 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             allowMultipleTimestamps: true,
             allowNoTimestamp: true,
             allowUnknownRevocation: true,
+            reportUnknownRevocation: false,
             allowNoRepositoryCertificateList: true,
             allowNoClientCertificateList: true,
-            alwaysVerifyCountersignature: false,
+            verificationTarget: VerificationTarget.All,
+            signaturePlacement: SignaturePlacement.PrimarySignature,
+            repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
             repoAllowListEntries: null,
             clientAllowListEntries: null);
 
-        private static readonly IEnumerable<ISignatureVerificationProvider> _minimalProviders = new[]
+        private static readonly PackageSignatureVerifier _minimalVerifier = new PackageSignatureVerifier(new[]
         {
             new MinimalSignatureVerificationProvider(),
-        };
+        });
 
-        private static readonly IEnumerable<ISignatureVerificationProvider> _fullProviders = new ISignatureVerificationProvider[]
+        private static readonly PackageSignatureVerifier _fullVerifier = new PackageSignatureVerifier(new ISignatureVerificationProvider[]
         {
             new IntegrityVerificationProvider(),
             new SignatureTrustAndValidityVerificationProvider(),
             new AllowListVerificationProvider(),
-        };
+        });
 
         private readonly IOptionsSnapshot<ProcessSignatureConfiguration> _config;
         private readonly SignedPackageVerifierSettings _authorSignatureSettings;
+        private readonly SignedPackageVerifierSettings _repositorySignatureSettings;
         private readonly SignedPackageVerifierSettings _authorOrRepositorySignatureSettings;
-
-        private readonly RepositorySignatureVerifier _repositorySignatureVerifier;
 
         public SignatureFormatValidator(IOptionsSnapshot<ProcessSignatureConfiguration> config)
         {
             _config = config ?? throw new ArgumentNullException(nameof(config));
 
+            // TODO - Merge "_authorSignatureSettings" and "_authorOrRepositorySignatureSettings" once this issue is fixed:
+            // https://github.com/NuGet/Home/issues/7042
             _authorSignatureSettings = new SignedPackageVerifierSettings(
                 allowUnsigned: false,
                 allowIllegal: false,
@@ -58,11 +62,14 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                 allowMultipleTimestamps: false,
                 allowNoTimestamp: false,
                 allowUnknownRevocation: true,
-                allowNoClientCertificateList: true,
-                alwaysVerifyCountersignature: true,
-                clientAllowListEntries: null,
+                reportUnknownRevocation: true,
                 allowNoRepositoryCertificateList: true,
-                repoAllowListEntries: null);
+                allowNoClientCertificateList: true,
+                verificationTarget: VerificationTarget.Author,
+                signaturePlacement: SignaturePlacement.PrimarySignature,
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.Never,
+                repoAllowListEntries: null,
+                clientAllowListEntries: null);
 
             var repoAllowListEntries = _config
                 .Value
@@ -76,6 +83,23 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
             repoAllowListEntries = repoAllowListEntries ?? new List<CertificateHashAllowListEntry>();
 
+            _repositorySignatureSettings = new SignedPackageVerifierSettings(
+                allowUnsigned: _authorSignatureSettings.AllowUnsigned,
+                allowIllegal: _authorSignatureSettings.AllowIllegal,
+                allowUntrusted: _authorSignatureSettings.AllowUntrusted,
+                allowIgnoreTimestamp: _authorSignatureSettings.AllowIgnoreTimestamp,
+                allowMultipleTimestamps: _authorSignatureSettings.AllowMultipleTimestamps,
+                allowNoTimestamp: _authorSignatureSettings.AllowNoTimestamp,
+                allowUnknownRevocation: _authorSignatureSettings.AllowUnknownRevocation,
+                reportUnknownRevocation: _authorSignatureSettings.ReportUnknownRevocation,
+                allowNoRepositoryCertificateList: false,
+                allowNoClientCertificateList: _authorSignatureSettings.AllowNoClientCertificateList,
+                verificationTarget: VerificationTarget.Repository,
+                signaturePlacement: SignaturePlacement.Any,
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                repoAllowListEntries: repoAllowListEntries,
+                clientAllowListEntries: _authorSignatureSettings.ClientCertificateList);
+
             _authorOrRepositorySignatureSettings = new SignedPackageVerifierSettings(
                 allowUnsigned: _authorSignatureSettings.AllowUnsigned,
                 allowIllegal: _authorSignatureSettings.AllowIllegal,
@@ -84,23 +108,43 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                 allowMultipleTimestamps: _authorSignatureSettings.AllowMultipleTimestamps,
                 allowNoTimestamp: _authorSignatureSettings.AllowNoTimestamp,
                 allowUnknownRevocation: _authorSignatureSettings.AllowUnknownRevocation,
-                allowNoClientCertificateList: _authorSignatureSettings.AllowNoClientCertificateList,
-                alwaysVerifyCountersignature: _authorSignatureSettings.AlwaysVerifyCountersignature,
-                clientAllowListEntries: _authorSignatureSettings.ClientCertificateList,
+                reportUnknownRevocation: _authorSignatureSettings.ReportUnknownRevocation,
                 allowNoRepositoryCertificateList: false,
-                repoAllowListEntries: repoAllowListEntries);
-
-            _repositorySignatureVerifier = new RepositorySignatureVerifier();
+                allowNoClientCertificateList: _authorSignatureSettings.AllowNoClientCertificateList,
+                verificationTarget: VerificationTarget.All,
+                signaturePlacement: SignaturePlacement.Any,
+                repositoryCountersignatureVerificationBehavior: SignatureVerificationBehavior.IfExists,
+                repoAllowListEntries: repoAllowListEntries,
+                clientAllowListEntries: _authorSignatureSettings.ClientCertificateList);
         }
 
         public async Task<VerifySignaturesResult> ValidateMinimalAsync(
             ISignedPackageReader package,
             CancellationToken token)
         {
-            return await VerifyAsync(
+            return await _minimalVerifier.VerifySignaturesAsync(
                 package,
-                _minimalProviders,
                 _minimalSettings,
+                token);
+        }
+
+        public async Task<VerifySignaturesResult> ValidateAuthorSignatureAsync(
+            ISignedPackageReader package,
+            CancellationToken token)
+        {
+            return await _fullVerifier.VerifySignaturesAsync(
+                package,
+                _authorSignatureSettings,
+                token);
+        }
+
+        public async Task<VerifySignaturesResult> ValidateRepositorySignatureAsync(
+            ISignedPackageReader package,
+            CancellationToken token)
+        {
+            return await _fullVerifier.VerifySignaturesAsync(
+                package,
+                _repositorySignatureSettings,
                 token);
         }
 
@@ -109,31 +153,11 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             bool hasRepositorySignature,
             CancellationToken token)
         {
+            // TODO - Use only the "authorOrRepositorySignatureSettings" once this issue is fixed:
+            // https://github.com/NuGet/Home/issues/7042
             var settings = hasRepositorySignature ? _authorOrRepositorySignatureSettings : _authorSignatureSettings;
 
-            return await VerifyAsync(
-                package,
-                _fullProviders,
-                settings,
-                token);
-        }
-
-        public async Task<SignatureVerificationStatus> VerifyRepositorySignatureAsync(
-            ISignedPackageReader package,
-            CancellationToken token)
-        {
-            return await _repositorySignatureVerifier.VerifyAsync(package, token);
-        }
-
-        private static async Task<VerifySignaturesResult> VerifyAsync(
-            ISignedPackageReader package,
-            IEnumerable<ISignatureVerificationProvider> verificationProviders,
-            SignedPackageVerifierSettings settings,
-            CancellationToken token)
-        {
-            var verifier = new PackageSignatureVerifier(verificationProviders);
-
-            return await verifier.VerifySignaturesAsync(
+            return await _fullVerifier.VerifySignaturesAsync(
                 package,
                 settings,
                 token);

--- a/tests/Validation.PackageSigning.Core.Tests/Support/ExtensionMethods.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/ExtensionMethods.cs
@@ -22,6 +22,27 @@ namespace Validation.PackageSigning.Core.Tests.Support
             bool addOcsp = true)
         {
             var responders = new DisposableList<IDisposable>();
+
+            if (addCa)
+            {
+                responders.Add(testServer.RegisterResponder(ca));
+            }
+
+            if (addOcsp)
+            {
+                responders.Add(testServer.RegisterResponder(ca.OcspResponder));
+            }
+
+            return responders;
+        }
+
+        public static DisposableList<IDisposable> RegisterRespondersForEntireChain(
+            this ISigningTestServer testServer,
+            CertificateAuthority ca,
+            bool addCa = true,
+            bool addOcsp = true)
+        {
+            var responders = new DisposableList<IDisposable>();
             var currentCa = ca;
 
             while (currentCa != null)
@@ -42,14 +63,14 @@ namespace Validation.PackageSigning.Core.Tests.Support
             return responders;
         }
 
-        public static DisposableList<IDisposable> RegisterResponders(
+        public static DisposableList<IDisposable> RegisterRespondersForTimestampServiceAndEntireChain(
             this ISigningTestServer testServer,
             TimestampService timestampService,
             bool addCa = true,
             bool addOcsp = true,
             bool addTimestamper = true)
         {
-            var responders = testServer.RegisterResponders(
+            var responders = testServer.RegisterRespondersForEntireChain(
                 timestampService.CertificateAuthority,
                 addCa,
                 addOcsp);

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -75,7 +75,7 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="Test.Utility">
-      <Version>4.7.0-preview4.5067</Version>
+      <Version>4.8.0-preview4.5289</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.3.1</Version>

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorFacts.cs
@@ -4,9 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -65,12 +62,12 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _packageSigningStateService = new Mock<IPackageSigningStateService>();
                 _formatValidator = new Mock<ISignatureFormatValidator>();
 
-                _minimalVerifyResult = new VerifySignaturesResult(true);
+                _minimalVerifyResult = new VerifySignaturesResult(valid: true, signed: true);
                 _formatValidator
                     .Setup(x => x.ValidateMinimalAsync(It.IsAny<ISignedPackageReader>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(() => _minimalVerifyResult);
 
-                _fullVerifyResult = new VerifySignaturesResult(true);
+                _fullVerifyResult = new VerifySignaturesResult(valid: true, signed: true);
                 _formatValidator
                     .Setup(x => x.ValidateFullAsync(It.IsAny<ISignedPackageReader>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(() => _fullVerifyResult);
@@ -89,7 +86,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _optionsSnapshot = new Mock<IOptionsSnapshot<ProcessSignatureConfiguration>>();
                 _configuration = new ProcessSignatureConfiguration
                 {
-                    AllowedRepositorySigningCertificates = new List<string>(),
+                    AllowedRepositorySigningCertificates = new List<string> { "fake-thumbprint" },
                     V3ServiceIndexUrl = "http://example/v3/index.json",
                 };
                 _optionsSnapshot.Setup(x => x.Value).Returns(() => _configuration);
@@ -252,7 +249,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             {
                 // Arrange
                 _packageStream = TestResources.GetResourceStream(TestResources.SignedPackageLeaf1);
-                _minimalVerifyResult = new VerifySignaturesResult(valid: false);
+                _minimalVerifyResult = new VerifySignaturesResult(valid: false, signed: true);
                 _message = new SignatureValidationMessage(
                     TestResources.SignedPackageLeafId,
                     TestResources.SignedPackageLeaf1Version,
@@ -281,10 +278,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _packageStream = TestResources.GetResourceStream(TestResources.SignedPackageLeaf1);
                 _minimalVerifyResult = new VerifySignaturesResult(
                     valid: false,
+                    signed: true,
                     results: new[]
                     {
                         new InvalidSignaturePackageVerificationResult(
-                            SignatureVerificationStatus.Illegal,
+                            SignatureVerificationStatus.Suspect,
                             new[]
                             {
                                 SignatureLog.Issue(
@@ -323,7 +321,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     _corePackageService,
                     TestResources.SignedPackageLeafId,
                     TestResources.Leaf1Thumbprint);
-                _fullVerifyResult = new VerifySignaturesResult(valid: false);
+                _fullVerifyResult = new VerifySignaturesResult(valid: false, signed: true);
                 _message = new SignatureValidationMessage(
                     TestResources.SignedPackageLeafId,
                     TestResources.SignedPackageLeaf1Version,
@@ -353,10 +351,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     TestResources.Leaf1Thumbprint);
                 _fullVerifyResult = new VerifySignaturesResult(
                     valid: false,
+                    signed: true,
                     results: new[]
                     {
                         new InvalidSignaturePackageVerificationResult(
-                            SignatureVerificationStatus.Illegal,
+                            SignatureVerificationStatus.Suspect,
                             new[]
                             {
                                 SignatureLog.Issue(

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -122,6 +122,24 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 output);
         }
 
+        public async Task<MemoryStream> AuthorSignPackageStreamAsync(
+            Stream inputPackageStream,
+            X509Certificate2 signingCertificate,
+            ITestOutputHelper output)
+        {
+            var timestampUri = await GetTimestampServiceUrlAsync();
+
+            var packageBytes = await GenerateSignedPackageBytesAsync(
+                inputPackageStream,
+                new AuthorSignPackageRequest(signingCertificate, HashAlgorithmName.SHA256),
+                timestampUri,
+                output);
+
+            var memoryStream = new MemoryStream();
+            memoryStream.Write(packageBytes, 0, packageBytes.Length);
+            return memoryStream;
+        }
+
         public async Task<MemoryStream> RepositorySignPackageStreamAsync(
             Stream inputPackageStream,
             X509Certificate2 signingCertificate,


### PR DESCRIPTION
In this change:

* The process signature job now properly Rejects untrusted author signing certificate when the package is repository countersigned
* Updates NuGet client dependencies
* Test improvements
  * Fixed several issue where responders were disposed more than intended. This fixed several flaky tests
  * Properly wait for responder's responses to expire instead of sleeping by a second

Fixes https://github.com/NuGet/Engineering/issues/1417