### PR TITLE
Move initial jobs to SQL AAD on DEV

### DIFF
--- a/src/ArchivePackages/Settings/dev.json
+++ b/src/ArchivePackages/Settings/dev.json
@@ -6,7 +6,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Integrated Security=False;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Connect Timeout=30;Encrypt=True"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=ArchivePackages;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbReader.ClientId};AadCertificate=$$dev-gallerydb-reader$$"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/Gallery.CredentialExpiration/Settings/dev.json
+++ b/src/Gallery.CredentialExpiration/Settings/dev.json
@@ -12,7 +12,7 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Gallery.CredentialExpiration;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbReader.ClientId};AadCertificate=$$dev-gallerydb-reader$$"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/Gallery.Maintenance/Settings/dev.json
+++ b/src/Gallery.Maintenance/Settings/dev.json
@@ -1,6 +1,6 @@
 {
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;User ID=$$Dev-GalleryDBWriter-UserName$$;Password=$$Dev-GalleryDBWriter-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Gallery.Maintenance;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbWriter.ClientId};AadCertificate=$$dev-gallerydb-writer"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/Gallery.Maintenance/Settings/dev.json
+++ b/src/Gallery.Maintenance/Settings/dev.json
@@ -1,6 +1,6 @@
 {
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Gallery.Maintenance;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbWriter.ClientId};AadCertificate=$$dev-gallerydb-writer"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Gallery.Maintenance;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbWriter.ClientId};AadCertificate=$$dev-gallerydb-writer$$"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/Search.GenerateAuxiliaryData/Job.cs
+++ b/src/Search.GenerateAuxiliaryData/Job.cs
@@ -10,6 +10,7 @@ using Autofac;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage;
 using NuGet.Jobs;
 using NuGet.Jobs.Configuration;
@@ -46,7 +47,7 @@ namespace Search.GenerateAuxiliaryData
         {
             base.Init(serviceContainer, jobArgsDictionary);
 
-            Configuration = _serviceProvider.GetRequiredService<InitializationConfiguration>();
+            Configuration = _serviceProvider.GetRequiredService<IOptionsSnapshot<InitializationConfiguration>>().Value;
 
             var destinationContainer = CloudStorageAccount.Parse(Configuration.PrimaryDestination)
                 .CreateCloudBlobClient()

--- a/src/Search.GenerateAuxiliaryData/Settings/dev-asia.json
+++ b/src/Search.GenerateAuxiliaryData/Settings/dev-asia.json
@@ -6,11 +6,11 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Search.GenerateAuxData.Asia;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbReader.ClientId};AadCertificate=$$dev-gallerydb-reader$$"
   },
 
   "StatisticsDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.StatisticsDatabaseAddress};Initial Catalog=nuget-dev-statistics;User ID=$$Dev-StatisticsDBReadOnly-UserName$$;Password=$$Dev-StatisticsDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.StatisticsDatabaseAddress};Initial Catalog=nuget-dev-statistics;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Search.GenerateAuxData.Asia;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.StatisticsDbReader.ClientId};AadCertificate=$$dev-statisticsdb-reader$$"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",

--- a/src/Search.GenerateAuxiliaryData/Settings/dev.json
+++ b/src/Search.GenerateAuxiliaryData/Settings/dev.json
@@ -6,11 +6,11 @@
   },
 
   "GalleryDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;User ID=$$Dev-GalleryDBReadOnly-UserName$$;Password=$$Dev-GalleryDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.GalleryDatabaseAddress};Initial Catalog=nuget-dev-0-v2gallery;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Search.GenerateAuxData;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.GalleryDbReader.ClientId};AadCertificate=$$dev-gallerydb-reader$$"
   },
 
   "StatisticsDb": {
-    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.StatisticsDatabaseAddress};Initial Catalog=nuget-dev-statistics;User ID=$$Dev-StatisticsDBReadOnly-UserName$$;Password=$$Dev-StatisticsDBReadOnly-Password$$;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+    "ConnectionString": "Data Source=tcp:#{Deployment.Azure.Sql.StatisticsDatabaseAddress};Initial Catalog=nuget-dev-statistics;Persist Security Info=False;Connect Timeout=30;Encrypt=True;TrustServerCertificate=False;Application Name=Search.GenerateAuxData;AadTenant=#{Deployment.Azure.ActiveDirectory.Tenant};AadClientId=#{Deployment.Azure.ActiveDirectory.StatisticsDbReader.ClientId};AadCertificate=$$dev-statisticsdb-reader$$"
   },
 
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",


### PR DESCRIPTION
Depends on #515, #516, #517, #518 

Moves the following jobs to use SQL AAD in DEV environment:
- ArchivePackages
- Gallery.CredentialExpiration
- Gallery.Maintenance
- Search.GenerateAuxillaryData

Status: Verified on DEV