### PR TITLE
[Repository Signing] Allow unsigned packages if owner has malformed username

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Symbols\SymbolsMessageEnqueuer.cs" />
     <Compile Include="Symbols\SymbolsValidator.cs" />
     <Compile Include="Symbols\SymbolsValidationConfiguration.cs" />
+    <Compile Include="UsernameHelper.cs" />
     <Compile Include="ValidatingEntitites\IValidatingEntity.cs" />
     <Compile Include="IValidationOutcomeProcessor.cs" />
     <Compile Include="IValidationPackageFileService.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/BaseSignatureProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/BaseSignatureProcessor.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.Storage;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureValidator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ScanAndSign/ScanAndSignProcessor.cs
@@ -20,8 +20,6 @@ namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
     [ValidatorName(ValidatorName.ScanAndSign)]
     public class ScanAndSignProcessor : IProcessor
     {
-        private const string UsernameRegex = @"^[A-Za-z0-9][A-Za-z0-9_\.-]+[A-Za-z0-9]$";
-
         private readonly IValidationEntitiesContext _validationContext;
         private readonly IValidatorStateService _validatorStateService;
         private readonly ICorePackageService _packageService;
@@ -218,7 +216,9 @@ namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
                 return false;
             }
 
-            if (owners.Any(IsInvalidUsername))
+            // TODO: Remove this check.
+            // See: https://github.com/NuGet/Engineering/issues/1582
+            if (owners.Any(UsernameHelper.IsInvalid))
             {
                 _logger.LogWarning(
                     "Package {PackageId} {PackageVersion} has an owner with an invalid username. Scanning instead of signing. {Owners}",
@@ -247,11 +247,6 @@ namespace NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign
                 .Owners
                 .Select(o => o.Username)
                 .ToList();
-        }
-
-        private bool IsInvalidUsername(string username)
-        {
-            return !Regex.IsMatch(username, UsernameRegex, RegexOptions.None, TimeSpan.FromSeconds(5));
         }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/UsernameHelper.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/UsernameHelper.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    // TODO: Remove this type.
+    // See: https://github.com/NuGet/Engineering/issues/1582
+    // See: https://github.com/NuGet/Engineering/issues/1592
+    public static class UsernameHelper
+    {
+        private const string UsernameRegex = @"^[A-Za-z0-9][A-Za-z0-9_\.-]+[A-Za-z0-9]$";
+
+        public static bool IsInvalid(string username)
+        {
+            return !Regex.IsMatch(username, UsernameRegex, RegexOptions.None, TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
@@ -436,6 +436,7 @@ namespace NuGet.Services.Validation.PackageSigning
             protected readonly Mock<IValidatorStateService> _validatorStateService;
             protected readonly Mock<IProcessSignatureEnqueuer> _packageSignatureVerifier;
             protected readonly Mock<ISimpleCloudBlobProvider> _blobProvider;
+            protected readonly Mock<ICorePackageService> _packages;
             protected readonly Mock<IOptionsSnapshot<ScanAndSignConfiguration>> _configAccessor;
             protected readonly Mock<ITelemetryService> _telemetryService;
             protected readonly ILogger<PackageSignatureValidator> _logger;
@@ -449,6 +450,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _validatorStateService = new Mock<IValidatorStateService>();
                 _packageSignatureVerifier = new Mock<IProcessSignatureEnqueuer>();
                 _blobProvider = new Mock<ISimpleCloudBlobProvider>();
+                _packages = new Mock<ICorePackageService>();
                 _config = new ScanAndSignConfiguration();
                 _configAccessor = new Mock<IOptionsSnapshot<ScanAndSignConfiguration>>();
                 _telemetryService = new Mock<ITelemetryService>();
@@ -468,6 +470,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     _validatorStateService.Object,
                     _packageSignatureVerifier.Object,
                     _blobProvider.Object,
+                    _packages.Object,
                     _configAccessor.Object,
                     _telemetryService.Object,
                     _logger);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
@@ -103,6 +103,10 @@ namespace NuGet.Services.Validation.PackageSigning
                 // Arrange
                 _config.RepositorySigningEnabled = true;
 
+                _packages
+                    .Setup(p => p.FindPackageRegistrationById(_validationRequest.Object.PackageId))
+                    .Returns(_packageRegistration);
+
                 _validatorStateService
                     .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
                     .ReturnsAsync(new ValidatorStatus
@@ -114,8 +118,10 @@ namespace NuGet.Services.Validation.PackageSigning
                         ValidatorIssues = new List<ValidatorIssue>(),
                     });
 
-                // Act
-                await Assert.ThrowsAsync<InvalidOperationException>(() => _target.GetResultAsync(_validationRequest.Object));
+                // Act & Assert
+                var e = await Assert.ThrowsAsync<InvalidOperationException>(() => _target.GetResultAsync(_validationRequest.Object));
+
+                Assert.Equal("Package signature validator has an unexpected validation result", e.Message);
             }
 
             [Fact]
@@ -123,6 +129,10 @@ namespace NuGet.Services.Validation.PackageSigning
             {
                 // Arrange
                 _config.RepositorySigningEnabled = true;
+
+                _packages
+                    .Setup(p => p.FindPackageRegistrationById(_validationRequest.Object.PackageId))
+                    .Returns(_packageRegistration);
 
                 _validatorStateService
                     .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
@@ -136,8 +146,41 @@ namespace NuGet.Services.Validation.PackageSigning
                         NupkgUrl = "https://nuget.org/a.nupkg"
                     });
 
