### PR TITLE
[Revalidate] Slow down based off the Gallery's event rate

### DIFF
--- a/src/NuGet.Services.Revalidate/Configuration/ApplicationInsightsConfiguration.cs
+++ b/src/NuGet.Services.Revalidate/Configuration/ApplicationInsightsConfiguration.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.Revalidate
+{
+    /// <summary>
+    /// The configuration needed to query an Application Insights account using
+    /// the REST endpoints.
+    /// </summary>
+    public class ApplicationInsightsConfiguration
+    {
+        /// <summary>
+        /// The Application Insights account identifier.
+        /// </summary>
+        public string AppId { get; set; }
+
+        /// <summary>
+        /// The API Key used to access the Application Insights account.
+        /// </summary>
+        public string ApiKey { get; set; }
+    }
+}

--- a/src/NuGet.Services.Revalidate/Configuration/RevalidationConfiguration.cs
+++ b/src/NuGet.Services.Revalidate/Configuration/RevalidationConfiguration.cs
@@ -41,6 +41,11 @@ namespace NuGet.Services.Revalidate
         public HealthConfiguration Health { get; set; }
 
         /// <summary>
+        /// The configurations to authenticate to Application Insight's REST endpoints.
+        /// </summary>
+        public ApplicationInsightsConfiguration AppInsights { get; set; }
+
+        /// <summary>
         /// The configurations used by the in-memory queue of revalidations to start.
         /// </summary>
         public RevalidationQueueConfiguration Queue { get; set; }

--- a/src/NuGet.Services.Revalidate/Job.cs
+++ b/src/NuGet.Services.Revalidate/Job.cs
@@ -97,6 +97,7 @@ namespace NuGet.Services.Revalidate
             services.AddSingleton(provider => provider.GetRequiredService<IOptionsSnapshot<RevalidationConfiguration>>().Value);
             services.AddSingleton(provider => provider.GetRequiredService<IOptionsSnapshot<RevalidationConfiguration>>().Value.Initialization);
             services.AddSingleton(provider => provider.GetRequiredService<IOptionsSnapshot<RevalidationConfiguration>>().Value.Health);
