### PR TITLE
[Process Signature] Improve validation of package registration requirements

### DIFF
--- a/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
@@ -514,7 +514,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             {
                 _logger.LogInformation(
                     "Signed package {PackageId} {PackageVersion} is blocked for validation {ValidationId} since it " +
-                    "is not author signed: {SignatureType}",
+                    "is neither author nor repository signed: {SignatureType}",
                     context.Message.PackageId,
                     context.Message.PackageVersion,
                     context.Message.ValidationId,

--- a/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
@@ -104,17 +104,10 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
         private async Task<SignatureValidatorResult> HandleUnsignedPackageAsync(Context context)
         {
-            var packageRegistration = _corePackageService.FindPackageRegistrationById(context.Message.PackageId);
-
-            if (packageRegistration.IsSigningRequired())
+            var validationResult = await ValidatePackageRegistrationSigningRequirementsAsync(context);
+            if (validationResult != null)
             {
-                _logger.LogWarning(
-                    "Package {PackageId} {PackageVersion} for validation {ValidationId} must be signed but is unsigned.",
-                    context.Message.PackageId,
-                    context.Message.PackageVersion,
-                    context.Message.ValidationId);
-
-                return await RejectAsync(context, ValidationIssue.PackageIsNotSigned);
+                return validationResult;
             }
 
             _logger.LogInformation(
@@ -507,29 +500,17 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
 
         private async Task<SignatureValidatorResult> PerformFinalValidationAsync(Context context)
         {
-            var signingCertificate = context.Signature.SignerInfo.Certificate;
-            var signingFingerprint = signingCertificate.ComputeSHA256Thumbprint();
+            var packageRegistration = _corePackageService.FindPackageRegistrationById(context.Message.PackageId);
 
-            if (context.Signature.Type == SignatureType.Author)
+            // Ensure the signature matches the package registration's signing requirements.
+            var validationResult = await ValidatePackageRegistrationSigningRequirementsAsync(context);
+            if (validationResult != null)
             {
-                // Block packages with any unknown signing certificates.
-                var packageRegistration = _corePackageService.FindPackageRegistrationById(context.Message.PackageId);
-
-                if (!packageRegistration.IsAcceptableSigningCertificate(signingFingerprint))
-                {
-                    _logger.LogWarning(
-                        "Signed package {PackageId} {PackageVersion} is blocked for validation {ValidationId} since it has an unknown certificate fingerprint: {UnknownFingerprint}",
-                        context.Message.PackageId,
-                        context.Message.PackageVersion,
-                        context.Message.ValidationId,
-                        signingFingerprint);
-
-                    return await RejectAsync(
-                        context,
-                        new UnauthorizedCertificateFailure(signingCertificate.Thumbprint.ToLowerInvariant()));
-                }
+                return validationResult;
             }
-            else if (context.Signature.Type != SignatureType.Repository)
+
+            if (context.Signature.Type != SignatureType.Author &&
+                context.Signature.Type != SignatureType.Repository)
             {
                 _logger.LogInformation(
                     "Signed package {PackageId} {PackageVersion} is blocked for validation {ValidationId} since it " +
@@ -560,6 +541,9 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
             }
 
             // Do a full verification of all signatures.
+            var signingCertificate = context.Signature.SignerInfo.Certificate;
+            var signingFingerprint = signingCertificate.ComputeSHA256Thumbprint();
+
             var verifyResult = await _formatValidator.ValidateAllSignaturesAsync(
                 context.PackageReader,
                 context.HasRepositorySignature,
@@ -588,6 +572,65 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                     context.Message.PackageId,
                     context.Message.PackageVersion,
                     signingFingerprint);
+            }
+
+            return null;
+        }
+
+        private async Task<SignatureValidatorResult> ValidatePackageRegistrationSigningRequirementsAsync(Context context)
+        {
+            // Skip signing requirement checks if the package is already available. This is needed otherwise revalidating
+            // a package after its owners have changed their signing requirements may fail.
+            var package = _corePackageService.FindPackageByIdAndVersionStrict(context.Message.PackageId, context.Message.PackageVersion);
+
+            if (package.PackageStatusKey == PackageStatus.Available)
+            {
+                _logger.LogInformation(
+                    "Package {PackageId} {PackageVersion} for validation {ValidationId} is already available, " +
+                    "skipping the package registration's certificate signing requirements",
+                    context.Message.PackageId,
+                    context.Message.PackageVersion,
+                    context.Message.ValidationId);
+
+                return null;
+            }
+
+            var packageRegistration = _corePackageService.FindPackageRegistrationById(context.Message.PackageId);
+
+            if (context.Signature == null || context.Signature.Type == SignatureType.Repository)
+            {
+                // Block unsigned packages if the registration requires a signature.
+                if (packageRegistration.IsSigningRequired())
+                {
+                    _logger.LogWarning(
+                        "Package {PackageId} {PackageVersion} for validation {ValidationId} must be signed but is unsigned.",
+                        context.Message.PackageId,
+                        context.Message.PackageVersion,
+                        context.Message.ValidationId);
+
+                    return await RejectAsync(context, ValidationIssue.PackageIsNotSigned);
+                }
+            }
+
+            if (context.Signature?.Type == SignatureType.Author)
+            {
+                var signingCertificate = context.Signature.SignerInfo.Certificate;
+                var signingFingerprint = signingCertificate.ComputeSHA256Thumbprint();
+
+                // Block packages with any unknown signing certificates.
+                if (!packageRegistration.IsAcceptableSigningCertificate(signingFingerprint))
+                {
+                    _logger.LogWarning(
+                        "Signed package {PackageId} {PackageVersion} is blocked for validation {ValidationId} since it has an unknown certificate fingerprint: {UnknownFingerprint}",
+                        context.Message.PackageId,
+                        context.Message.PackageVersion,
+                        context.Message.ValidationId,
+                        signingFingerprint);
+
+                    return await RejectAsync(
+                        context,
+                        new UnauthorizedCertificateFailure(signingCertificate.Thumbprint.ToLowerInvariant()));
+                }
             }
 
             return null;

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -197,7 +197,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
         public async Task<MemoryStream> GetAuthorSignedPackageStream1Async()
         {
-            TestUtility.RequireSignedPackage(_corePackageService, _message.PackageId, await _fixture.GetSigningCertificateThumbprintAsync());
+            TestUtility.RequireSignedPackage(
+                _corePackageService,
+                _message.PackageId,
+                _message.PackageVersion,
+                await _fixture.GetSigningCertificateThumbprintAsync());
             return await _fixture.GetAuthorSignedPackageStream1Async(_output);
         }
 
@@ -233,7 +237,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                         _output);
                 }
 
-                TestUtility.RequireSignedPackage(_corePackageService, TestResources.UnsignedPackageId, certificate.Certificate.ComputeSHA256Thumbprint());
+                TestUtility.RequireSignedPackage(
+                    _corePackageService,
+                    TestResources.UnsignedPackageId,
+                    TestResources.UnsignedPackageVersion,
+                    certificate.Certificate.ComputeSHA256Thumbprint());
                 _message = _unsignedPackageMessage;
 
                 // Act
@@ -270,6 +278,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
                 TestUtility.RequireSignedPackage(_corePackageService, 
                     TestResources.SignedPackageLeafId,
+                    TestResources.SignedPackageLeaf1Version,
                     await _fixture.GetSigningCertificateThumbprintAsync());
 
                 _packageStream = new MemoryStream(packageBytes);
@@ -317,6 +326,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
                 TestUtility.RequireSignedPackage(_corePackageService,
                     TestResources.SignedPackageLeafId,
+                    TestResources.SignedPackageLeaf1Version,
                     await _fixture.GetSigningCertificateThumbprintAsync());
 
                 _packageStream = new MemoryStream(packageBytes);
@@ -365,7 +375,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 // Wait for the OCSP response cached by the operating system during signing to get stale.
                 await certificateWithUnavailableRevocation.WaitForResponseExpirationAsync();
 
-                TestUtility.RequireSignedPackage(_corePackageService, TestResources.UnsignedPackageId, certificateWithUnavailableRevocation.Certificate.ComputeSHA256Thumbprint());
+                TestUtility.RequireSignedPackage(
+                    _corePackageService,
+                    TestResources.UnsignedPackageId,
+                    TestResources.UnsignedPackageVersion,
+                    certificateWithUnavailableRevocation.Certificate.ComputeSHA256Thumbprint());
                 _message = _unsignedPackageMessage;
 
                 // Act
@@ -471,6 +485,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             // Arrange
             SetSignatureContent(
                 TestResources.SignedPackageLeafId,
+                TestResources.SignedPackageLeaf1Version,
                 TestResources.GetResourceStream(TestResources.SignedPackageLeaf1),
                 configuredSignedCms: signedCms =>
                 {
@@ -478,6 +493,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     {
                         TestUtility.RequireSignedPackage(_corePackageService, 
                             TestResources.SignedPackageLeafId,
+                            TestResources.SignedPackageLeaf1Version,
                             additionalCertificate.ComputeSHA256Thumbprint());
                         signedCms.ComputeSignature(new CmsSigner(additionalCertificate));
                     }
@@ -510,7 +526,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 {
                     using (var counterCertificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
                     {
-                        TestUtility.RequireSignedPackage(_corePackageService, _message.PackageId, counterCertificate.ComputeSHA256Thumbprint());
+                        TestUtility.RequireSignedPackage(
+                            _corePackageService,
+                            _message.PackageId,
+                            _message.PackageVersion,
+                            counterCertificate.ComputeSHA256Thumbprint());
 
                         var cmsSigner = new CmsSigner(counterCertificate);
                         cmsSigner.SignedAttributes.Add(AttributeUtility.CreateCommitmentTypeIndication(SignatureType.Author));
@@ -543,7 +563,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _output);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -573,7 +593,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _output);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -603,7 +623,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _output);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -635,7 +655,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _output);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -666,7 +686,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 output: _output);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -703,7 +723,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 }
 
                 // Initialize the subject of testing.
-                TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+                TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
                 _message = _unsignedPackageMessage;
 
                 var target = CreateSignatureValidator(
@@ -734,7 +754,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _output);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -773,7 +793,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     output: _output);
 
                 // Initialize the subject of testing.
-                TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+                TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
                 _message = _unsignedPackageMessage;
 
                 var target = CreateSignatureValidator(
@@ -811,7 +831,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             AddFileToPackageStream(_packageStream);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -841,7 +861,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 _output);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             var target = CreateSignatureValidator(
@@ -884,7 +904,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     output: _output);
 
                 // Initialize the subject of testing.
-                TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+                TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
                 _message = _unsignedPackageMessage;
 
                 var target = CreateSignatureValidator(
@@ -926,7 +946,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             AddFileToPackageStream(_packageStream);
 
             // Initialize the subject of testing.
-            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId);
+            TestUtility.RequireUnsignedPackage(_corePackageService, TestResources.UnsignedPackageId, TestResources.UnsignedPackageVersion);
             _message = _unsignedPackageMessage;
 
             _validationEntitiesContext.Object.PackageSigningStates.Add(new PackageSigningState
@@ -1342,7 +1362,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             // Arrange
             var certificate = await _fixture.GetSigningCertificateAsync();
-            TestUtility.RequireSignedPackage(_corePackageService, TestResources.SignedPackageLeafId, TestResources.Leaf1Thumbprint);
+            TestUtility.RequireSignedPackage(
+                _corePackageService,
+                TestResources.SignedPackageLeafId,
+                TestResources.SignedPackageLeaf1Version,
+                TestResources.Leaf1Thumbprint);
             _packageStream = await _fixture.RepositorySignPackageStreamAsync(
                 TestResources.GetResourceStream(TestResources.SignedPackageLeaf1),
                 certificate,
@@ -1395,6 +1419,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
                 TestUtility.RequireSignedPackage(_corePackageService,
                     TestResources.SignedPackageLeafId,
+                    TestResources.SignedPackageLeaf1Version,
                     await _fixture.GetSigningCertificateThumbprintAsync());
 
                 _message = new SignatureValidationMessage(
@@ -1448,6 +1473,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 
                 TestUtility.RequireSignedPackage(_corePackageService,
                     TestResources.SignedPackageLeafId,
+                    TestResources.SignedPackageLeaf1Version,
                     await _fixture.GetSigningCertificateThumbprintAsync());
 
                 _message = new SignatureValidationMessage(
@@ -1530,7 +1556,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 {
                     using (var counterCertificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
                     {
-                        TestUtility.RequireSignedPackage(_corePackageService, _message.PackageId, counterCertificate.ComputeSHA256Thumbprint());
+                        TestUtility.RequireSignedPackage(
+                            _corePackageService,
+                            _message.PackageId,
+                            _message.PackageVersion,
+                            counterCertificate.ComputeSHA256Thumbprint());
 
                         var cmsSigner = new CmsSigner(counterCertificate);
                         foreach (var type in counterSignatureTypes)
@@ -1615,6 +1645,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             // Arrange
             SetSignatureContent(
                 TestResources.SignedPackageLeafId,
+                TestResources.SignedPackageLeaf1Version,
                 TestResources.GetResourceStream(TestResources.SignedPackageLeaf1),
                 "!!--:::FOO...");
 
@@ -1640,6 +1671,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             // Arrange
             SetSignatureContent(
                 TestResources.SignedPackageLeafId,
+                TestResources.SignedPackageLeaf1Version,
                 TestResources.GetResourceStream(TestResources.SignedPackageLeaf1),
                 "Version:2" + Environment.NewLine + Environment.NewLine + "2.16.840.1.101.3.4.2.1-Hash:hash");
 
@@ -1666,6 +1698,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 hashValue: "hash");
             SetSignatureContent(
                 TestResources.SignedPackageLeafId,
+                TestResources.SignedPackageLeaf1Version,
                 TestResources.GetResourceStream(TestResources.SignedPackageLeaf1),
                 content.GetBytes());
 
@@ -1787,6 +1820,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
         private void SetSignatureContent(
             string packageId,
+            string packageVersion,
             MemoryStream packageStream,
             byte[] signatureContent = null,
             Action<SignedCms> configuredSignedCms = null)
@@ -1801,7 +1835,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 
             using (var certificate = SigningTestUtility.GenerateCertificate(subjectName: null, modifyGenerator: null))
             {
-                TestUtility.RequireSignedPackage(_corePackageService, packageId, certificate.ComputeSHA256Thumbprint());
+                TestUtility.RequireSignedPackage(_corePackageService, packageId, packageVersion, certificate.ComputeSHA256Thumbprint());
 
                 var contentInfo = new ContentInfo(signatureContent);
                 var signedCms = new SignedCms(contentInfo);
@@ -1816,9 +1850,9 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             }
         }
 
-        private void SetSignatureContent(string packageId, MemoryStream packageStream, string signatureContent)
+        private void SetSignatureContent(string packageId, string packageVersion, MemoryStream packageStream, string signatureContent)
         {
-            SetSignatureContent(packageId, packageStream, signatureContent: Encoding.UTF8.GetBytes(signatureContent));
+            SetSignatureContent(packageId, packageVersion, packageStream, signatureContent: Encoding.UTF8.GetBytes(signatureContent));
         }
 
         private void AddFileToPackageStream(MemoryStream packageStream)

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestUtility.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Support/TestUtility.cs
@@ -9,14 +9,22 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
 {
     internal static class TestUtility
     {
-        internal static void RequireUnsignedPackage(Mock<ICorePackageService> corePackageService, string packageId)
+        internal static void RequireUnsignedPackage(
+            Mock<ICorePackageService> corePackageService,
+            string packageId,
+            string packageVersion,
+            PackageStatus status = PackageStatus.Validating)
         {
-            var packageRegistration = new PackageRegistration()
+            var packageRegistration = new PackageRegistration
             {
                 Key = 1,
                 Id = packageId
             };
-            var user = new User()
+            var package = new Package
+            {
+                PackageStatusKey = status
+            };
+            var user = new User
             {
                 Key = 2
             };
@@ -24,31 +32,37 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             packageRegistration.Owners.Add(user);
 
             corePackageService
-                .Setup(x => x.FindPackageRegistrationById(It.Is<string>(id => id == packageId)))
+                .Setup(x => x.FindPackageRegistrationById(packageId))
                 .Returns(packageRegistration);
+
+            corePackageService
+                .Setup(x => x.FindPackageByIdAndVersionStrict(packageId, packageVersion))
+                .Returns(package);
         }
 
         internal static void RequireSignedPackage(
             Mock<ICorePackageService> corePackageService,
             string packageId,
-            string thumbprint = null)
+            string packageVersion,
+            string thumbprint = null,
+            PackageStatus status = PackageStatus.Validating)
         {
-            var packageRegistration = new PackageRegistration()
+            var packageRegistration = new PackageRegistration
             {
                 Key = 1,
                 Id = packageId
             };
-            var user = new User()
-            {
-                Key = 2
-            };
-            var certificate = new Certificate()
+
+            var package = new Package { PackageStatusKey = status };
+            var user = new User { Key = 2 };
+
+            var certificate = new Certificate
             {
                 Key = 3,
                 Thumbprint = thumbprint ?? Guid.NewGuid().ToString()
             };
 
-            user.UserCertificates.Add(new UserCertificate()
+            user.UserCertificates.Add(new UserCertificate
             {
                 Key = 4,
                 CertificateKey = certificate.Key,
@@ -60,8 +74,12 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             packageRegistration.Owners.Add(user);
 
             corePackageService
-                .Setup(x => x.FindPackageRegistrationById(It.Is<string>(id => id == packageId)))
+                .Setup(x => x.FindPackageRegistrationById(packageId))
                 .Returns(packageRegistration);
+
+            corePackageService
+                .Setup(x => x.FindPackageByIdAndVersionStrict(packageId, packageVersion))
+                .Returns(package);
         }
     }
 }


### PR DESCRIPTION
Improve the Process Signature job for the following scenarios:

1. If a package's primary signature is a repository signature, validate that the package passes its registration's author signing certificate requirements.
2. If a package is already available, skip its registration's author signing certificate requirements. This is needed as the requirements may have changed since the package was uploaded.

Addresses https://github.com/NuGet/Engineering/issues/1603
Addresses https://github.com/NuGet/Engineering/issues/1637