### PR TITLE
SubscriptionProcessor is now set up to use ScopedMessageHandler

### DIFF
--- a/src/Validation.Common.Job/JsonConfigurationJob.cs
+++ b/src/Validation.Common.Job/JsonConfigurationJob.cs
@@ -104,6 +104,7 @@ namespace NuGet.Jobs.Validation
             var containerBuilder = new ContainerBuilder();
             containerBuilder.Populate(services);
 
+            ConfigureAutofacServicesInternal(containerBuilder);
             ConfigureAutofacServices(containerBuilder);
 
             return new AutofacServiceProvider(containerBuilder.Build());
@@ -184,7 +185,12 @@ namespace NuGet.Jobs.Validation
             services.AddLogging();
         }
 
-        protected abstract void ConfigureAutofacServices(ContainerBuilder containerBuilder);
+        protected virtual void ConfigureAutofacServices(ContainerBuilder containerBuilder)
+        {
+        }
         protected abstract void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot);
+        internal virtual void ConfigureAutofacServicesInternal(ContainerBuilder containerBuilder)
+        {
+        }
     }
 }

--- a/src/Validation.Common.Job/JsonConfigurationJob.cs
+++ b/src/Validation.Common.Job/JsonConfigurationJob.cs
@@ -104,7 +104,6 @@ namespace NuGet.Jobs.Validation
             var containerBuilder = new ContainerBuilder();
             containerBuilder.Populate(services);
 
-            ConfigureAutofacServicesInternal(containerBuilder);
             ConfigureAutofacServices(containerBuilder);
 
             return new AutofacServiceProvider(containerBuilder.Build());
@@ -185,12 +184,16 @@ namespace NuGet.Jobs.Validation
             services.AddLogging();
         }
 
-        protected virtual void ConfigureAutofacServices(ContainerBuilder containerBuilder)
-        {
-        }
+        /// <summary>
+        /// Method to be implemented in derived classes to provide Autofac-specific configuration for
+        /// that specific job (like setting up keyed resolution).
+        /// </summary>
+        protected abstract void ConfigureAutofacServices(ContainerBuilder containerBuilder);
+
+        /// <summary>
+        /// Method to be implemented in derived classes to provide DI container configuration
+        /// specific for the job.
+        /// </summary>
         protected abstract void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot);
-        internal virtual void ConfigureAutofacServicesInternal(ContainerBuilder containerBuilder)
-        {
-        }
     }
 }

--- a/src/Validation.PackageSigning.ProcessSignature/Job.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Job.cs
@@ -68,26 +68,12 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
         {
-            const string validateSignatureBindingKey = "ValidateSignatureKey";
-            var signatureValidationMessageHandlerType = typeof(IMessageHandler<SignatureValidationMessage>);
-
             containerBuilder
                 .RegisterType<ValidatorStateService>()
                 .WithParameter(
                     (pi, ctx) => pi.ParameterType == typeof(string),
                     (pi, ctx) => ValidatorName.PackageSignatureProcessor)
                 .As<IValidatorStateService>();
-
-            containerBuilder
-                .RegisterType<ScopedMessageHandler<SignatureValidationMessage>>()
-                .Keyed<IMessageHandler<SignatureValidationMessage>>(validateSignatureBindingKey);
-
-            containerBuilder
-                .RegisterType<SubscriptionProcessor<SignatureValidationMessage>>()
-                .WithParameter(
-                    (parameter, context) => parameter.ParameterType == signatureValidationMessageHandlerType,
-                    (parameter, context) => context.ResolveKeyed(validateSignatureBindingKey, signatureValidationMessageHandlerType))
-                .As<ISubscriptionProcessor<SignatureValidationMessage>>();
         }
     }
 }

--- a/src/Validation.PackageSigning.ProcessSignature/Job.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Job.cs
@@ -68,6 +68,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
         {
+            ConfigureDefaultSubscriptionProcessor(containerBuilder);
+
             containerBuilder
                 .RegisterType<ValidatorStateService>()
                 .WithParameter(

--- a/src/Validation.PackageSigning.ValidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/Job.cs
@@ -44,22 +44,5 @@ namespace Validation.PackageSigning.ValidateCertificate
             services.AddTransient<ITelemetryService, TelemetryService>();
             services.AddSingleton(new TelemetryClient());
         }
-
-        protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
-        {
-            const string validateCertificateBindingKey = "ValidateCertificateKey";
-            var certificateValidationMessageHandlerType = typeof(IMessageHandler<CertificateValidationMessage>);
-
-            containerBuilder
-                .RegisterType<ScopedMessageHandler<CertificateValidationMessage>>()
-                .Keyed<IMessageHandler<CertificateValidationMessage>>(validateCertificateBindingKey);
-
-            containerBuilder
-                .RegisterType<SubscriptionProcessor<CertificateValidationMessage>>()
-                .WithParameter(
-                    (parameter, context) => parameter.ParameterType == certificateValidationMessageHandlerType,
-                    (parameter, context) => context.ResolveKeyed(validateCertificateBindingKey, certificateValidationMessageHandlerType))
-                .As<ISubscriptionProcessor<CertificateValidationMessage>>();
-        }
     }
 }

--- a/src/Validation.PackageSigning.ValidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/Job.cs
@@ -44,5 +44,10 @@ namespace Validation.PackageSigning.ValidateCertificate
             services.AddTransient<ITelemetryService, TelemetryService>();
             services.AddSingleton(new TelemetryClient());
         }
+
+        protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
+        {
+            ConfigureDefaultSubscriptionProcessor(containerBuilder);
+        }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/1501 and https://github.com/NuGet/Engineering/issues/1486

No more copying the same DI setup for injecting the `ScopedMessageHandler` into `SubscriptionProcessor` in every job that derives from `SubcriptionProcessorJob<T>`, easy to forget to do that setup and the consequences are weird.