### PR TITLE
Move JsonConfigurationJob to Jobs.Common / Migrate ArchivePackages to JsonConfig

### DIFF
--- a/src/ArchivePackages/ArchivePackages.Job.cs
+++ b/src/ArchivePackages/ArchivePackages.Job.cs
@@ -4,20 +4,22 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
-using System.Diagnostics.Tracing;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Autofac;
 using Dapper;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json.Linq;
 using NuGet.Jobs;
-using NuGet.Services.KeyVault;
-using NuGet.Services.Sql;
+using NuGet.Jobs.Configuration;
 
 namespace ArchivePackages
 {
-    public class Job : JobBase
+    public class Job : JsonConfigurationJob
     {
         private readonly JobEventSource JobEventSourceLog = JobEventSource.Log;
         private const string ContentTypeJson = "application/json";
@@ -26,6 +28,8 @@ namespace ArchivePackages
         private const string DefaultPackagesContainerName = "packages";
         private const string DefaultPackagesArchiveContainerName = "ng-backups";
         private const string DefaultCursorBlobName = "cursor.json";
+
+        private InitializationConfiguration Configuration { get; set; }
 
         /// <summary>
         /// Gets or sets an Azure Storage Uri referring to a container to use as the source for package blobs
@@ -44,6 +48,7 @@ namespace ArchivePackages
         /// DestinationContainerName should be same as the primary destination
         /// </summary>
         public CloudStorageAccount SecondaryDestination { get; set; }
+
         /// <summary>
         /// Destination Container name for both Primary and Secondary destinations. Also, for the cursor blob
         /// </summary>
@@ -53,8 +58,11 @@ namespace ArchivePackages
         /// Blob containing the cursor data. Cursor data comprises of cursorDateTime
         /// </summary>
         public string CursorBlobName { get; set; }
-        
-        private ISqlConnectionFactory _packageDbConnectionFactory;
+
+        /// <summary>
+        /// Gallery database registration, for diagnostics.
+        /// </summary>
+        private SqlConnectionStringBuilder GalleryDatabase { get; set; }
 
         protected CloudBlobContainer SourceContainer { get; private set; }
 
@@ -66,33 +74,34 @@ namespace ArchivePackages
 
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {
-            var secretInjector = (ISecretInjector)serviceContainer.GetService(typeof(ISecretInjector));
-            var packageDbConnectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PackageDatabase);
-            _packageDbConnectionFactory = new AzureSqlConnectionFactory(packageDbConnectionString, secretInjector);
+            base.Init(serviceContainer, jobArgsDictionary);
 
-            Source = CloudStorageAccount.Parse(
-                        JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.Source));
+            Configuration = _serviceProvider.GetRequiredService<InitializationConfiguration>();
 
-            PrimaryDestination = CloudStorageAccount.Parse(
-                                    JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.PrimaryDestination));
+            GalleryDatabase = GetDatabaseRegistration<GalleryDbConfiguration>();
 
-            var secondaryDestinationCstr = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.SecondaryDestination);
-            SecondaryDestination = string.IsNullOrEmpty(secondaryDestinationCstr) ? null : CloudStorageAccount.Parse(secondaryDestinationCstr);
+            Source = CloudStorageAccount.Parse(Configuration.Source);
 
-            SourceContainerName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.SourceContainerName) ?? DefaultPackagesContainerName;
+            PrimaryDestination = CloudStorageAccount.Parse(Configuration.PrimaryDestination);
 
-            DestinationContainerName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.DestinationContainerName) ?? DefaultPackagesArchiveContainerName;
+            if (!string.IsNullOrEmpty(Configuration.SecondaryDestination))
+            {
+                SecondaryDestination = CloudStorageAccount.Parse(Configuration.SecondaryDestination);
+            }
+
+            SourceContainerName = Configuration.SourceContainerName ?? DefaultPackagesContainerName;
+            DestinationContainerName = Configuration.DestinationContainerName ?? DefaultPackagesArchiveContainerName;
 
             SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(SourceContainerName);
             PrimaryDestinationContainer = PrimaryDestination.CreateCloudBlobClient().GetContainerReference(DestinationContainerName);
             SecondaryDestinationContainer = SecondaryDestination?.CreateCloudBlobClient().GetContainerReference(DestinationContainerName);
 
