### PR TITLE
[Repository Signing] Enable the extraction of repository signatures

### DIFF
--- a/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
@@ -23,7 +23,7 @@
       "cf6ce6768ef858a3a667be1af8aa524d386c7f59a34542713f5dfb0d79acf3dd"
     ],
     "V3ServiceIndexUrl": "https://apidev.nugettest.org/v3/index.json",
-    "CommitRepositorySignatures": false
+    "CommitRepositorySignatures": true
   },
 
   "PackageDownloadTimeout": "00:10:00",

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
@@ -23,7 +23,7 @@
       "cf6ce6768ef858a3a667be1af8aa524d386c7f59a34542713f5dfb0d79acf3dd"
     ],
     "V3ServiceIndexUrl": "https://apiint.nugettest.org/v3/index.json",
-    "CommitRepositorySignatures": false
+    "CommitRepositorySignatures": true
   },
 
   "PackageDownloadTimeout": "00:10:00",

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
@@ -23,7 +23,7 @@
       "0e5f38f57dc1bcc806d8494f4f90fbcedd988b46760709cbeec6f4219aa6157d"
     ],
     "V3ServiceIndexUrl": "https://api.nuget.org/v3/index.json",
-    "CommitRepositorySignatures":  false
+    "CommitRepositorySignatures": true
   },
 
   "PackageDownloadTimeout": "00:10:00",


### PR DESCRIPTION
Updates the Process Signature's configuration so that it saves repository signatures to the database. This MUST be deployed after the Orchestrator's test mode of repository signing has been deployed (see [this](https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetDeployment/pullrequest/549?_a=overview))