### PR TITLE
Update repository signing certificate

### DIFF
--- a/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
@@ -20,7 +20,7 @@
   },
   "ProcessSignature": {
     "AllowedRepositorySigningCertificates": [
-      "cf7ac17ad047ecd5fdc36822031b12d4ef078b6f2b4c5e6ba41f8ff2cf4bad67"
+      "0e5f38f57dc1bcc806d8494f4f90fbcedd988b46760709cbeec6f4219aa6157d"
     ],
     "V3ServiceIndexUrl": "https://api.nuget.org/v3/index.json",
     "CommitRepositorySignatures":  false


### PR DESCRIPTION
The previous thumbprint value was incorrect (it was the thumbprint of the certificate used to timestamp packages).

You can verify this is the proper thumbprint as this matches the generated service index: https://github.com/NuGet/NuGet.Services.Index/pull/98/files#diff-f958528513e78f03741f219bf42a1bafR6