### PR TITLE
[Orchestrator] Add scan only validator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -66,6 +66,7 @@ namespace NuGet.Services.Validation.Orchestrator
         private const string PackageSignatureBindingKey = PackageSigningSectionName;
         private const string PackageCertificatesBindingKey = PackageCertificatesSectionName;
         private const string ScanAndSignBindingKey = ScanAndSignSectionName;
+        private const string ScanBindingKey = "Scan";
         private const string ValidationStorageBindingKey = "ValidationStorage";
         private const string OrchestratorBindingKey = "Orchestrator";
 
@@ -362,6 +363,7 @@ namespace NuGet.Services.Validation.Orchestrator
             ConfigurePackageSigningValidators(containerBuilder);
             ConfigurePackageCertificatesValidator(containerBuilder);
             ConfigureScanAndSignProcessor(containerBuilder);
+            ConfigureScanValidator(containerBuilder);
 
             return new AutofacServiceProvider(containerBuilder.Build());
         }
@@ -465,6 +467,21 @@ namespace NuGet.Services.Validation.Orchestrator
             builder
                 .RegisterType<ScanAndSignProcessor>()
                 .WithKeyedParameter(typeof(IValidatorStateService), ScanAndSignBindingKey)
+                .AsSelf();
+        }
+
+        private static void ConfigureScanValidator(ContainerBuilder builder)
+        {
+            builder
+                .RegisterType<ValidatorStateService>()
+                .WithParameter(
+                    (pi, ctx) => pi.ParameterType == typeof(string),
+                    (pi, ctx) => ValidatorName.ScanOnly)
+                .Keyed<IValidatorStateService>(ScanBindingKey);
+
+            builder
+                .RegisterType<ScanValidator>()
+                .WithKeyedParameter(typeof(IValidatorStateService), ScanBindingKey)
                 .AsSelf();
         }
 

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -51,6 +51,7 @@
     <Compile Include="DiskMailSender.cs" />
     <Compile Include="Configuration\EmailConfiguration.cs" />
     <Compile Include="Error.cs" />
+    <Compile Include="PackageSigning\Scan\ScanValidator.cs" />
     <Compile Include="Services\IEntityService.cs" />
     <Compile Include="IMessageService.cs" />
     <Compile Include="IPackageStatusProcessor.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/Scan/ScanValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/Scan/ScanValidator.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.Storage;