+                // Act & Assert
+                var e = await Assert.ThrowsAsync<InvalidOperationException>(() => _target.GetResultAsync(_validationRequest.Object));
+
+                Assert.Equal("Package signature validator has an unexpected validation result", e.Message);
+            }
+
+            [Fact]
+            public async Task WhenRepositorySigningEnabled_IgnoresFailedValidationIfOwnerHasMalformedUsername()
+            {
+                // Arrange
+                _config.RepositorySigningEnabled = true;
+
+                _packages
+                    .Setup(p => p.FindPackageRegistrationById(_validationRequest.Object.PackageId))
+                    .Returns(_packageRegistrationWithBadUsername);
+
+                _validatorStateService
+                    .Setup(x => x.GetStatusAsync(It.IsAny<IValidationRequest>()))
+                    .ReturnsAsync(new ValidatorStatus
+                    {
+                        ValidationId = ValidationId,
+                        PackageKey = PackageKey,
+                        ValidatorName = ValidatorName.PackageSignatureProcessor,
+                        State = ValidationStatus.Failed,
+                        ValidatorIssues = new List<ValidatorIssue>(),
+                    });
+
                 // Act
-                await Assert.ThrowsAsync<InvalidOperationException>(() => _target.GetResultAsync(_validationRequest.Object));
+                var result = await _target.GetResultAsync(_validationRequest.Object);
+
+                // Assert
+                Assert.Null(result.NupkgUrl);
+                Assert.Empty(result.Issues);
+                Assert.Equal(ValidationStatus.Succeeded, result.Status);
+
             }
 
             public static IEnumerable<object[]> PossibleValidationStatuses => possibleValidationStatuses.Select(s => new object[] { s });
@@ -444,6 +487,8 @@ namespace NuGet.Services.Validation.PackageSigning
             protected readonly PackageSignatureValidator _target;
 
             protected readonly ScanAndSignConfiguration _config;
+            protected readonly PackageRegistration _packageRegistration;
+            protected readonly PackageRegistration _packageRegistrationWithBadUsername;
 
             public FactsBase(ITestOutputHelper output)
             {
@@ -465,6 +510,22 @@ namespace NuGet.Services.Validation.PackageSigning
                 _validationRequest.Setup(x => x.ValidationId).Returns(ValidationId);
 
                 _configAccessor.Setup(a => a.Value).Returns(_config);
+
+                _packageRegistration = new PackageRegistration
+                {
+                    Owners = new[]
+                    {
+                        new User { Username = "GoodUsername" }
+                    }
+                };
+
+                _packageRegistrationWithBadUsername = new PackageRegistration
+                {
+                    Owners = new[]
+                    {
+                        new User { Username = "Bad Username" }
+                    }
+                };
 
                 _target = new PackageSignatureValidator(
                     _validatorStateService.Object,


### PR DESCRIPTION
Packages that are owned by users with malformed usernames are not repository signed (see https://github.com/NuGet/Engineering/issues/1582). The validator that verifies that a package is repository signed should take this into account. When all malformed usernames have been removed from the Gallery, this change will be reverted. This is tracked by: https://github.com/NuGet/Engineering/issues/1592

Addresses https://github.com/NuGet/Engineering/issues/1591