-            CursorBlobName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.CursorBlob) ?? DefaultCursorBlobName;
+            CursorBlobName = Configuration.CursorBlob ?? DefaultCursorBlobName;
         }
 
         public override async Task Run()
         {
-            JobEventSourceLog.PreparingToArchive(Source.Credentials.AccountName, SourceContainer.Name, PrimaryDestination.Credentials.AccountName, PrimaryDestinationContainer.Name, _packageDbConnectionFactory.DataSource, _packageDbConnectionFactory.InitialCatalog);
+            JobEventSourceLog.PreparingToArchive(Source.Credentials.AccountName, SourceContainer.Name, PrimaryDestination.Credentials.AccountName, PrimaryDestinationContainer.Name, GalleryDatabase.DataSource, GalleryDatabase.InitialCatalog);
             await Archive(PrimaryDestinationContainer);
 
             // todo: consider reusing package query for primary and secondary archives
@@ -124,9 +133,9 @@ namespace ArchivePackages
 
             JobEventSourceLog.CursorData(cursorDateTime.ToString(DateTimeFormatSpecifier));
 
-            JobEventSourceLog.GatheringPackagesToArchiveFromDb(_packageDbConnectionFactory.DataSource, _packageDbConnectionFactory.InitialCatalog);
+            JobEventSourceLog.GatheringPackagesToArchiveFromDb(GalleryDatabase.DataSource, GalleryDatabase.InitialCatalog);
             List<PackageRef> packages;
-            using (var connection = await _packageDbConnectionFactory.CreateAsync())
+            using (var connection = await OpenSqlConnectionAsync<GalleryDbConfiguration>())
             {
                 packages = (await connection.QueryAsync<PackageRef>(@"
 			    SELECT pr.Id, p.NormalizedVersion AS Version, p.Hash, p.LastEdited, p.Published
@@ -135,7 +144,7 @@ namespace ArchivePackages
 			    WHERE Published > @cursorDateTime OR LastEdited > @cursorDateTime", new { cursorDateTime = cursorDateTime }))
                     .ToList();
             }
-            JobEventSourceLog.GatheredPackagesToArchiveFromDb(packages.Count, _packageDbConnectionFactory.DataSource, _packageDbConnectionFactory.InitialCatalog);
+            JobEventSourceLog.GatheredPackagesToArchiveFromDb(packages.Count, GalleryDatabase.DataSource, GalleryDatabase.InitialCatalog);
 
             var archiveSet = packages
                 .AsParallel()
@@ -193,129 +202,14 @@ namespace ArchivePackages
                 JobEventSourceLog.StartedCopy(sourceBlob.Name, destBlob.Name);
             }
         }
-    }
 
-    [EventSource(Name = "Outercurve-NuGet-Jobs-ArchivePackages")]
-    public class JobEventSource : EventSource
-    {
-        public static readonly JobEventSource Log = new JobEventSource();
-
-        private JobEventSource() { }
-
-        [Event(
-            eventId: 1,
-            Level = EventLevel.Informational,
-            Message = "Preparing to archive packages from {0}/{1} to primary destination {2}/{3} using package data from {4}/{5}")]
-        public void PreparingToArchive(string sourceAccount, string sourceContainer, string destAccount, string destContainer, string dbServer, string dbName) { WriteEvent(1, sourceAccount, sourceContainer, destAccount, destContainer, dbServer, dbName); }
-
-        [Event(
-            eventId: 2,
-            Level = EventLevel.Informational,
-            Message = "Preparing to archive packages to secondary destination {0}/{1}")]
-        public void PreparingToArchive2(string destAccount, string destContainer) { WriteEvent(2, destAccount, destContainer); }
-
-        [Event(
-            eventId: 3,
-            Level = EventLevel.Informational,
-            Message = "Cursor data: CursorDateTime is {0}")]
-        public void CursorData(string cursorDateTime) { WriteEvent(3, cursorDateTime); }
-
-        [Event(
-            eventId: 4,
-            Level = EventLevel.Informational,
-            Task = Tasks.GatheringDbPackages,
-            Opcode = EventOpcode.Start,
-            Message = "Gathering list of packages to archive from {0}/{1}")]
-        public void GatheringPackagesToArchiveFromDb(string dbServer, string dbName) { WriteEvent(4, dbServer, dbName); }
-
-        [Event(
-            eventId: 5,
-            Level = EventLevel.Informational,
-            Task = Tasks.GatheringDbPackages,
-            Opcode = EventOpcode.Stop,
-            Message = "Gathered {0} packages to archive from {1}/{2}")]
-        public void GatheredPackagesToArchiveFromDb(int gathered, string dbServer, string dbName) { WriteEvent(5, gathered, dbServer, dbName); }
-
-        [Event(
-            eventId: 6,
-            Level = EventLevel.Informational,
-            Task = Tasks.ArchivingPackages,
-            Opcode = EventOpcode.Start,
-            Message = "Starting archive of {0} packages.")]
-        public void StartingArchive(int count) { WriteEvent(6, count); }
-
-        [Event(
-            eventId: 7,
-            Level = EventLevel.Informational,
-            Task = Tasks.ArchivingPackages,
-            Opcode = EventOpcode.Stop,
-            Message = "Started archive.")]
-        public void StartedArchive() { WriteEvent(7); }
-
-        [Event(
-            eventId: 8,
-            Level = EventLevel.Informational,
-            Message = "Archive already exists: {0}")]
-        public void ArchiveExists(string blobName) { WriteEvent(8, blobName); }
-
-        [Event(
-            eventId: 9,
-            Level = EventLevel.Warning,
-            Message = "Source Blob does not exist: {0}")]
-        public void SourceBlobMissing(string blobName) { WriteEvent(9, blobName); }
-
-        [Event(
-            eventId: 12,
-            Level = EventLevel.Informational,
-            Task = Tasks.StartingPackageCopy,
-            Opcode = EventOpcode.Start,
-            Message = "Starting copy of {0} to {1}.")]
-        public void StartingCopy(string source, string dest) { WriteEvent(12, source, dest); }
-
-        [Event(
-            eventId: 13,
-            Level = EventLevel.Informational,
-            Task = Tasks.StartingPackageCopy,
-            Opcode = EventOpcode.Stop,
-            Message = "Started copy of {0} to {1}.")]
-        public void StartedCopy(string source, string dest) { WriteEvent(13, source, dest); }
-
-        [Event(
-            eventId: 14,
-            Level = EventLevel.Informational,
-            Message = "NewCursor data: CursorDateTime is {0}")]
-        public void NewCursorData(string cursorDateTime) { WriteEvent(14, cursorDateTime); }
-    }
-
-    public static class Tasks
-    {
-        public const EventTask GatheringDbPackages = (EventTask)0x1;
-        public const EventTask ArchivingPackages = (EventTask)0x2;
-        public const EventTask StartingPackageCopy = (EventTask)0x3;
-    }
-
-    public class PackageRef
-    {
-        public PackageRef(string id, string version, string hash)
+        protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)
         {
-            Id = id;
-            Version = version;
-            Hash = hash;
         }