+using NuGet.Jobs.Validation.ScanAndSign;
+using NuGet.Services.Validation.Vcs;
+using NuGetGallery;
+
+namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
+{
+    [ValidatorName(ValidatorName.ScanOnly)]
+    public class ScanValidator : BaseValidator, IValidator
+    {
+        private readonly IValidationEntitiesContext _validationContext;
+        private readonly IValidatorStateService _validatorStateService;
+        private readonly ICorePackageService _packageService;
+        private readonly ICriteriaEvaluator<Package> _criteriaEvaluator;
+        private readonly IScanAndSignEnqueuer _scanAndSignEnqueuer;
+        private readonly ScanAndSignConfiguration _configuration;
+        private readonly ILogger<ScanAndSignProcessor> _logger;
+
+        public ScanValidator(
+            IValidationEntitiesContext validationContext,
+            IValidatorStateService validatorStateService,
+            ICorePackageService packageService,
+            ICriteriaEvaluator<Package> criteriaEvaluator,
+            IScanAndSignEnqueuer scanAndSignEnqueuer,
+            IOptionsSnapshot<ScanAndSignConfiguration> configurationAccessor,
+            ILogger<ScanAndSignProcessor> logger)
+        {
+            _validationContext = validationContext ?? throw new ArgumentNullException(nameof(validationContext));
+            _validatorStateService = validatorStateService ?? throw new ArgumentNullException(nameof(validatorStateService));
+            _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
+            _criteriaEvaluator = criteriaEvaluator ?? throw new ArgumentNullException(nameof(criteriaEvaluator));
+            _scanAndSignEnqueuer = scanAndSignEnqueuer ?? throw new ArgumentNullException(nameof(scanAndSignEnqueuer));
+
+            if (configurationAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(configurationAccessor));
+            }
+            if (configurationAccessor.Value == null)
+            {
+                throw new ArgumentException($"{nameof(configurationAccessor.Value)} property is null", nameof(configurationAccessor));
+            }
+            _configuration = configurationAccessor.Value;
+
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            configurationAccessor = configurationAccessor ?? throw new ArgumentNullException(nameof(configurationAccessor));
+
+            if (configurationAccessor.Value == null)
+            {
+                throw new ArgumentException($"{nameof(configurationAccessor.Value)} property is null", nameof(configurationAccessor));
+            }
+
+            _configuration = configurationAccessor.Value;
+        }
+
+        public async Task<IValidationResult> GetResultAsync(IValidationRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var validatorStatus = await _validatorStateService.GetStatusAsync(request);
+
+            return validatorStatus.ToValidationResult();
+        }
+
+        public async Task<IValidationResult> StartAsync(IValidationRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var validatorStatus = await _validatorStateService.GetStatusAsync(request);
+
+            if (validatorStatus.State != ValidationStatus.NotStarted)
+            {
+                _logger.LogWarning(
+                    "Scan and Sign validation with validation Id {ValidationId} ({PackageId} {PackageVersion}) has already started.",
+                    request.ValidationId,
+                    request.PackageId,
+                    request.PackageVersion);
+
+                return validatorStatus.ToValidationResult();
+            }
+
+            if (ShouldSkipScan(request))
+            {
+                return ValidationResult.Succeeded;
+            }
+
+            await _scanAndSignEnqueuer.EnqueueScanAsync(request.ValidationId, request.NupkgUrl);
+
+            var result = await _validatorStateService.TryAddValidatorStatusAsync(request, validatorStatus, ValidationStatus.Incomplete);
+
+            return result.ToValidationResult();
+        }
+
+        private bool ShouldSkipScan(IValidationRequest request)
+        {
+            var package = _packageService.FindPackageByIdAndVersionStrict(
+                request.PackageId,
+                request.PackageVersion);
+
+            if (!_criteriaEvaluator.IsMatch(_configuration.PackageCriteria, package))
+            {
+                _logger.LogInformation(
+                    "The scan for {ValidationId} ({PackageId} {PackageVersion}) was skipped due to package criteria configuration.",
+                    request.ValidationId,
+                    request.PackageId,
+                    request.PackageVersion);
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/Scan/ScanValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/Scan/ScanValidator.cs
@@ -86,7 +86,7 @@ namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
             if (validatorStatus.State != ValidationStatus.NotStarted)
             {
                 _logger.LogWarning(
-                    "Scan and Sign validation with validation Id {ValidationId} ({PackageId} {PackageVersion}) has already started.",
+                    "Scan only validation with validation Id {ValidationId} ({PackageId} {PackageVersion}) has already started.",
                     request.ValidationId,
                     request.PackageId,
                     request.PackageVersion);

--- a/src/Validation.Common.Job/Validation/ValidatorName.cs
+++ b/src/Validation.Common.Job/Validation/ValidatorName.cs
@@ -8,6 +8,7 @@ namespace NuGet.Jobs.Validation
         public const string Vcs = "VcsValidator";
         public const string PackageCertificate = "PackageCertificatesValidator";
         public const string ScanAndSign = "ScanAndSign";
+        public const string ScanOnly = "ScanOnly";
         public const string PackageSignatureProcessor = "PackageSigningValidator";
         public const string PackageSignatureValidator = "PackageSigningValidator2";
     }

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
@@ -51,10 +51,14 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             _blobProvider.Verify(x => x.GetBlobFromUrl(It.IsAny<string>()), Times.Never);
         }
 
-        [Fact]
-        public async Task DeletesTheBlobWhenThereIsNupkgUrl()
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        public async Task WhenThereIsNupkgUrl_DeletesTheBlobIfRepositorySigningIsEnabled(bool repositorySigningEnabled, bool expectsBlobDeleted)
         {
             // Arrange
+            _config.RepositorySigningEnabled = repositorySigningEnabled;
+
             var request = new ValidationRequest(Guid.NewGuid(), 42, "somepackage", "somversion", "https://nuget.test/package.nupkg");
             var nupkgUrl = "http://example/packages/nuget.versioning.4.6.0.nupkg";
 
@@ -80,8 +84,17 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
 
             // Assert
             _validatorStateServiceMock.Verify(x => x.GetStatusAsync(request), Times.Once);
-            _blobProvider.Verify(x => x.GetBlobFromUrl(nupkgUrl), Times.Once);
-            blob.Verify(x => x.DeleteIfExistsAsync(), Times.Once);
+
+            if (expectsBlobDeleted)
+            {
+                _blobProvider.Verify(x => x.GetBlobFromUrl(nupkgUrl), Times.Once);
+                blob.Verify(x => x.DeleteIfExistsAsync(), Times.Once);
+            }
+            else
+            {
+                _blobProvider.Verify(x => x.GetBlobFromUrl(nupkgUrl), Times.Never);
+                blob.Verify(x => x.DeleteIfExistsAsync(), Times.Never);
+            }
         }
     }
 
@@ -149,6 +162,36 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
                 .Verify(vss => vss.GetStatusAsync(It.IsAny<ValidationRequest>()), Times.Once);
             _validatorStateServiceMock
                 .Verify(vss => vss.GetStatusAsync(It.IsAny<Guid>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task WhenRepositorySigningIsDisabled_SuppressesNupkgUrl()
+        {
+            _config.RepositorySigningEnabled = false;
+
+            var request = new ValidationRequest(Guid.NewGuid(), 42, "somepackage", "somversion", "https://example.com/package.nupkg");
+            var status = new ValidatorStatus
+            {
+                State = ValidationStatus.Incomplete,
+                NupkgUrl = "https://nuget.test/package.nupkg",
+                ValidatorIssues = new List<ValidatorIssue>()
+            };
+
+            _validatorStateServiceMock
+                .Setup(vss => vss.GetStatusAsync(request))
+                .ReturnsAsync(status);
+
+            var result = await _target.GetResultAsync(request);
+
+            _validatorStateServiceMock
+                .Verify(vss => vss.GetStatusAsync(request), Times.Once);
+            _validatorStateServiceMock
+                .Verify(vss => vss.GetStatusAsync(It.IsAny<ValidationRequest>()), Times.Once);
+            _validatorStateServiceMock
+                .Verify(vss => vss.GetStatusAsync(It.IsAny<Guid>()), Times.Never);
+            Assert.Empty(result.Issues);
+            Assert.Equal(status.State, result.Status);
+            Assert.Null(result.NupkgUrl);
         }
     }
 
@@ -221,7 +264,7 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
         }
 
         [Fact]
-        public async Task EnqueuesScanIfRepositorySigningIsDisabled()
+        public async Task EnqueuesScanAndSignEvenIfRepositorySigningIsDisabled()
         {
             _config.RepositorySigningEnabled = false;
 
@@ -232,13 +275,25 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
 
             var result = await _target.StartAsync(_request);
 
+            _packageServiceMock
+                .Verify(p => p.FindPackageRegistrationById(_request.PackageId), Times.Once);
+
             _enqueuerMock
-                .Verify(e => e.EnqueueScanAsync(_request.ValidationId, _request.NupkgUrl), Times.Once);
+                .Verify(e =>
+                    e.EnqueueScanAndSignAsync(
+                        _request.ValidationId,
+                        _request.NupkgUrl,
+                        _config.V3ServiceIndexUrl,
+                        It.Is<List<string>>(l =>
+                            l.Count() == 2 &&
+                            l.Contains("Billy") &&
+                            l.Contains("Bob"))),
+                    Times.Once);
 
             _validatorStateServiceMock
-                .Verify(vss => vss.TryAddValidatorStatusAsync(_request, _status, ValidationStatus.Incomplete), Times.Once);
+                .Verify(v => v.TryAddValidatorStatusAsync(_request, _status, ValidationStatus.Incomplete), Times.Once);
             _validatorStateServiceMock
-                .Verify(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Once);
+                .Verify(v => v.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Once);
         }
 
         [Fact]
@@ -321,10 +376,13 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
                 .Verify(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Never);
         }
 
