### PR TITLE
Status Aggregator - Add traffic manager incident support

### DIFF
--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -61,6 +61,7 @@ namespace StatusAggregator
             serviceCollection.AddTransient<IIncidentParser, OutdatedSearchServiceInstanceIncidentParser>();
             serviceCollection.AddTransient<IIncidentParser, PingdomIncidentParser>();
             serviceCollection.AddTransient<IIncidentParser, ValidationDurationIncidentParser>();
+            serviceCollection.AddTransient<IIncidentParser, TrafficManagerEndpointStatusIncidentParser>();
 
             serviceCollection.AddTransient<IAggregateIncidentParser, AggregateIncidentParser>();
         }

--- a/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
+++ b/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
@@ -32,66 +32,81 @@ namespace StatusAggregator.Parse
             var target = groups[TargetGroupName].Value;
             _logger.LogInformation("Target is {Target}.", target);
 
-            switch (domain)
+            var environment = groups[EnvironmentFilter.EnvironmentGroupName].Value;
+            switch (environment.ToLowerInvariant())
             {
-                case "devnugettest.trafficmanager.net":
-                    switch (target)
+                case "dev":
+                case "test":
+                    switch (domain)
                     {
-                        case "nuget-dev-use2-gallery.cloudapp.net":
-                            affectedComponentPath = ComponentUtility.GetPath(
-                                NuGetServiceComponentFactory.RootName, 
-                                NuGetServiceComponentFactory.GalleryName, 
-                                NuGetServiceComponentFactory.UsncInstanceName);
-                            break;
-                        case "nuget-dev-ussc-gallery.cloudapp.net":
-                            affectedComponentPath = ComponentUtility.GetPath(
-                                NuGetServiceComponentFactory.RootName,
-                                NuGetServiceComponentFactory.GalleryName,
-                                NuGetServiceComponentFactory.UsscInstanceName);
-                            break;
-                        default:
+                        case "devnugettest.trafficmanager.net":
+                            switch (target)
+                            {
+                                case "nuget-dev-use2-gallery.cloudapp.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.GalleryName,
+                                        NuGetServiceComponentFactory.UsncInstanceName);
+                                    break;
+                                case "nuget-dev-ussc-gallery.cloudapp.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.GalleryName,
+                                        NuGetServiceComponentFactory.UsscInstanceName);
+                                    break;
+                                default:
+                                    break;
+                            }
                             break;
                     }
                     break;
-                case "nuget-int-test-failover.trafficmanager.net":
-                    switch (target)
+                case "int":
+                    switch (domain)
                     {
-                        case "nuget-int-0-v2gallery.cloudapp.net":
-                            affectedComponentPath = ComponentUtility.GetPath(
-                                NuGetServiceComponentFactory.RootName,
-                                NuGetServiceComponentFactory.GalleryName,
-                                NuGetServiceComponentFactory.UsncInstanceName);
-                            break;
-                        case "nuget-int-ussc-gallery.cloudapp.net":
-                            affectedComponentPath = ComponentUtility.GetPath(
-                                NuGetServiceComponentFactory.RootName,
-                                NuGetServiceComponentFactory.GalleryName,
-                                NuGetServiceComponentFactory.UsscInstanceName);
-                            break;
-                        default:
+                        case "nuget-int-test-failover.trafficmanager.net":
+                            switch (target)
+                            {
+                                case "nuget-int-0-v2gallery.cloudapp.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.GalleryName,
+                                        NuGetServiceComponentFactory.UsncInstanceName);
+                                    break;
+                                case "nuget-int-ussc-gallery.cloudapp.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.GalleryName,
+                                        NuGetServiceComponentFactory.UsscInstanceName);
+                                    break;
+                                default:
+                                    break;
+                            }
                             break;
                     }
                     break;
-                case "nuget-prod-v2gallery.trafficmanager.net":
-                    switch (target)
+                case "prod":
+                    switch (domain)
                     {
-                        case "nuget-prod-0-v2gallery.cloudapp.net":
-                            affectedComponentPath = ComponentUtility.GetPath(
-                                NuGetServiceComponentFactory.RootName,
-                                NuGetServiceComponentFactory.GalleryName,
-                                NuGetServiceComponentFactory.UsncInstanceName);
-                            break;
-                        case "nuget-prod-ussc-gallery.cloudapp.net":
-                            affectedComponentPath = ComponentUtility.GetPath(
-                                NuGetServiceComponentFactory.RootName,
-                                NuGetServiceComponentFactory.GalleryName,
-                                NuGetServiceComponentFactory.UsscInstanceName);
-                            break;
-                        default:
+                        case "nuget-prod-v2gallery.trafficmanager.net":
+                            switch (target)
+                            {
+                                case "nuget-prod-0-v2gallery.cloudapp.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.GalleryName,
+                                        NuGetServiceComponentFactory.UsncInstanceName);
+                                    break;
+                                case "nuget-prod-ussc-gallery.cloudapp.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.GalleryName,
+                                        NuGetServiceComponentFactory.UsscInstanceName);
+                                    break;
+                                default:
+                                    break;
+                            }
                             break;
                     }