-        public PackageRef(string id, string version, string hash, DateTime lastEdited)
-            : this(id, version, hash)
+
+        protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
-            LastEdited = lastEdited;
+            ConfigureInitializationSection<InitializationConfiguration>(services, configurationRoot);
         }
-        public PackageRef(string id, string version, string hash, DateTime lastEdited, DateTime published)
-            : this(id, version, hash, lastEdited)
-        {
-            Published = published;
-        }
-        public string Id { get; set; }
-        public string Version { get; set; }
-        public string Hash { get; set; }
-        public DateTime? LastEdited { get; set; }
-        public DateTime? Published { get; set; }
     }
 }

--- a/src/ArchivePackages/ArchivePackages.csproj
+++ b/src/ArchivePackages/ArchivePackages.csproj
@@ -51,9 +51,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="App.config" />
     <None Include="Scripts\*" />
     <None Include="ArchivePackages.nuspec" />
     <None Include="Settings\dev.json" />

--- a/src/ArchivePackages/ArchivePackages.csproj
+++ b/src/ArchivePackages/ArchivePackages.csproj
@@ -44,6 +44,10 @@
   <ItemGroup>
     <Compile Include="ArchivePackages.Job.cs" />
     <Compile Include="ArchivePackages.Program.cs" />
+    <Compile Include="Configuration\InitializationConfiguration.cs" />
+    <Compile Include="JobEventSource.cs" />
+    <Compile Include="JobTasks.cs" />
+    <Compile Include="PackageRef.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -52,6 +56,9 @@
     </None>
     <None Include="Scripts\*" />
     <None Include="ArchivePackages.nuspec" />
+    <None Include="Settings\dev.json" />
+    <None Include="Settings\int.json" />
+    <None Include="Settings\prod.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
@@ -75,9 +82,6 @@
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.27.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>
     </PackageReference>
@@ -85,6 +89,7 @@
       <Version>7.1.2</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\build\sign.targets" Condition="Exists('..\..\build\sign.targets')" />
 </Project>

--- a/src/ArchivePackages/ArchivePackages.nuspec
+++ b/src/ArchivePackages/ArchivePackages.nuspec
@@ -11,12 +11,14 @@
   </metadata>
   <files>
     <file src="bin\$configuration$\*.*" target="bin"/>
-	
+
     <file src="Scripts\ArchivePackages.cmd" />
-	
+
     <file src="Scripts\Functions.ps1" />
     <file src="Scripts\PreDeploy.ps1" />
     <file src="Scripts\PostDeploy.ps1" />
     <file src="Scripts\nssm.exe" />
+
+    <file src="Settings\*.json" target="bin" />
   </files>
 </package>

--- a/src/ArchivePackages/Configuration/InitializationConfiguration.cs
+++ b/src/ArchivePackages/Configuration/InitializationConfiguration.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace ArchivePackages
+{
+    public class InitializationConfiguration
+    {
+        /// <summary>
+        /// Source storage account.
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// Source storage container name.
+        /// </summary>
+        public string SourceContainerName { get; set; }
+
+        /// <summary>
+        /// Primary archive destination.
+        /// </summary>
+        public string PrimaryDestination { get; set; }
+
+        /// <summary>
+        /// Secondary archive destination.
+        /// </summary>
+        public string SecondaryDestination { get; set; }
+
+        /// <summary>
+        /// Source storage container name.
+        /// </summary>
+        public string DestinationContainerName { get; set; }
+
+        /// <summary>
+        /// Cursor blob name.
+        /// </summary>
+        public string CursorBlob { get; set; }
+
+        /// <summary>
+        /// Sleep interval between job run iterations.
+        /// </summary>
+        public int Sleep { get; set; }
+
+        /// <summary>
+        /// Application insights instrumentation key.
+        /// </summary>
+        public string InstrumentationKey { get; set; }
+    }
+}

--- a/src/ArchivePackages/Configuration/InitializationConfiguration.cs
+++ b/src/ArchivePackages/Configuration/InitializationConfiguration.cs
@@ -11,7 +11,7 @@ namespace ArchivePackages
         public string Source { get; set; }
 
         /// <summary>
-        /// Source storage container name.
+        /// Source storage container name (defaults to "packages").
         /// </summary>
         public string SourceContainerName { get; set; }
 
@@ -21,28 +21,18 @@ namespace ArchivePackages
         public string PrimaryDestination { get; set; }
 
         /// <summary>
-        /// Secondary archive destination.
+        /// Secondary archive destination (optional).
         /// </summary>
         public string SecondaryDestination { get; set; }
 
         /// <summary>
-        /// Source storage container name.
+        /// Destination storage container name (defaults to "ng-backups").
         /// </summary>
         public string DestinationContainerName { get; set; }
 
         /// <summary>
-        /// Cursor blob name.
+        /// Cursor blob name (defaults to "cursor.json").
         /// </summary>
         public string CursorBlob { get; set; }
