### PR TITLE
[Revalidation] Update configuration

### DIFF
--- a/src/NuGet.Services.Revalidate/Settings/dev.json
+++ b/src/NuGet.Services.Revalidate/Settings/dev.json
@@ -6,7 +6,7 @@
         "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder",
         "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder\\.tools"
       ],
-      "MaxPackageCreationDate": "2021-03-01T23:52:40.7022034+00:00", // TODO: Update this when repository signing is enabled
+      "MaxPackageCreationDate": "2018-08-08T23:59:59.0000000Z",
       "SleepDurationBetweenBatches": "00:00:30"
     },
 
@@ -17,7 +17,7 @@
     },
 
     "MinPackageEventRate": 120,
-    "MaxPackageEventRate": 500,
+    "MaxPackageEventRate": 200,
 
     "AppInsights": {
       "AppId": "46f13c7d-635f-42c3-8120-593edeaad426",

--- a/src/NuGet.Services.Revalidate/Settings/int.json
+++ b/src/NuGet.Services.Revalidate/Settings/int.json
@@ -6,7 +6,7 @@
         "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder",
         "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder\\.tools"
       ],
-      "MaxPackageCreationDate": "2021-03-01T23:52:40.7022034+00:00", // TODO: Update this when repository signing is enabled
+      "MaxPackageCreationDate": "2018-08-08T23:59:59.0000000Z",
       "SleepDurationBetweenBatches": "00:00:30"
     },
 
@@ -17,7 +17,7 @@
     },
 
     "MinPackageEventRate": 120,
-    "MaxPackageEventRate": 500,
+    "MaxPackageEventRate": 200,
 
     "AppInsights": {
       "AppId": "718e0c81-9132-4bf2-b24b-aa625dafd800",

--- a/src/NuGet.Services.Revalidate/Settings/prod.json
+++ b/src/NuGet.Services.Revalidate/Settings/prod.json
@@ -6,7 +6,7 @@
         "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder",
         "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder\\.tools"
       ],
-      "MaxPackageCreationDate": "2021-03-01T23:52:40.7022034+00:00", // TODO: Update this when repository signing is enabled
+      "MaxPackageCreationDate": "2018-08-08T23:59:59.0000000Z",
       "SleepDurationBetweenBatches": "00:00:30"
     },
 
@@ -17,7 +17,7 @@
     },
 
     "MinPackageEventRate": 120,
-    "MaxPackageEventRate": 500,
+    "MaxPackageEventRate": 200,
 
     "AppInsights": {
       "AppId": "338f6804-b1a9-4fe3-bba7-c93064e7ae7b",


### PR DESCRIPTION
Update the revalidation job's configurations:

1. `MaxPackageCreationDate` - This is the package upload cutoff after which packages will not be revalidated. The plan is to deploy repository signing this morning, so the value is now set to 8/8/2018 4:59PM PST. I won't merge this change until after we've verified the repository signing deployment.
2. `MaxPackageEventRate` - The revalidation job enqueues revalidations to try to reach this maximum package event rate. I lowered this setting to 200 package events per hour. This means that if there were 100 package pushes in the last hour, the revalidation job will enqueue revalidations at 100 revalidations per hour. PROD's package event rate has spanned from 0-300 per hour this week, so 200 package events per hour should be a safe starting point. This does mean that there will be periods where the revalidation job will sit idly due to its quota being met. This is fine, we will raise the `MaxPackageEventRate` over time as we build confidence in this job.