### PR TITLE
Removed unused dependency

### DIFF
--- a/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
@@ -50,9 +50,6 @@
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.8.1.3</Version>
     </PackageReference>
-    <PackageReference Include="SharpZipLib">
-      <Version>0.86.0</Version>
-    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.3.1</Version>
     </PackageReference>


### PR DESCRIPTION
SharpZipLib is not used in RevalidateCertificate tests, removed.