-
-        /// <summary>
-        /// Sleep interval between job run iterations.
-        /// </summary>
-        public int Sleep { get; set; }
-
-        /// <summary>
-        /// Application insights instrumentation key.
-        /// </summary>
-        public string InstrumentationKey { get; set; }
     }
 }

--- a/src/ArchivePackages/JobEventSource.cs
+++ b/src/ArchivePackages/JobEventSource.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics.Tracing;
+
+namespace ArchivePackages
+{
+    [EventSource(Name = "Outercurve-NuGet-Jobs-ArchivePackages")]
+    public class JobEventSource : EventSource
+    {
+        public static readonly JobEventSource Log = new JobEventSource();
+
+        private JobEventSource() { }
+
+        [Event(
+            eventId: 1,
+            Level = EventLevel.Informational,
+            Message = "Preparing to archive packages from {0}/{1} to primary destination {2}/{3} using package data from {4}/{5}")]
+        public void PreparingToArchive(string sourceAccount, string sourceContainer, string destAccount, string destContainer, string dbServer, string dbName) { WriteEvent(1, sourceAccount, sourceContainer, destAccount, destContainer, dbServer, dbName); }
+
+        [Event(
+            eventId: 2,
+            Level = EventLevel.Informational,
+            Message = "Preparing to archive packages to secondary destination {0}/{1}")]
+        public void PreparingToArchive2(string destAccount, string destContainer) { WriteEvent(2, destAccount, destContainer); }
+
+        [Event(
+            eventId: 3,
+            Level = EventLevel.Informational,
+            Message = "Cursor data: CursorDateTime is {0}")]
+        public void CursorData(string cursorDateTime) { WriteEvent(3, cursorDateTime); }
+
+        [Event(
+            eventId: 4,
+            Level = EventLevel.Informational,
+            Task = JobTasks.GatheringDbPackages,
+            Opcode = EventOpcode.Start,
+            Message = "Gathering list of packages to archive from {0}/{1}")]
+        public void GatheringPackagesToArchiveFromDb(string dbServer, string dbName) { WriteEvent(4, dbServer, dbName); }
+
+        [Event(
+            eventId: 5,
+            Level = EventLevel.Informational,
+            Task = JobTasks.GatheringDbPackages,
+            Opcode = EventOpcode.Stop,
+            Message = "Gathered {0} packages to archive from {1}/{2}")]
+        public void GatheredPackagesToArchiveFromDb(int gathered, string dbServer, string dbName) { WriteEvent(5, gathered, dbServer, dbName); }
+
+        [Event(
+            eventId: 6,
+            Level = EventLevel.Informational,
+            Task = JobTasks.ArchivingPackages,
+            Opcode = EventOpcode.Start,
+            Message = "Starting archive of {0} packages.")]
+        public void StartingArchive(int count) { WriteEvent(6, count); }
+
+        [Event(
+            eventId: 7,
+            Level = EventLevel.Informational,
+            Task = JobTasks.ArchivingPackages,
+            Opcode = EventOpcode.Stop,
+            Message = "Started archive.")]
+        public void StartedArchive() { WriteEvent(7); }
+
+        [Event(
+            eventId: 8,
+            Level = EventLevel.Informational,
+            Message = "Archive already exists: {0}")]
+        public void ArchiveExists(string blobName) { WriteEvent(8, blobName); }
+
+        [Event(
+            eventId: 9,
+            Level = EventLevel.Warning,
+            Message = "Source Blob does not exist: {0}")]
+        public void SourceBlobMissing(string blobName) { WriteEvent(9, blobName); }
+
+        [Event(
+            eventId: 12,
+            Level = EventLevel.Informational,
+            Task = JobTasks.StartingPackageCopy,
+            Opcode = EventOpcode.Start,
+            Message = "Starting copy of {0} to {1}.")]
+        public void StartingCopy(string source, string dest) { WriteEvent(12, source, dest); }
+
+        [Event(
+            eventId: 13,
+            Level = EventLevel.Informational,
+            Task = JobTasks.StartingPackageCopy,
+            Opcode = EventOpcode.Stop,
+            Message = "Started copy of {0} to {1}.")]
+        public void StartedCopy(string source, string dest) { WriteEvent(13, source, dest); }
+
+        [Event(
+            eventId: 14,
+            Level = EventLevel.Informational,
+            Message = "NewCursor data: CursorDateTime is {0}")]
+        public void NewCursorData(string cursorDateTime) { WriteEvent(14, cursorDateTime); }
+    }
+}

--- a/src/ArchivePackages/JobTasks.cs
+++ b/src/ArchivePackages/JobTasks.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics.Tracing;
+
+namespace ArchivePackages
+{
+    public static class JobTasks
+    {
+        public const EventTask GatheringDbPackages = (EventTask)0x1;
+
+        public const EventTask ArchivingPackages = (EventTask)0x2;
+
+        public const EventTask StartingPackageCopy = (EventTask)0x3;
+    }
+}

--- a/src/ArchivePackages/PackageRef.cs
+++ b/src/ArchivePackages/PackageRef.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace ArchivePackages
+{
+    public class PackageRef
+    {
+        public PackageRef(string id, string version, string hash)
+        {
+            Id = id;
+            Version = version;
+            Hash = hash;
+        }
+
+        public PackageRef(string id, string version, string hash, DateTime lastEdited)
+            : this(id, version, hash)
+        {
+            LastEdited = lastEdited;
+        }
+
+        public PackageRef(string id, string version, string hash, DateTime lastEdited, DateTime published)
+            : this(id, version, hash, lastEdited)
+        {
+            Published = published;
+        }
+
+        public string Id { get; set; }
+
+        public string Version { get; set; }
+
+        public string Hash { get; set; }
+
+        public DateTime? LastEdited { get; set; }
+
+        public DateTime? Published { get; set; }
+    }
+}