-                    break;
-                default:
                     break;
             }
 

--- a/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
+++ b/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Incidents;
 using NuGet.Services.Status;
 using System.Collections.Generic;

--- a/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
+++ b/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
@@ -50,7 +50,7 @@ namespace StatusAggregator.Parse
                                 NuGetServiceComponentFactory.UsscInstanceName);
                             break;
                         default:
-                            return false;
+                            break;
                     }
                     break;
                 case "nuget-int-test-failover.trafficmanager.net":
@@ -69,7 +69,7 @@ namespace StatusAggregator.Parse
                                 NuGetServiceComponentFactory.UsscInstanceName);
                             break;
                         default:
-                            return false;
+                            break;
                     }
                     break;
                 case "nuget-prod-v2gallery.trafficmanager.net":
@@ -88,14 +88,14 @@ namespace StatusAggregator.Parse
                                 NuGetServiceComponentFactory.UsscInstanceName);
                             break;
                         default:
-                            return false;
+                            break;
                     }
                     break;
                 default:
-                    return false;
+                    break;
             }
 
-            return true;
+            return affectedComponentPath != null;
         }
 
         protected override bool TryParseAffectedComponentStatus(Incident incident, GroupCollection groups, out ComponentStatus affectedComponentStatus)

--- a/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
+++ b/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
@@ -58,6 +58,25 @@ namespace StatusAggregator.Parse
                                     break;
                             }
                             break;
+                        case "nugetapidev.trafficmanager.net":
+                            switch (target)
+                            {
+                                case "az635243.vo.msecnd.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.RestoreName,
+                                        NuGetServiceComponentFactory.V3ProtocolName,
+                                        NuGetServiceComponentFactory.GlobalRegionName);
+                                    break;
+                                case "nugetdevcnredirect.trafficmanager.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.RestoreName,
+                                        NuGetServiceComponentFactory.V3ProtocolName,
+                                        NuGetServiceComponentFactory.ChinaRegionName);
+                                    break;
+                            }
+                            break;
                     }
                     break;
                 case "int":
@@ -103,6 +122,25 @@ namespace StatusAggregator.Parse
                                         NuGetServiceComponentFactory.UsscInstanceName);
                                     break;
                                 default:
+                                    break;
+                            }
+                            break;
+                        case "nugetapiprod.trafficmanager.net":
+                            switch (target)
+                            {
+                                case "az320820.vo.msecnd.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.RestoreName,
+                                        NuGetServiceComponentFactory.V3ProtocolName,
+                                        NuGetServiceComponentFactory.GlobalRegionName);
+                                    break;
+                                case "nugetprodcnredirect.trafficmanager.net":
+                                    affectedComponentPath = ComponentUtility.GetPath(
+                                        NuGetServiceComponentFactory.RootName,
+                                        NuGetServiceComponentFactory.RestoreName,
+                                        NuGetServiceComponentFactory.V3ProtocolName,
+                                        NuGetServiceComponentFactory.ChinaRegionName);
                                     break;
                             }
                             break;

--- a/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
+++ b/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
@@ -54,8 +54,6 @@ namespace StatusAggregator.Parse
                                         NuGetServiceComponentFactory.GalleryName,
                                         NuGetServiceComponentFactory.UsscInstanceName);
                                     break;
-                                default:
-                                    break;
                             }
                             break;
                         case "nugetapidev.trafficmanager.net":
@@ -97,8 +95,6 @@ namespace StatusAggregator.Parse
                                         NuGetServiceComponentFactory.GalleryName,
                                         NuGetServiceComponentFactory.UsscInstanceName);
                                     break;
-                                default:
-                                    break;
                             }
                             break;
                     }
@@ -120,8 +116,6 @@ namespace StatusAggregator.Parse
                                         NuGetServiceComponentFactory.RootName,
                                         NuGetServiceComponentFactory.GalleryName,
                                         NuGetServiceComponentFactory.UsscInstanceName);
-                                    break;
-                                default:
                                     break;
                             }
                             break;