-        [Fact]
-        public async Task WhenPackageFitsCriteriaAndIsNotRepositorySignedAndRepositorySigningEnabled_DoesNotSkipScanAndSign()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+
+        public async Task WhenPackageFitsCriteriaAndIsNotRepositorySigned_DoesNotSkipScanAndSign(bool repositorySigningEnabled)
         {
-            _config.RepositorySigningEnabled = true;
+            _config.RepositorySigningEnabled = repositorySigningEnabled;
 
             _validationContext.Mock();
             _packageServiceMock
@@ -344,30 +402,6 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
                 .Verify(v =>
                     v.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), ValidationStatus.Incomplete),
                     Times.Once);
-        }
-
-        [Fact]
-        public async Task WhenPackageFitsCriteriaAndIsNotRepositorySignedAndRepositorySigningDisabled_SkipsScan()
-        {
-            _config.RepositorySigningEnabled = false;
-
-            _validationContext.Mock();
-            _packageServiceMock
-                .Setup(p => p.FindPackageRegistrationById(_request.PackageId))
-                .Returns(_packageRegistration);
-
-            _criteriaEvaluatorMock
-                .Setup(ce => ce.IsMatch(It.IsAny<ICriteria>(), It.IsAny<Package>()))
-                .Returns(false);
-
-            var result = await _target.StartAsync(_request);
-
-            Assert.Equal(ValidationStatus.Succeeded, result.Status);
-
-            _enqueuerMock
-                .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
-            _validatorStateServiceMock
-                .Verify(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Never);
         }
 
         private ValidationRequest _request;

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanValidatorFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanValidatorFacts.cs
@@ -1,0 +1,274 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NuGet.Jobs.Validation.PackageSigning.Storage;
+using NuGet.Jobs.Validation.Storage;
+using NuGet.Jobs.Validation.ScanAndSign;
+using NuGet.Services.Validation;
+using NuGet.Services.Validation.Orchestrator;
+using NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign;
+using NuGet.Services.Validation.Vcs;
+using NuGetGallery;
+using Tests.ContextHelpers;
+using Xunit;
+
+namespace Validation.PackageSigning.ScanAndSign.Tests
+{
+    public class ScanValidatorFacts
+    {
+        public class TheGetResultAsyncMethod : ScanValidatorFactsBase
+        {
+            [Fact]
+            public async Task ThrowsWhenRequestIsNull()
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _target.GetResultAsync(null));
+                Assert.Equal("request", ex.ParamName);
+            }
+
+            [Fact]
+            public async Task ForwardsCallToValidatorStateService()
+            {
+                var request = new ValidationRequest(Guid.NewGuid(), 42, "somepackage", "somversion", "https://example.com/package.nupkg");
+                var status = new ValidatorStatus
+                {
+                    State = ValidationStatus.Incomplete,
+                    NupkgUrl = null,
+                    ValidatorIssues = new List<ValidatorIssue>()
+                };
+
+                _validatorStateServiceMock
+                    .Setup(vss => vss.GetStatusAsync(request))
+                    .ReturnsAsync(status);
+
+                var result = await _target.GetResultAsync(request);
+
+                _validatorStateServiceMock
+                    .Verify(vss => vss.GetStatusAsync(request), Times.Once);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.GetStatusAsync(It.IsAny<ValidationRequest>()), Times.Once);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.GetStatusAsync(It.IsAny<Guid>()), Times.Never);
+                Assert.Empty(result.Issues);
+                Assert.Equal(status.State, result.Status);
+                Assert.Equal(status.NupkgUrl, result.NupkgUrl);
+            }
+
+            [Fact]
+            public async Task DoesNotSkipCheckWhenPackageFitsCriteria()
+            {
+                var request = new ValidationRequest(Guid.NewGuid(), 42, "somepackage", "somversion", "https://example.com/package.nupkg");
+                var status = new ValidatorStatus
+                {
+                    State = ValidationStatus.NotStarted,
+                    NupkgUrl = null,
+                    ValidatorIssues = new List<ValidatorIssue>()
+                };
+
+                _criteriaEvaluatorMock
+                    .Setup(ce => ce.IsMatch(It.IsAny<ICriteria>(), It.IsAny<Package>()))
+                    .Returns(false);
+
+                _validatorStateServiceMock
+                    .Setup(vss => vss.GetStatusAsync(request))
+                    .ReturnsAsync(status);
+
+                var result = await _target.GetResultAsync(request);
+
+                Assert.Equal(ValidationStatus.NotStarted, result.Status);
+
+                _validatorStateServiceMock
+                    .Verify(vss => vss.GetStatusAsync(It.IsAny<ValidationRequest>()), Times.Once);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.GetStatusAsync(It.IsAny<Guid>()), Times.Never);
+            }
+        }
+
+        public class TheStartAsyncMethod : ScanValidatorFactsBase
+        {
+            [Fact]
+            public async Task ThrowsWhenRequestIsNull()
+            {
+                var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => _target.StartAsync(null));
+                Assert.Equal("request", ex.ParamName);
+            }
+
+            [Theory]
+            [InlineData(ValidationStatus.Incomplete, null)]
+            [InlineData(ValidationStatus.Succeeded, "https://example.com/package-output.nupkg")]
+            [InlineData(ValidationStatus.Failed, null)]
+            public async Task DoesNotEnqueueNewOperationIfOneAlreadyExists(ValidationStatus status, string nupkgUrl)
+            {
+                _status.State = status;
+                _status.NupkgUrl = nupkgUrl;
+
+                var result = await _target.StartAsync(_request);
+
+                _enqueuerMock
+                    .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.SaveStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Never);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.TryUpdateValidationStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Never);
+
+                Assert.Equal(_status.State, result.Status);
+                Assert.Equal(_status.NupkgUrl, result.NupkgUrl);
+            }
+
+            [Theory]
+            [InlineData(true)]
+            [InlineData(false)]
+            public async Task WhenPackageHasNoRepositorySignature_Scans(bool repositorySigningEnabled)
+            {
+                _config.RepositorySigningEnabled = repositorySigningEnabled;
+
+                _validationContext.Mock();
+
+                var result = await _target.StartAsync(_request);
+
+                _enqueuerMock
+                    .Verify(e => e.EnqueueScanAsync(_request.ValidationId, _request.NupkgUrl), Times.Once);
+
+                _validatorStateServiceMock
+                    .Verify(vss => vss.TryAddValidatorStatusAsync(_request, _status, ValidationStatus.Incomplete), Times.Once);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Once);
+            }
+
+            [Fact]
+            public async Task WhenPackageHasARepositorySignature_Scans()
+            {
+                _validationContext.Mock(packageSignatures: new[]
+                {
+                    new PackageSignature
+                    {
+                        PackageKey = _request.PackageKey,
+                        Type = PackageSignatureType.Repository,
+                    }
+                });
+
+                var result = await _target.StartAsync(_request);
+
+                _packageServiceMock
+                    .Verify(p => p.FindPackageRegistrationById(It.IsAny<string>()), Times.Never);
+
+                _enqueuerMock
+                    .Verify(e => e.EnqueueScanAsync(_request.ValidationId, _request.NupkgUrl), Times.Once);
+
+                _validatorStateServiceMock
+                    .Verify(vss => vss.TryAddValidatorStatusAsync(_request, _status, ValidationStatus.Incomplete), Times.Once);
+                _validatorStateServiceMock
+                    .Verify(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Once);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+
+            public async Task WhenPackageFitsCriteriaAndIsNotRepositorySigned_Skips(bool repositorySigningEnabled)
+            {
+                _config.RepositorySigningEnabled = repositorySigningEnabled;
+
+                _validationContext.Mock();
+                _packageServiceMock
+                    .Setup(p => p.FindPackageRegistrationById(_request.PackageId))
+                    .Returns(_packageRegistration);
+
+                _criteriaEvaluatorMock
+                    .Setup(ce => ce.IsMatch(It.IsAny<ICriteria>(), It.IsAny<Package>()))
+                    .Returns(false);
+
+                await _target.StartAsync(_request);
+
+                _enqueuerMock
+                    .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+
+                _enqueuerMock
+                    .Verify(e => e.EnqueueScanAndSignAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()), Times.Never);
+
+                _validatorStateServiceMock
+                    .Verify(v =>
+                        v.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()),
+                        Times.Never);
+            }
+
+            private ValidationRequest _request;
+            private ValidatorStatus _status;
+            private PackageRegistration _packageRegistration = new PackageRegistration();
+
+            public TheStartAsyncMethod()
+            {
+                _request = new ValidationRequest(Guid.NewGuid(), 42, "somepackage", "somversion", "https://example.com/package.nupkg");
+                _status = new ValidatorStatus
+                {
+                    State = ValidationStatus.NotStarted,
+                    NupkgUrl = null,
+                    ValidatorIssues = new List<ValidatorIssue>()
+                };
+
+                _validatorStateServiceMock
+                    .Setup(vss => vss.GetStatusAsync(_request))
+                    .ReturnsAsync(_status);
+                _validatorStateServiceMock
+                    .Setup(vss => vss.TryAddValidatorStatusAsync(It.IsAny<IValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()))
+                    .ReturnsAsync(_status);
+            }
+        }
+
+        public class ScanValidatorFactsBase
+        {
+            protected readonly Mock<IValidationEntitiesContext> _validationContext;
+            protected readonly Mock<IValidatorStateService> _validatorStateServiceMock;
+            protected readonly Mock<ICorePackageService> _packageServiceMock;
+            protected Mock<ICriteriaEvaluator<Package>> _criteriaEvaluatorMock;
+            protected readonly Mock<IScanAndSignEnqueuer> _enqueuerMock;
+            protected readonly Mock<ISimpleCloudBlobProvider> _blobProvider;
+            protected readonly Mock<IOptionsSnapshot<ScanAndSignConfiguration>> _optionsMock;
+            protected readonly Mock<ILogger<ScanAndSignProcessor>> _loggerMock;
+            protected readonly ScanAndSignConfiguration _config;
+            protected readonly ScanValidator _target;
+
+            public ScanValidatorFactsBase()
+            {
+                _validationContext = new Mock<IValidationEntitiesContext>();
+                _validatorStateServiceMock = new Mock<IValidatorStateService>();
+                _packageServiceMock = new Mock<ICorePackageService>();
+                _criteriaEvaluatorMock = new Mock<ICriteriaEvaluator<Package>>();
+                _enqueuerMock = new Mock<IScanAndSignEnqueuer>();
+                _loggerMock = new Mock<ILogger<ScanAndSignProcessor>>();
+                _blobProvider = new Mock<ISimpleCloudBlobProvider>();
+                _optionsMock = new Mock<IOptionsSnapshot<ScanAndSignConfiguration>>();
+                _loggerMock = new Mock<ILogger<ScanAndSignProcessor>>();
+
+                _criteriaEvaluatorMock
+                    .Setup(ce => ce.IsMatch(It.IsAny<ICriteria>(), It.IsAny<Package>()))
+                    .Returns(true);
+
+                _config = new ScanAndSignConfiguration();
+
+                _config.V3ServiceIndexUrl = "http://awesome.v3/service/index.json";
+
+                _optionsMock.Setup(o => o.Value).Returns(_config);
+
+                _target = new ScanValidator(
+                    _validationContext.Object,
+                    _validatorStateServiceMock.Object,
+                    _packageServiceMock.Object,
+                    _criteriaEvaluatorMock.Object,
+                    _enqueuerMock.Object,
+                    _optionsMock.Object,
+                    _loggerMock.Object);
+            }
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="ScanAndSignEnqueuerFacts.cs" />
     <Compile Include="ScanAndSignMessageFacts.cs" />
     <Compile Include="ScanAndSignProcessorFacts.cs" />
+    <Compile Include="ScanValidatorFacts.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NuGet.Services.Validation.Orchestrator\NuGet.Services.Validation.Orchestrator.csproj">


### PR DESCRIPTION
Add a validator that does a the scan subset of the `ScanAndSignProcessor`. This will be used to test the scan operation independently of the sign operation. Once `ScanAndSignProcessor` is fully vetted, this validator will be deleted.

Part of https://github.com/NuGet/Engineering/issues/1464