--- a/src/ArchivePackages/Scripts/ArchivePackages.cmd
+++ b/src/ArchivePackages/Scripts/ArchivePackages.cmd
@@ -7,7 +7,7 @@ cd bin
 
 	title #{Jobs.archivepackages.Title}
 
-	start /w archivepackages.exe -Configuration "#{Jobs.archivepackages.Configuration}"
+	start /w archivepackages.exe -Configuration "#{Jobs.archivepackages.Configuration}" -Sleep "#{Jobs.archivepackages.Sleep}" -InstrumentationKey "#{Jobs.archivepackages.ApplicationInsightsInstrumentationKey}"
 
 	echo "Finished #{Jobs.archivepackages.Title}"
 

--- a/src/ArchivePackages/Scripts/ArchivePackages.cmd
+++ b/src/ArchivePackages/Scripts/ArchivePackages.cmd
@@ -7,7 +7,7 @@ cd bin
 
 	title #{Jobs.archivepackages.Title}
 
-    start /w archivepackages.exe -VaultName "#{Deployment.Azure.KeyVault.VaultName}" -ClientId "#{Deployment.Azure.KeyVault.ClientId}" -CertificateThumbprint "#{Deployment.Azure.KeyVault.CertificateThumbprint}" -PackageDatabase "#{Jobs.archivepackages.PackageDatabase}" -Source "#{Jobs.archivepackages.Source}" -PrimaryDestination "#{Jobs.archivepackages.PrimaryDestination}" -SecondaryDestination "#{Jobs.archivepackages.SecondaryDestination}" -Sleep "#{Jobs.archivepackages.Sleep}" -InstrumentationKey "#{Jobs.archivepackages.ApplicationInsightsInstrumentationKey}"
+	start /w archivepackages.exe -Configuration "#{Jobs.archivepackages.Configuration}"
 
 	echo "Finished #{Jobs.archivepackages.Title}"
 