--- a/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
+++ b/src/StatusAggregator/Parse/TrafficManagerEndpointStatusIncidentParser.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Services.Incidents;
+using NuGet.Services.Status;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace StatusAggregator.Parse
+{
+    public class TrafficManagerEndpointStatusIncidentParser : EnvironmentPrefixIncidentParser
+    {
+        private const string DomainGroupName = "Domain";
+        private const string TargetGroupName = "Target";
+        private static string SubtitleRegEx = $"Traffic Manager for (?<{DomainGroupName}>.*) is reporting (?<{TargetGroupName}>.*) as not Online!";
+
+        private readonly ILogger<TrafficManagerEndpointStatusIncidentParser> _logger;
+
+        public TrafficManagerEndpointStatusIncidentParser(
+            IEnumerable<IIncidentParsingFilter> filters,
+            ILogger<TrafficManagerEndpointStatusIncidentParser> logger)
+            : base(SubtitleRegEx, filters, logger)
+        {
+            _logger = logger;
+        }
+
+        protected override bool TryParseAffectedComponentPath(Incident incident, GroupCollection groups, out string affectedComponentPath)
+        {
+            affectedComponentPath = null;
+
+            var domain = groups[DomainGroupName].Value;
+            _logger.LogInformation("Domain is {Domain}.", domain);
+
+            var target = groups[TargetGroupName].Value;
+            _logger.LogInformation("Target is {Target}.", target);
+
+            switch (domain)
+            {
+                case "devnugettest.trafficmanager.net":
+                    switch (target)
+                    {
+                        case "nuget-dev-use2-gallery.cloudapp.net":
+                            affectedComponentPath = ComponentUtility.GetPath(
+                                NuGetServiceComponentFactory.RootName, 
+                                NuGetServiceComponentFactory.GalleryName, 
+                                NuGetServiceComponentFactory.UsncInstanceName);
+                            break;
+                        case "nuget-dev-ussc-gallery.cloudapp.net":
+                            affectedComponentPath = ComponentUtility.GetPath(
+                                NuGetServiceComponentFactory.RootName,
+                                NuGetServiceComponentFactory.GalleryName,
+                                NuGetServiceComponentFactory.UsscInstanceName);
+                            break;
+                        default:
+                            return false;
+                    }
+                    break;
+                case "nuget-int-test-failover.trafficmanager.net":
+                    switch (target)
+                    {
+                        case "nuget-int-0-v2gallery.cloudapp.net":
+                            affectedComponentPath = ComponentUtility.GetPath(
+                                NuGetServiceComponentFactory.RootName,
+                                NuGetServiceComponentFactory.GalleryName,
+                                NuGetServiceComponentFactory.UsncInstanceName);
+                            break;
+                        case "nuget-int-ussc-gallery.cloudapp.net":
+                            affectedComponentPath = ComponentUtility.GetPath(
+                                NuGetServiceComponentFactory.RootName,
+                                NuGetServiceComponentFactory.GalleryName,
+                                NuGetServiceComponentFactory.UsscInstanceName);
+                            break;
+                        default:
+                            return false;
+                    }
+                    break;
+                case "nuget-prod-v2gallery.trafficmanager.net":
+                    switch (target)
+                    {
+                        case "nuget-prod-0-v2gallery.cloudapp.net":
+                            affectedComponentPath = ComponentUtility.GetPath(
+                                NuGetServiceComponentFactory.RootName,
+                                NuGetServiceComponentFactory.GalleryName,
+                                NuGetServiceComponentFactory.UsncInstanceName);
+                            break;
+                        case "nuget-prod-ussc-gallery.cloudapp.net":
+                            affectedComponentPath = ComponentUtility.GetPath(
+                                NuGetServiceComponentFactory.RootName,
+                                NuGetServiceComponentFactory.GalleryName,
+                                NuGetServiceComponentFactory.UsscInstanceName);
+                            break;
+                        default:
+                            return false;
+                    }
+                    break;
+                default:
+                    return false;
+            }
+
+            return true;
+        }
+
+        protected override bool TryParseAffectedComponentStatus(Incident incident, GroupCollection groups, out ComponentStatus affectedComponentStatus)
+        {
+            affectedComponentStatus = ComponentStatus.Down;
+            return true;
+        }
+    }
+}

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="NuGetServiceComponentFactory.cs" />
     <Compile Include="LogEvents.cs" />
+    <Compile Include="Parse\TrafficManagerEndpointStatusIncidentParser.cs" />
     <Compile Include="StatusAggregatorConfiguration.cs" />
     <Compile Include="Cursor.cs" />
     <Compile Include="EventUpdater.cs" />


### PR DESCRIPTION
This integrates the status job with traffic manager incidents.

The following two types of traffic manager incidents are supported:
- Gallery traffic manager says USNC or USSC is down
- The traffic manager in front of V3 says either Global or China is down