### PR TITLE
[Revalidation] Improve package registration finder

### DIFF
--- a/src/NuGet.Services.Revalidate/Initialization/IPackageFinder.cs
+++ b/src/NuGet.Services.Revalidate/Initialization/IPackageFinder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NuGet.Versioning;
 
 namespace NuGet.Services.Revalidate
@@ -41,7 +42,7 @@ namespace NuGet.Services.Revalidate
         /// <param name="setName">The name of this set of packages.</param>
         /// <param name="packageRegistrationKeys">The set of package registration keys.</param>
         /// <returns>Information about each package registration, if it exists in the database.</returns>
-        List<PackageRegistrationInformation> FindPackageRegistrationInformation(string setName, HashSet<int> packageRegistrationKeys);
+        Task<List<PackageRegistrationInformation>> FindPackageRegistrationInformationAsync(string setName, HashSet<int> packageRegistrationKeys);
 
         /// <summary>
         /// Find versions that are appropriate for revalidations.

--- a/src/NuGet.Services.Revalidate/Initialization/InitializationManager.cs
+++ b/src/NuGet.Services.Revalidate/Initialization/InitializationManager.cs
@@ -122,7 +122,7 @@ namespace NuGet.Services.Revalidate
 
         private async Task InitializePackageSetAsync(string setName, HashSet<int> packageRegistrationKeys)
         {
-            var packageInformations = _packageFinder.FindPackageRegistrationInformation(setName, packageRegistrationKeys);
+            var packageInformations = await _packageFinder.FindPackageRegistrationInformationAsync(setName, packageRegistrationKeys);
 
             var chunks = packageInformations
                 .OrderByDescending(p => p.Downloads)

--- a/tests/NuGet.Services.Revalidate.Tests/Initializer/InitializationManagerFacts.cs
+++ b/tests/NuGet.Services.Revalidate.Tests/Initializer/InitializationManagerFacts.cs
@@ -39,8 +39,8 @@ namespace NuGet.Services.Revalidate.Tests.Initializer
                 _packageFinder.Setup(f => f.FindDependencyPackages(It.IsAny<HashSet<int>>())).Returns(new HashSet<int>());
                 _packageFinder.Setup(f => f.FindAllPackages(It.IsAny<HashSet<int>>())).Returns(new HashSet<int>());
 
-                _packageFinder.Setup(f => f.FindPackageRegistrationInformation(It.IsAny<string>(), It.IsAny<HashSet<int>>()))
-                    .Returns(new List<PackageRegistrationInformation>());
+                _packageFinder.Setup(f => f.FindPackageRegistrationInformationAsync(It.IsAny<string>(), It.IsAny<HashSet<int>>()))
+                    .ReturnsAsync(new List<PackageRegistrationInformation>());
 
                 var firstRemove = true;
 
@@ -339,20 +339,20 @@ namespace NuGet.Services.Revalidate.Tests.Initializer
                 }
 
                 _packageFinder
-                    .Setup(f => f.FindPackageRegistrationInformation(PackageFinder.MicrosoftSetName, It.IsAny<HashSet<int>>()))
-                    .Returns(RegistrationInformation(microsoftPackages));
+                    .Setup(f => f.FindPackageRegistrationInformationAsync(PackageFinder.MicrosoftSetName, It.IsAny<HashSet<int>>()))
+                    .ReturnsAsync(RegistrationInformation(microsoftPackages));
 
                 _packageFinder
-                    .Setup(f => f.FindPackageRegistrationInformation(PackageFinder.PreinstalledSetName, It.IsAny<HashSet<int>>()))
-                    .Returns(RegistrationInformation(preinstalledPackages));
+                    .Setup(f => f.FindPackageRegistrationInformationAsync(PackageFinder.PreinstalledSetName, It.IsAny<HashSet<int>>()))
+                    .ReturnsAsync(RegistrationInformation(preinstalledPackages));
 
                 _packageFinder
-                    .Setup(f => f.FindPackageRegistrationInformation(PackageFinder.DependencySetName, It.IsAny<HashSet<int>>()))
-                    .Returns(RegistrationInformation(dependencyPackages));
+                    .Setup(f => f.FindPackageRegistrationInformationAsync(PackageFinder.DependencySetName, It.IsAny<HashSet<int>>()))
+                    .ReturnsAsync(RegistrationInformation(dependencyPackages));
 
                 _packageFinder
-                    .Setup(f => f.FindPackageRegistrationInformation(PackageFinder.RemainingSetName, It.IsAny<HashSet<int>>()))
-                    .Returns(RegistrationInformation(remainingPackages));
+                    .Setup(f => f.FindPackageRegistrationInformationAsync(PackageFinder.RemainingSetName, It.IsAny<HashSet<int>>()))
+                    .ReturnsAsync(RegistrationInformation(remainingPackages));
 
                 // Build the list of versions for each version of packages.
                 var versions = microsoftPackages

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignProcessorFacts.cs
@@ -311,9 +311,12 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
                         _request.NupkgUrl,
                         _config.V3ServiceIndexUrl,
                         It.Is<List<string>>(l =>
-                            l.Count() == 2 &&
-                            l.Contains("Billy") &&
-                            l.Contains("Bob"))),
+                            // Ensure that the owners are lexicographically ordered.
+                            l.Count() == 4 &&
+                            l[0] == "Annie" &&
+                            l[1] == "Bob" &&
+                            l[2] == "zack" &&
+                            l[3] == "Zorro")),
                     Times.Once);
 
             _validatorStateServiceMock


### PR DESCRIPTION
Improves the code that finds the information about package registrations by:

1. Sleeping between batches of registrations
2. Creating a new scope for each batch

I recommend you review this with whitespace disabled: https://github.com/NuGet/NuGet.Jobs/pull/532/files?utf8=%E2%9C%93&diff=unified&w=1