+            services.AddSingleton(provider => provider.GetRequiredService<IOptionsSnapshot<RevalidationConfiguration>>().Value.AppInsights);
             services.AddSingleton(provider => provider.GetRequiredService<IOptionsSnapshot<RevalidationConfiguration>>().Value.Queue);
 
             services.AddScoped<IGalleryContext>(provider =>
@@ -112,13 +113,14 @@ namespace NuGet.Services.Revalidate
 
             services.AddTransient<IPackageRevalidationStateService, PackageRevalidationStateService>();
             services.AddTransient<IRevalidationJobStateService, RevalidationJobStateService>();
-            services.AddTransient<NuGetGallery.IRevalidationStateService, NuGetGallery.RevalidationStateService>();
+            services.AddTransient<IRevalidationStateService, RevalidationStateService>();
 
             // Initialization
             services.AddTransient<IPackageFinder, PackageFinder>();
             services.AddTransient<InitializationManager>();
 
             // Revalidation
+            services.AddTransient<IGalleryService, GalleryService>();
             services.AddTransient<IHealthService, HealthService>();
             services.AddTransient<IRevalidationQueue, RevalidationQueue>();
             services.AddTransient<IRevalidationService, RevalidationService>();

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -44,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configuration\HealthConfiguration.cs" />
+    <Compile Include="Configuration\ApplicationInsightsConfiguration.cs" />
     <Compile Include="Configuration\InitializationConfiguration.cs" />
     <Compile Include="Configuration\RevalidationQueueConfiguration.cs" />
     <Compile Include="Extensions\IEnumerableExtensions.cs" />
@@ -52,7 +54,9 @@
     <Compile Include="Initialization\IPackageFinder.cs" />
     <Compile Include="Initialization\PackageFinder.cs" />
     <Compile Include="Initialization\PackageRegistrationInformation.cs" />
+    <Compile Include="Services\GalleryService.cs" />
     <Compile Include="Services\HealthService.cs" />
+    <Compile Include="Services\IGalleryService.cs" />
     <Compile Include="Services\IHealthService.cs" />
     <Compile Include="Services\IRevalidationQueue.cs" />
     <Compile Include="Services\IRevalidationJobStateService.cs" />

--- a/src/NuGet.Services.Revalidate/Services/GalleryService.cs
+++ b/src/NuGet.Services.Revalidate/Services/GalleryService.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace NuGet.Services.Revalidate
+{
+    public class GalleryService : IGalleryService
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ApplicationInsightsConfiguration _appInsightsConfig;
+        private readonly ILogger<GalleryService> _logger;
+
+        public GalleryService(
+            HttpClient httpClient,
+            RevalidationConfiguration config,
+            ApplicationInsightsConfiguration appInsightsConfig,
+            ILogger<GalleryService> logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _appInsightsConfig = appInsightsConfig ?? throw new ArgumentNullException(nameof(appInsightsConfig));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<int> CountEventsInPastHourAsync()
+        {
+            try
+            {
+                var query = HttpUtility.UrlPathEncode(
+                    "customMetrics | " +
+                    "where name == \"PackagePush\" or name == \"PackageUnlisted\" or name == \"PackageListed\" | " +
+                    "summarize sum(value)");
+
+                using (var request = new HttpRequestMessage())
+                {
+                    request.RequestUri = new Uri($"https://api.applicationinsights.io/v1/apps/{_appInsightsConfig.AppId}/query?timespan=PT1H&query={query}");
+                    request.Method = HttpMethod.Get;
+
+                    request.Headers.Add("x-api-key", _appInsightsConfig.ApiKey);
+
+                    using (var response = await _httpClient.SendAsync(request))
+                    {
+                        response.EnsureSuccessStatusCode();
+
+                        var json = await response.Content.ReadAsStringAsync();
+                        var data = JsonConvert.DeserializeObject<QueryResult>(json);
+
+                        if (data.Tables == null || data.Tables.Length != 1 ||
+                            data.Tables[0].Rows == null || data.Tables[0].Rows.Length != 1 ||
+                            data.Tables[0].Rows[0] == null || data.Tables[0].Rows[0].Length != 1)
+                        {
+                            throw new InvalidOperationException("Malformed response content");
+                        }
+
+                        // Get the first row's first column's value.
+                        return data.Tables[0].Rows[0][0];
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(0, e, "Exception thrown when getting the Gallery's package event rate.");
+
+                throw new InvalidOperationException("Exception thrown when getting the Gallery's package event rate.", e);
+            }
+        }
+
+        private class QueryResult
+        {
+            public QueryTable[] Tables { get; set; }
+        }
+
+        private class QueryTable
+        {
+            public int[][] Rows { get; set; }
+        }
+    }
+}

--- a/src/NuGet.Services.Revalidate/Services/GalleryService.cs
+++ b/src/NuGet.Services.Revalidate/Services/GalleryService.cs
@@ -37,7 +37,7 @@ namespace NuGet.Services.Revalidate
             {
                 using (var request = new HttpRequestMessage())
                 {
-                    request.RequestUri = new Uri($"https://api.applicationinsights.io/v1/apps/{_appInsightsConfig.AppId}/query?timespan=PT1H&query={query}");
+                    request.RequestUri = new Uri($"https://api.applicationinsights.io/v1/apps/{_appInsightsConfig.AppId}/query?timespan=PT1H&query={GalleryEventsQuery}");
                     request.Method = HttpMethod.Get;
 
                     request.Headers.Add("x-api-key", _appInsightsConfig.ApiKey);

--- a/src/NuGet.Services.Revalidate/Services/IGalleryService.cs
+++ b/src/NuGet.Services.Revalidate/Services/IGalleryService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Revalidate
+{
+    public interface IGalleryService
+    {
+        /// <summary>
+        /// Count the number of gallery events (package pushes, listing, and unlisting) in the past hour.
+        /// </summary>
+        /// <returns>The number of gallery events in the past hour.</returns>
+        Task<int> CountEventsInPastHourAsync();
+    }
+}

--- a/src/NuGet.Services.Revalidate/Settings/dev.json
+++ b/src/NuGet.Services.Revalidate/Settings/dev.json
@@ -19,15 +19,15 @@
     "MinPackageEventRate": 120,
     "MaxPackageEventRate": 500,
 
+    "AppInsights": {
+      "AppId": "46f13c7d-635f-42c3-8120-593edeaad426",
+      "ApiKey": "$$Dev-ApplicationInsights-ApiKey-Gallery-RevalidationJob$$"
+    },
+
     "Queue": {
       "MaximumAttempts": 5,
       "SleepBetweenAttempts": "00:05:00"
     }
-  },
-
-  "Storage": {
-    "ConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$",
-    "Container": "revalidations"
   },
 
   "GalleryDb": {
@@ -43,6 +43,8 @@
     "ConnectionString": "Endpoint=sb://nugetdev.servicebus.windows.net/;SharedAccessKeyName=gallery;SharedAccessKey=$$Dev-ServiceBus-SharedAccessKey-Validation-GallerySender$$",
     "TopicPath": "validation"
   },
+
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/src/NuGet.Services.Revalidate/Settings/int.json
+++ b/src/NuGet.Services.Revalidate/Settings/int.json
@@ -19,6 +19,11 @@
     "MinPackageEventRate": 120,
     "MaxPackageEventRate": 500,
 
+    "AppInsights": {
+      "AppId": "718e0c81-9132-4bf2-b24b-aa625dafd800",
+      "ApiKey": "$$Int-ApplicationInsights-ApiKey-Gallery-RevalidationJob$$"
+    },
+
     "Queue": {
       "MaximumAttempts": 5,
       "SleepBetweenAttempts": "00:05:00"
@@ -38,6 +43,8 @@
     "ConnectionString": "Endpoint=sb://nugetint.servicebus.windows.net/;SharedAccessKeyName=gallery;SharedAccessKey=$$Int-ServiceBus-SharedAccessKey-Validation-GallerySender$$",
     "TopicPath": "validation"
   },
+
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",

--- a/src/NuGet.Services.Revalidate/Settings/prod.json
+++ b/src/NuGet.Services.Revalidate/Settings/prod.json
@@ -19,6 +19,11 @@
     "MinPackageEventRate": 120,
     "MaxPackageEventRate": 500,
 
+    "AppInsights": {
+      "AppId": "338f6804-b1a9-4fe3-bba7-c93064e7ae7b",
+      "ApiKey": "$$Prod-ApplicationInsights-ApiKey-Gallery-RevalidationJob$$"
+    },
+
     "Queue": {
       "MaximumAttempts": 5,
       "SleepBetweenAttempts": "00:05:00"
@@ -38,6 +43,8 @@
     "ConnectionString": "Endpoint=sb://nugetprod.servicebus.windows.net/;SharedAccessKeyName=gallery;SharedAccessKey=$$Prod-ServiceBus-SharedAccessKey-Validation-GallerySender$$",
     "TopicPath": "validation"
   },
+
+  "PackageDownloadTimeout": "00:10:00",
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",


### PR DESCRIPTION
This makes the revalidate job slow down if it detects package events on the Gallery.

Part of: https://github.com/NuGet/Engineering/issues/1441