--- a/src/ArchivePackages/Settings/dev.json
+++ b/src/ArchivePackages/Settings/dev.json
@@ -2,9 +2,7 @@
   "Initialization": {
     "Source": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$",
     "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$",
-    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetdev1;AccountKey=$$Dev-NuGetDev1Storage-Key$$",
-    "Sleep": "600000",
-    "InstrumentationKey": "$$Dev-ApplicationInsightsV2Gallery-InstrumentationKey$$"
+    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetdev1;AccountKey=$$Dev-NuGetDev1Storage-Key$$"
   },
 
   "GalleryDb": {

--- a/src/ArchivePackages/Settings/dev.json
+++ b/src/ArchivePackages/Settings/dev.json
@@ -6,7 +6,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.archivepackages.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/ArchivePackages/Settings/dev.json
+++ b/src/ArchivePackages/Settings/dev.json
@@ -1,0 +1,20 @@
+{
+  "Initialization": {
+    "Source": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$",
+    "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$",
+    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetdev1;AccountKey=$$Dev-NuGetDev1Storage-Key$$",
+    "Sleep": "600000",
+    "InstrumentationKey": "$$Dev-ApplicationInsightsV2Gallery-InstrumentationKey$$"
+  },
+
+  "GalleryDb": {
+    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
+  },
+
+  "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
+  "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
+  "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",
+  "KeyVault_ValidateCertificate": true,
+  "KeyVault_StoreName": "My",
+  "KeyVault_StoreLocation": "LocalMachine"
+}

--- a/src/ArchivePackages/Settings/dev.json
+++ b/src/ArchivePackages/Settings/dev.json
@@ -8,7 +8,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.validation.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
+    "ConnectionString": "Data Source=tcp:#{Jobs.archivepackages.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/ArchivePackages/Settings/int.json
+++ b/src/ArchivePackages/Settings/int.json
@@ -2,9 +2,7 @@
   "Initialization": {
     "Source": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$",
     "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$",
-    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetint1;AccountKey=$$Int-NuGetInt1Storage-Key$$",
-    "Sleep": "600000",
-    "InstrumentationKey": "$$Int-ApplicationInsightsV2Gallery-InstrumentationKey$$"
+    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetint1;AccountKey=$$Int-NuGetInt1Storage-Key$$"
   },
 
   "GalleryDb": {

--- a/src/ArchivePackages/Settings/int.json
+++ b/src/ArchivePackages/Settings/int.json
@@ -1,0 +1,20 @@
+{
+  "Initialization": {
+    "Source": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$",
+    "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$",
+    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetint1;AccountKey=$$Int-NuGetInt1Storage-Key$$",
+    "Sleep": "600000",
+    "InstrumentationKey": "$$Int-ApplicationInsightsV2Gallery-InstrumentationKey$$"
+  },
+
+  "GalleryDb": {
+    "ConnectionString": "Data Source=tcp:jvhowicii4.database.windows.net;Initial Catalog=nuget-int-0-v2gallery;User ID=$$Int-GalleryDBReadOnly-UserName$$;Password=$$Int-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30"
+  },
+
+  "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
+  "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
+  "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",
+  "KeyVault_ValidateCertificate": true,
+  "KeyVault_StoreName": "My",
+  "KeyVault_StoreLocation": "LocalMachine"
+}

--- a/src/ArchivePackages/Settings/int.json
+++ b/src/ArchivePackages/Settings/int.json
@@ -6,7 +6,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.archivepackages.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;User ID=$$Int-GalleryDBReadOnly-UserName$$;Password=$$Int-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;User ID=$$Int-GalleryDBReadOnly-UserName$$;Password=$$Int-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/ArchivePackages/Settings/int.json
+++ b/src/ArchivePackages/Settings/int.json
@@ -8,7 +8,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:jvhowicii4.database.windows.net;Initial Catalog=nuget-int-0-v2gallery;User ID=$$Int-GalleryDBReadOnly-UserName$$;Password=$$Int-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30"
+    "ConnectionString": "Data Source=tcp:#{Jobs.archivepackages.GalleryDatabaseAddress};Initial Catalog=nuget-int-0-v2gallery;User ID=$$Int-GalleryDBReadOnly-UserName$$;Password=$$Int-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/ArchivePackages/Settings/prod.json
+++ b/src/ArchivePackages/Settings/prod.json
@@ -2,9 +2,7 @@
   "Initialization": {
     "Source": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$",
     "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$",
-    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetprod1;AccountKey=$$Prod-NuGetProd1Storage-Key$$",
-    "Sleep": "600000",
-    "InstrumentationKey": "$$Prod-ApplicationInsightsV2Gallery-InstrumentationKey$$"
+    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetprod1;AccountKey=$$Prod-NuGetProd1Storage-Key$$"
   },
 
   "GalleryDb": {

--- a/src/ArchivePackages/Settings/prod.json
+++ b/src/ArchivePackages/Settings/prod.json
@@ -6,7 +6,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Jobs.archivepackages.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;User ID=$$Prod-GalleryDBReadOnly-UserName$$;Password=$$Prod-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;User ID=$$Prod-GalleryDBReadOnly-UserName$$;Password=$$Prod-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/ArchivePackages/Settings/prod.json
+++ b/src/ArchivePackages/Settings/prod.json
@@ -8,7 +8,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:amejn8fzzh.database.windows.net;Initial Catalog=NuGetGallery;User ID=$$Prod-GalleryDBReadOnly-UserName$$;Password=$$Prod-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Jobs.archivepackages.GalleryDatabaseAddress};Initial Catalog=NuGetGallery;User ID=$$Prod-GalleryDBReadOnly-UserName$$;Password=$$Prod-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/ArchivePackages/Settings/prod.json
+++ b/src/ArchivePackages/Settings/prod.json
@@ -1,0 +1,20 @@
+{
+  "Initialization": {
+    "Source": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$",
+    "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$",
+    "SecondaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetprod1;AccountKey=$$Prod-NuGetProd1Storage-Key$$",
+    "Sleep": "600000",
+    "InstrumentationKey": "$$Prod-ApplicationInsightsV2Gallery-InstrumentationKey$$"
+  },
+
+  "GalleryDb": {
+    "ConnectionString": "Data Source=tcp:amejn8fzzh.database.windows.net;Initial Catalog=NuGetGallery;User ID=$$Prod-GalleryDBReadOnly-UserName$$;Password=$$Prod-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+  },
+
+  "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
+  "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
+  "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",
+  "KeyVault_ValidateCertificate": true,
+  "KeyVault_StoreName": "My",
+  "KeyVault_StoreLocation": "LocalMachine"
+}

--- a/src/Monitoring.RebootSearchInstance/Job.cs
+++ b/src/Monitoring.RebootSearchInstance/Job.cs
@@ -17,7 +17,7 @@ using NuGet.Services.AzureManagement;
 
 namespace NuGet.Monitoring.RebootSearchInstance
 {
-    public class Job : JsonConfigurationJob
+    public class Job : ValidationJobBase
     {
         private const string AzureManagementSectionName = "AzureManagement";
         private const string MonitorConfigurationSectionName = "MonitorConfiguration";

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -167,28 +167,38 @@ namespace NuGet.Jobs
             return connectionFactory.SqlConnectionStringBuilder;
         }
 
+        private ISqlConnectionFactory GetSqlConnectionFactory<T>()
+            where T : IDbConfiguration
+        {
+            return GetSqlConnectionFactory(GetDatabaseKey<T>());
+        }
+
+        private ISqlConnectionFactory GetSqlConnectionFactory(string name)
+        {
+            if (!SqlConnectionFactories.ContainsKey(name))
+            {
+                throw new InvalidOperationException($"Database {name} has not been registered.");
+            }
+
+            return SqlConnectionFactories[name];
+        }
+
         private static string GetDatabaseKey<T>()
         {
             return typeof(T).Name;
         }
 
         /// <summary>
-        /// Create a SqlConnection, for use by validation jobs.
+        /// Create a SqlConnection, for use by jobs that use an EF context.
         /// </summary>
         public Task<SqlConnection> CreateSqlConnectionAsync<T>()
             where T : IDbConfiguration
         {
-            var name = GetDatabaseKey<T>();
-            if (!SqlConnectionFactories.ContainsKey(name))
-            {
-                throw new InvalidOperationException($"Database {name} has not been registered.");
-            }
-
-            return SqlConnectionFactories[name].CreateAsync();
+            return GetSqlConnectionFactory<T>().CreateAsync();
         }
 
         /// <summary>
-        /// Synchronous creation of a SqlConnection, for use by validation jobs.
+        /// Synchronous creation of a SqlConnection, for use by jobs that use an EF context.
         /// </summary>
         public SqlConnection CreateSqlConnection<T>()
             where T : IDbConfiguration
@@ -197,22 +207,16 @@ namespace NuGet.Jobs
         }
 
         /// <summary>
-        /// Opens a SqlConnection.
+        /// Open a SqlConnection, for use by jobs that do NOT use an EF context.
         /// </summary>
         public Task<SqlConnection> OpenSqlConnectionAsync<T>()
             where T : IDbConfiguration
         {
-            var name = GetDatabaseKey<T>();
-            if (!SqlConnectionFactories.ContainsKey(name))
-            {
-                throw new InvalidOperationException($"Database {name} has not been registered.");
-            }
-
-            return SqlConnectionFactories[name].OpenAsync();
+            return GetSqlConnectionFactory<T>().OpenAsync();
         }
 
         /// <summary>
-        /// Creates and opens a SqlConnection, for use by non-validation jobs.
+        /// Opens a SqlConnection, for use by jobs that do NOT use an EF context.
         /// </summary>
         public Task<SqlConnection> OpenSqlConnectionAsync(string connectionStringArgName)
         {
@@ -221,12 +225,7 @@ namespace NuGet.Jobs
                 throw new ArgumentException("Argument cannot be null or empty.", nameof(connectionStringArgName));
             }
 
-            if (!SqlConnectionFactories.ContainsKey(connectionStringArgName))
-            {
-                throw new InvalidOperationException($"Database {connectionStringArgName} has not been registered.");
-            }
-
-            return SqlConnectionFactories[connectionStringArgName].OpenAsync();
+            return GetSqlConnectionFactory(connectionStringArgName).OpenAsync();
         }
     }
 }

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -197,6 +197,21 @@ namespace NuGet.Jobs
         }
 
         /// <summary>
