### PR TITLE
[Revalidation] Speed up bulk insertions

### DIFF
--- a/src/NuGet.Jobs.Common/DelegateSqlConnectionFactory.cs
+++ b/src/NuGet.Jobs.Common/DelegateSqlConnectionFactory.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Jobs.Configuration;
+
+namespace NuGet.Jobs
+{
+    public class DelegateSqlConnectionFactory<TbDbConfiguration> : ISqlConnectionFactory<TbDbConfiguration>
+        where TbDbConfiguration : IDbConfiguration
+    {
+        private readonly Func<Task<SqlConnection>> _connectionFunc;
+        private readonly ILogger<DelegateSqlConnectionFactory<TbDbConfiguration>> _logger;
+
+        public DelegateSqlConnectionFactory(Func<Task<SqlConnection>> connectionFunc, ILogger<DelegateSqlConnectionFactory<TbDbConfiguration>> logger)
+        {
+            _connectionFunc = connectionFunc ?? throw new ArgumentNullException(nameof(connectionFunc));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task<SqlConnection> CreateAsync() => _connectionFunc();
+
+        public async Task<SqlConnection> OpenAsync()
+        {
+            SqlConnection connection = null;
+
+            try
+            {
+                _logger.LogDebug("Opening SQL connection...");
+
+                connection = await _connectionFunc();
+
+                await connection.OpenAsync();
+
+                _logger.LogDebug("Opened SQL connection");
+
+                return connection;
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(0, e, "Unable to open SQL connection due to exception");
+
+                connection?.Dispose();
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/NuGet.Jobs.Common/ISqlConnectionFactory.cs
+++ b/src/NuGet.Jobs.Common/ISqlConnectionFactory.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using NuGet.Jobs.Configuration;
+
+namespace NuGet.Jobs
+{
+    /// <summary>
+    /// A factory to create and open <see cref="SqlConnection"/>s.
+    /// </summary>
+    public interface ISqlConnectionFactory
+    {
+        /// <summary>
+        /// Create an unopened SQL connection.
+        /// </summary>
+        /// <returns>The unopened SQL connection.</returns>
+        Task<SqlConnection> CreateAsync();
+
+        /// <summary>
+        /// Create and then open a SQL connection.
+        /// </summary>
+        /// <returns>A task that creates and then opens a SQL connection.</returns>
+        Task<SqlConnection> OpenAsync();
+    }
+
+    /// <summary>
+    /// A factory to create and open <see cref="SqlConnection"/>s for a specific
+    /// <see cref="TDbConfiguration"/>. This type can be used to avoid Dependency
+    /// Injection key bindings.
+    /// </summary>
+    /// <typeparam name="TDbConfiguration">The configuration used to create the connection.</typeparam>
+    public interface ISqlConnectionFactory<TDbConfiguration> : ISqlConnectionFactory
+        where TDbConfiguration : IDbConfiguration
+    {
+    }
+}

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -117,6 +117,27 @@ namespace NuGet.Jobs
 
             services.AddSingleton(new TelemetryClient());
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
+
+            services.AddScoped<ISqlConnectionFactory<GalleryDbConfiguration>>(p =>
+            {
+                return new DelegateSqlConnectionFactory<GalleryDbConfiguration>(
+                    CreateSqlConnectionAsync<GalleryDbConfiguration>,
+                    p.GetRequiredService<ILogger<DelegateSqlConnectionFactory<GalleryDbConfiguration>>>());
+            });
+
+            services.AddScoped<ISqlConnectionFactory<StatisticsDbConfiguration>>(p =>
+            {
+                return new DelegateSqlConnectionFactory<StatisticsDbConfiguration>(
+                    CreateSqlConnectionAsync<StatisticsDbConfiguration>,
+                    p.GetRequiredService<ILogger<DelegateSqlConnectionFactory<StatisticsDbConfiguration>>>());
+            });
+
+            services.AddScoped<ISqlConnectionFactory<ValidationDbConfiguration>>(p =>
+            {
+                return new DelegateSqlConnectionFactory<ValidationDbConfiguration>(
+                    CreateSqlConnectionAsync<ValidationDbConfiguration>,
+                    p.GetRequiredService<ILogger<DelegateSqlConnectionFactory<ValidationDbConfiguration>>>());
+            });
         }
 
         private void ConfigureLibraries(IServiceCollection services)

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -50,8 +50,10 @@
     <Compile Include="Configuration\StatisticsDbConfiguration.cs" />
     <Compile Include="Configuration\ValidationDbConfiguration.cs" />
     <Compile Include="Configuration\ValidationStorageConfiguration.cs" />
+    <Compile Include="DelegateSqlConnectionFactory.cs" />
     <Compile Include="Extensions\LoggerExtensions.cs" />
     <Compile Include="Extensions\XElementExtensions.cs" />
+    <Compile Include="ISqlConnectionFactory.cs" />
     <Compile Include="JsonConfigurationJob.cs" />
     <Compile Include="SecretReader\ISecretReaderFactory.cs" />
     <Compile Include="SecretReader\SecretReaderFactory.cs" />

--- a/src/NuGet.Services.Revalidate/Job.cs
+++ b/src/NuGet.Services.Revalidate/Job.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
+using System.Data.SqlClient;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -78,7 +79,7 @@ namespace NuGet.Services.Revalidate
 
                         preinstalledPackagesNames.UnionWith(packagesInPath);
                     }
-
+                        
                     File.WriteAllText(_preinstalledSetPath, JsonConvert.SerializeObject(preinstalledPackagesNames));
 
                     Logger.LogInformation("Rebuilt the preinstalled package set. Found {PreinstalledPackages} package ids", preinstalledPackagesNames.Count);
@@ -139,6 +140,7 @@ namespace NuGet.Services.Revalidate
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
 
             services.AddTransient<IPackageRevalidationStateService, PackageRevalidationStateService>();
+            services.AddTransient<IPackageRevalidationInserter, PackageRevalidationInserter>();
             services.AddTransient<IRevalidationJobStateService, RevalidationJobStateService>();
             services.AddTransient<IRevalidationStateService, RevalidationStateService>();
 

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -58,12 +58,14 @@
     <Compile Include="Services\HealthService.cs" />
     <Compile Include="Services\IGalleryService.cs" />
     <Compile Include="Services\IHealthService.cs" />
+    <Compile Include="Services\IPackageRevalidationInserter.cs" />
     <Compile Include="Services\IRevalidationQueue.cs" />
     <Compile Include="Services\IRevalidationJobStateService.cs" />
     <Compile Include="Services\IPackageRevalidationStateService.cs" />
     <Compile Include="Services\IRevalidationService.cs" />
     <Compile Include="Services\IRevalidationThrottler.cs" />
     <Compile Include="Services\ISingletonService.cs" />
+    <Compile Include="Services\PackageRevalidationInserter.cs" />
     <Compile Include="Services\RevalidationOperation.cs" />
     <Compile Include="Services\RevalidationQueue.cs" />
     <Compile Include="Services\RevalidationResult.cs" />

--- a/src/NuGet.Services.Revalidate/Services/IPackageRevalidationInserter.cs
+++ b/src/NuGet.Services.Revalidate/Services/IPackageRevalidationInserter.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.Services.Validation;
+
+namespace NuGet.Services.Revalidate
+{
+    public interface IPackageRevalidationInserter
+    {
+        Task AddPackageRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations);
+    }
+}

--- a/src/NuGet.Services.Revalidate/Services/PackageRevalidationInserter.cs
+++ b/src/NuGet.Services.Revalidate/Services/PackageRevalidationInserter.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Jobs;
+using NuGet.Jobs.Configuration;
+using NuGet.Jobs.Validation;
+using NuGet.Services.Validation;
+
+namespace NuGet.Services.Revalidate
+{
+    public class PackageRevalidationInserter : IPackageRevalidationInserter
+    {
+        private const string TableName = "[dbo].[PackageRevalidations]";
+
+        private const string PackageIdColumn = "PackageId";
+        private const string PackageNormalizedVersionColumn = "PackageNormalizedVersion";
+        private const string EnqueuedColumn = "Enqueued";
+        private const string ValidationTrackingIdColumn = "ValidationTrackingId";
+        private const string CompletedColumn = "Completed";
+
+        private readonly ISqlConnectionFactory<ValidationDbConfiguration> _connectionFactory;
+        private readonly ILogger<PackageRevalidationInserter> _logger;
+
+        public PackageRevalidationInserter(
+            ISqlConnectionFactory<ValidationDbConfiguration> connectionFactory,
+            ILogger<PackageRevalidationInserter> logger)
+        {
+            _connectionFactory = connectionFactory ?? throw new ArgumentNullException(nameof(connectionFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task AddPackageRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations)
+        {
+            _logger.LogDebug("Persisting package revalidations to database...");
+
+            var table = PrepareTable(revalidations);
+
+            using (var connection = await _connectionFactory.OpenAsync())
+            {
+                var bulkCopy = new SqlBulkCopy(
+                    connection,
+                    SqlBulkCopyOptions.TableLock | SqlBulkCopyOptions.FireTriggers | SqlBulkCopyOptions.UseInternalTransaction,
+                    externalTransaction: null);
+
+                foreach (DataColumn column in table.Columns)
+                {
+                    bulkCopy.ColumnMappings.Add(column.ColumnName, column.ColumnName);
+                }
+
+                bulkCopy.DestinationTableName = TableName;
+                bulkCopy.WriteToServer(table);
+            }
+
+            _logger.LogDebug("Finished persisting package revalidations to database...");
+        }
+
+        private DataTable PrepareTable(IReadOnlyList<PackageRevalidation> revalidations)
+        {
+            // Prepare the table.
+            var table = new DataTable();
+
+            table.Columns.Add(PackageIdColumn, typeof(string));
+            table.Columns.Add(PackageNormalizedVersionColumn, typeof(string));
+            table.Columns.Add(CompletedColumn, typeof(bool));
+
+            var enqueued = table.Columns.Add(EnqueuedColumn, typeof(DateTime));
+            var trackingId = table.Columns.Add(ValidationTrackingIdColumn, typeof(Guid));
+
+            enqueued.AllowDBNull = true;
+            trackingId.AllowDBNull = true;
+
+            // Populate the table.
+            foreach (var revalidation in revalidations)
+            {
+                var row = table.NewRow();
+
+                row[PackageIdColumn] = revalidation.PackageId;
+                row[PackageNormalizedVersionColumn] = revalidation.PackageNormalizedVersion;
+                row[EnqueuedColumn] = ((object)revalidation.Enqueued) ?? DBNull.Value;
+                row[ValidationTrackingIdColumn] = ((object)revalidation.ValidationTrackingId) ?? DBNull.Value;
+                row[CompletedColumn] = revalidation.Completed;
+
+                table.Rows.Add(row);
+            }
+
+            return table;
+        }
+    }
+}

--- a/src/NuGet.Services.Revalidate/Services/PackageRevalidationStateService.cs
+++ b/src/NuGet.Services.Revalidate/Services/PackageRevalidationStateService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
@@ -15,44 +16,22 @@ namespace NuGet.Services.Revalidate
     public class PackageRevalidationStateService : IPackageRevalidationStateService
     {
         private readonly IValidationEntitiesContext _context;
+        private readonly IPackageRevalidationInserter _inserter;
         private readonly ILogger<PackageRevalidationStateService> _logger;
 
-        public PackageRevalidationStateService(IValidationEntitiesContext context, ILogger<PackageRevalidationStateService> logger)
+        public PackageRevalidationStateService(
+            IValidationEntitiesContext context,
+            IPackageRevalidationInserter inserter,
+            ILogger<PackageRevalidationStateService> logger)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
+            _inserter = inserter ?? throw new ArgumentNullException(nameof(inserter));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task AddPackageRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations)
+        public Task AddPackageRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations)
         {
-            _logger.LogDebug("Persisting package revalidations to database...");
-
-            var validationContext = _context as ValidationEntitiesContext;
-
-            if (validationContext != null)
-            {
-                validationContext.Configuration.AutoDetectChangesEnabled = false;
-                validationContext.Configuration.ValidateOnSaveEnabled = false;
-            }
-
-            foreach (var revalidation in revalidations)
-            {
-                _context.PackageRevalidations.Add(revalidation);
-            }
-
-            _logger.LogDebug("Saving the validation context...");
-
-            await _context.SaveChangesAsync();
-
-            _logger.LogDebug("Finished saving the validation context...");
-
-            if (validationContext != null)
-            {
-                validationContext.Configuration.AutoDetectChangesEnabled = true;
-                validationContext.Configuration.ValidateOnSaveEnabled = true;
-            }
-
-            _logger.LogDebug("Finished persisting package revalidations to database...");
+            return _inserter.AddPackageRevalidationsAsync(revalidations);
         }
 
         public async Task<int> RemovePackageRevalidationsAsync(int max)

--- a/src/Stats.RefreshClientDimension/RefreshClientDimensionJob.cs
+++ b/src/Stats.RefreshClientDimension/RefreshClientDimensionJob.cs
@@ -14,9 +14,11 @@ using Stats.ImportAzureCdnStatistics;
 
 namespace Stats.RefreshClientDimension
 {
+    using ICoreSqlConnectionFactory = NuGet.Services.Sql.ISqlConnectionFactory;
+
     public class RefreshClientDimensionJob : JobBase
     {
-        private static ISqlConnectionFactory _statisticsDbConnectionFactory;
+        private static ICoreSqlConnectionFactory _statisticsDbConnectionFactory;
         private static string _targetClientName;
         private static string _userAgentFilter;
 

--- a/tests/NuGet.Services.Revalidate.Tests/Services/PackageRevalidationStateServiceFacts.cs
+++ b/tests/NuGet.Services.Revalidate.Tests/Services/PackageRevalidationStateServiceFacts.cs
@@ -15,29 +15,6 @@ namespace NuGet.Services.Revalidate.Tests.Services
 {
     public class PackageRevalidationStateServiceFacts
     {
-        public class TheAddPackageRevalidationsAsyncMethod : FactsBase
-        {
-            [Fact]
-            public async Task AddsRevalidations()
-            {
-                // Arrange
-                var revalidations = new List<PackageRevalidation>
-                {
-                    new PackageRevalidation { PackageId = "A" },
-                    new PackageRevalidation { PackageId = "B" }
-                };
-
-                _context.Mock();
-                
-                // Act & Assert
-                await _target.AddPackageRevalidationsAsync(revalidations);
-
-                Assert.Equal(2, _context.Object.PackageRevalidations.Count());
-
-                _context.Verify(c => c.SaveChangesAsync(), Times.Once);
-            }
-        }
-
         public class TheRemoveRevalidationsAsyncMethod : FactsBase
         {
             [Fact]
@@ -124,6 +101,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
 
                 _target = new PackageRevalidationStateService(
                     _context.Object,
+                    Mock.Of<IPackageRevalidationInserter>(),
                     Mock.Of<ILogger<PackageRevalidationStateService>>());
             }
         }


### PR DESCRIPTION
The initialization phase of the job has to insert 1.5 million records into the validation DB in batches of 1,000 records. On DEV, each batch was taking 30 - 120 seconds using Entity Framework. This fix uses `SqlBulkCopy` to speed up batches to be sub-second.