+        /// Opens a SqlConnection.
+        /// </summary>
+        public Task<SqlConnection> OpenSqlConnectionAsync<T>()
+            where T : IDbConfiguration
+        {
+            var name = GetDatabaseKey<T>();
+            if (!SqlConnectionFactories.ContainsKey(name))
+            {
+                throw new InvalidOperationException($"Database {name} has not been registered.");
+            }
+
+            return SqlConnectionFactories[name].OpenAsync();
+        }
+
+        /// <summary>
         /// Creates and opens a SqlConnection, for use by non-validation jobs.
         /// </summary>
         public Task<SqlConnection> OpenSqlConnectionAsync(string connectionStringArgName)

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Configuration\ValidationStorageConfiguration.cs" />
     <Compile Include="Extensions\LoggerExtensions.cs" />
     <Compile Include="Extensions\XElementExtensions.cs" />
+    <Compile Include="JsonConfigurationJob.cs" />
     <Compile Include="SecretReader\ISecretReaderFactory.cs" />
     <Compile Include="SecretReader\SecretReaderFactory.cs" />
     <Compile Include="SmtpUri.cs" />
@@ -70,8 +71,20 @@
     <EmbeddedResource Include="Strings.resx" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Autofac">
+      <Version>4.6.2</Version>
+    </PackageReference>
+    <PackageReference Include="Autofac.Extensions.DependencyInjection">
+      <Version>4.2.0</Version>
+    </PackageReference>
     <PackageReference Include="Dapper.StrongName">
       <Version>1.50.2</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection">
+      <Version>1.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions">
+      <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.27.0</Version>

--- a/src/NuGet.Services.Revalidate/Job.cs
+++ b/src/NuGet.Services.Revalidate/Job.cs
@@ -26,7 +26,7 @@ namespace NuGet.Services.Revalidate
     using GalleryContext = EntitiesContext;
     using IGalleryContext = IEntitiesContext;
 
-    public class Job : JsonConfigurationJob
+    public class Job : ValidationJobBase
     {
         private const string RebuildPreinstalledSetArgumentName = "RebuildPreinstalledSet";
         private const string InitializeArgumentName = "Initialize";

--- a/src/PackageHash/Job.cs
+++ b/src/PackageHash/Job.cs
@@ -18,7 +18,7 @@ using NuGetGallery;
 
 namespace NuGet.Services.PackageHash
 {
-    public class Job : JsonConfigurationJob
+    public class Job : ValidationJobBase
     {
         private const string PackageHashConfigurationSectionName = "PackageHash";
 

--- a/src/Validation.Common.Job/SubcriptionProcessorJob.cs
+++ b/src/Validation.Common.Job/SubcriptionProcessorJob.cs
@@ -12,7 +12,7 @@ using NuGet.Services.ServiceBus;
 
 namespace NuGet.Jobs.Validation
 {
-    public abstract class SubcriptionProcessorJob<T> : JsonConfigurationJob
+    public abstract class SubcriptionProcessorJob<T> : ValidationJobBase
     {
         private const string SubscriptionProcessorConfigurationSectionName = "ServiceBus";
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -61,7 +61,7 @@
     <Compile Include="Storage\ValidatorStateService.cs" />
     <Compile Include="Storage\ValidatorStatusExtensions.cs" />
     <Compile Include="SubcriptionProcessorJob.cs" />
-    <Compile Include="JsonConfigurationJob.cs" />
+    <Compile Include="ValidationJobBase.cs" />
     <Compile Include="SubscriptionProcessorConfiguration.cs" />
     <Compile Include="Validation\IValidatorProvider.cs" />
     <Compile Include="Validation\ValidatorName.cs" />

--- a/src/Validation.Common.Job/ValidationJobBase.cs
+++ b/src/Validation.Common.Job/ValidationJobBase.cs
@@ -37,9 +37,7 @@ namespace NuGet.Jobs.Validation
         protected override void ConfigureDefaultJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
             base.ConfigureDefaultJobServices(services, configurationRoot);
-
-            //services.AddSingleton(new TelemetryClient());
-            //services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
+            
             services.AddTransient<ICommonTelemetryService, CommonTelemetryService>();
             services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
             services.AddTransient<IFileDownloader, PackageDownloader>();

--- a/src/Validation.Common.Job/ValidationJobBase.cs
+++ b/src/Validation.Common.Job/ValidationJobBase.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NuGet.Jobs.Configuration;
+using NuGet.Services.ServiceBus;
+using NuGet.Services.Validation;
+using NuGetGallery;
+using NuGetGallery.Diagnostics;
+
+namespace NuGet.Jobs.Validation
+{
+    public abstract class ValidationJobBase : JsonConfigurationJob
+    {
+        private const string PackageDownloadTimeoutName = "PackageDownloadTimeout";
+
+        /// <summary>
+        /// The maximum number of concurrent connections that can be established to a single server.
+        /// </summary>
+        private const int MaximumConnectionsPerServer = 64;
+
+        public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
+        {
+            base.Init(serviceContainer, jobArgsDictionary);
+
+            ServicePointManager.DefaultConnectionLimit = MaximumConnectionsPerServer;
+        }
+
+        protected override void ConfigureDefaultJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
+        {
+            base.ConfigureDefaultJobServices(services, configurationRoot);
+
+            //services.AddSingleton(new TelemetryClient());
+            //services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
+            services.AddTransient<ICommonTelemetryService, CommonTelemetryService>();
+            services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
+            services.AddTransient<IFileDownloader, PackageDownloader>();
+
+            services.AddTransient<ICloudBlobClient>(c =>
+            {
+                var configurationAccessor = c.GetRequiredService<IOptionsSnapshot<ValidationStorageConfiguration>>();
+                return new CloudBlobClientWrapper(
+                    configurationAccessor.Value.ConnectionString,
+                    readAccessGeoRedundant: false);
+            });
+            services.AddTransient<ICoreFileStorageService, CloudBlobCoreFileStorageService>();
+
+            services.AddScoped<IValidationEntitiesContext>(p =>
+            {
+                return new ValidationEntitiesContext(CreateSqlConnection<ValidationDbConfiguration>());
+            });
+
+            services.AddScoped<IEntitiesContext>(p =>
+            {
+                return new EntitiesContext(CreateSqlConnection<GalleryDbConfiguration>(), readOnly: true);
+            });
+
+            services.AddTransient<ISubscriptionClient>(p =>
+            {
+                var config = p.GetRequiredService<IOptionsSnapshot<ServiceBusConfiguration>>().Value;
+
+                return new SubscriptionClientWrapper(config.ConnectionString, config.TopicPath, config.SubscriptionName);
+            });
+
+            services.AddSingleton(p =>
+            {
+                var assembly = Assembly.GetEntryAssembly();
+                var assemblyName = assembly.GetName().Name;
+                var assemblyVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
+
+                var client = new HttpClient(new WebRequestHandler
+                {
+                    AllowPipelining = true,
+                    AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate),
+                });
+
+                client.Timeout = configurationRoot.GetValue<TimeSpan>(PackageDownloadTimeoutName);
+                client.DefaultRequestHeaders.Add("User-Agent", $"{assemblyName}/{assemblyVersion}");
+
+                return client;
+            });
+        }
+    }
+}

--- a/src/Validation.PackageSigning.ProcessSignature/Job.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Job.cs
@@ -35,7 +35,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
             services.AddScoped<IEntitiesContext>(p =>
             {
-                return new EntitiesContext(CreateDbConnection<GalleryDbConfiguration>(p), readOnly: false);
+                return new EntitiesContext(CreateSqlConnection<GalleryDbConfiguration>(), readOnly: false);
             });
 
             services.Add(ServiceDescriptor.Transient(typeof(IEntityRepository<>), typeof(EntityRepository<>)));

--- a/src/Validation.PackageSigning.RevalidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Job.cs
@@ -15,7 +15,7 @@ using NuGet.Services.ServiceBus;
 
 namespace Validation.PackageSigning.RevalidateCertificate
 {
-    public class Job : JsonConfigurationJob
+    public class Job : ValidationJobBase
     {
         private const string RevalidationConfigurationSectionName = "RevalidateJob";
 


### PR DESCRIPTION
Part of https://github.com/NuGet/Engineering/issues/1560. Depends on https://github.com/NuGet/NuGet.Jobs/pull/505

Includes the following:
- Moves bulk of `JsonConfigurationJob` into `NuGet.Jobs.Common`, for use by legacy jobs
- Updates validation jobs use db helpers from https://github.com/NuGet/NuGet.Jobs/pull/505
  - `JsonConfigurationJob` registers databases when `GalleryDbConfiguration` or `ValidationDbConfiguration` is found
- Updates `ArchivePackages.Job` to descend from `JsonConfigurationJob`
  - Requires new "Configuration" and "GalleryDatabaseAddress" Octopus config. Will remove old config only after these changes RI'd to master and deployed to prod.

Testing should include the following jobs:
- ArchivePackages (Verified on DEV)
- Revalidate
- ProcessSignature
- RebootSearchInstance
- SubscriptionProcessor
- RevalidateCertificate
