### PR TITLE
Status Aggregator - Monitor manual status changes from multiple storages

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -120,6 +120,7 @@ namespace NuGet.Jobs
 
         // Arguments specific to StatusAggregator
         public const string StatusStorageAccount = "StatusStorageAccount";
+        public const string StatusStorageAccountSecondary = "StatusStorageAccountSecondary";
         public const string StatusContainerName = "StatusContainerName";
         public const string StatusTableName = "StatusTableName";
         public const string StatusEnvironment = "StatusEnvironment";

--- a/src/StatusAggregator/Cursor.cs
+++ b/src/StatusAggregator/Cursor.cs
@@ -24,35 +24,35 @@ namespace StatusAggregator
 
         private readonly ILogger<Cursor> _logger;
 
-        public async Task<DateTime> Get()
+        public async Task<DateTime> Get(string name)
         {
-            using (_logger.Scope("Fetching cursor."))
+            using (_logger.Scope("Fetching cursor with name {CursorName}.", name))
             {
-                var cursor = await _table.Retrieve<CursorEntity>(
-                    CursorEntity.DefaultPartitionKey, CursorEntity.DefaultRowKey);
+                var cursor = await _table.RetrieveAsync<CursorEntity>(
+                    CursorEntity.DefaultPartitionKey, name);
 
                 DateTime value;
                 if (cursor == null)
                 {
                     // If we can't find a cursor, the job is likely uninitialized, so start at the beginning of time.
                     value = DateTime.MinValue;
-                    _logger.LogInformation("Could not fetch cursor, reinitializing cursor at {Cursor}.", value);
+                    _logger.LogInformation("Could not fetch cursor, reinitializing cursor at {CursorValue}.", value);
                 }
                 else
                 {
                     value = cursor.Value;
-                    _logger.LogInformation("Fetched cursor with value {Cursor}.", value);
+                    _logger.LogInformation("Fetched cursor with value {CursorValue}.", value);
                 }
 
                 return value;
             }
         }
 
-        public Task Set(DateTime value)
+        public Task Set(string name, DateTime value)
         {
-            using (_logger.Scope("Updating cursor to {Cursor}.", value))
+            using (_logger.Scope("Updating cursor with name {CursorName} to {CursorValue}.", name, value))
             {
-                var cursorEntity = new CursorEntity(value);
+                var cursorEntity = new CursorEntity(name, value);
                 return _table.InsertOrReplaceAsync(cursorEntity);
             }
         }

--- a/src/StatusAggregator/ICursor.cs
+++ b/src/StatusAggregator/ICursor.cs
@@ -11,7 +11,7 @@ namespace StatusAggregator
     /// </summary>
     public interface ICursor
     {
-        Task<DateTime> Get();
-        Task Set(DateTime value);
+        Task<DateTime> Get(string name);
+        Task Set(string name, DateTime value);
     }
 }

--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -95,8 +95,8 @@ namespace StatusAggregator
         {
             var statusStorageConnectionBuilders = new StatusStorageConnectionBuilder[]
             {
-                new StatusStorageConnectionBuilder(configuration => configuration.StorageAccount, PrimaryStorageAccountKey),
-                new StatusStorageConnectionBuilder(configuration => configuration.StorageAccountSecondary, "Secondary")
+                new StatusStorageConnectionBuilder(PrimaryStorageAccountKey, configuration => configuration.StorageAccount),
+                new StatusStorageConnectionBuilder("Secondary", configuration => configuration.StorageAccountSecondary)
             };
 
             // Add the primary storage to the container as default
@@ -124,6 +124,7 @@ namespace StatusAggregator
                 })
                 .As<CloudBlobContainer>();
 
+            // We need to listen to manual status change updates from the primary storage.
             containerBuilder
                 .RegisterType<ManualStatusChangeUpdater>()
                 .WithParameter(new NamedParameter("name", PrimaryStorageAccountKey))

--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -89,14 +89,17 @@ namespace StatusAggregator
             serviceCollection.AddTransient<IAggregateIncidentParser, AggregateIncidentParser>();
         }
 
+        private const string StorageAccountNameParameter = "name";
+
         private const string PrimaryStorageAccountKey = "Primary";
+        private const string SecondaryStorageAccountKey = "Primary";
 
         private static void AddStorage(ContainerBuilder containerBuilder)
         {
             var statusStorageConnectionBuilders = new StatusStorageConnectionBuilder[]
             {
                 new StatusStorageConnectionBuilder(PrimaryStorageAccountKey, configuration => configuration.StorageAccount),
-                new StatusStorageConnectionBuilder("Secondary", configuration => configuration.StorageAccountSecondary)
+                new StatusStorageConnectionBuilder(SecondaryStorageAccountKey, configuration => configuration.StorageAccountSecondary)
             };
 
             // Add the primary storage to the container as default
@@ -127,7 +130,7 @@ namespace StatusAggregator
             // We need to listen to manual status change updates from the primary storage.
             containerBuilder
                 .RegisterType<ManualStatusChangeUpdater>()
-                .WithParameter(new NamedParameter("name", PrimaryStorageAccountKey))
+                .WithParameter(new NamedParameter(StorageAccountNameParameter, PrimaryStorageAccountKey))
                 .As<IManualStatusChangeUpdater>();
 
             // Add secondary storages to the container by name
@@ -158,7 +161,7 @@ namespace StatusAggregator
                 // We need to listen to manual status change updates from each storage.
                 containerBuilder
                     .RegisterType<ManualStatusChangeUpdater>()
-                    .WithParameter(new NamedParameter("name", name))
+                    .WithParameter(new NamedParameter(StorageAccountNameParameter, name))
                     .WithParameter(new ResolvedParameter(
                         (pi, ctx) => pi.ParameterType == typeof(ITableWrapper),
                         (pi, ctx) => ctx.ResolveNamed<ITableWrapper>(name)))

--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -11,6 +11,8 @@ using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json.Linq;
 using NuGet.Jobs;
 using NuGet.Services.Incidents;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
 using StatusAggregator.Parse;
 using StatusAggregator.Table;
 
@@ -48,9 +50,22 @@ namespace StatusAggregator
             serviceCollection.AddTransient<IIncidentFactory, IncidentFactory>();
             AddParsing(serviceCollection);
             serviceCollection.AddTransient<IIncidentUpdater, IncidentUpdater>();
+            AddManualStatusChangeHandling(serviceCollection);
             serviceCollection.AddTransient<IStatusUpdater, StatusUpdater>();
             serviceCollection.AddTransient<IStatusExporter, StatusExporter>();
             serviceCollection.AddTransient<StatusAggregator>();
+        }
+
+        private static void AddManualStatusChangeHandling(IServiceCollection serviceCollection)
+        {
+            serviceCollection.AddTransient<IManualStatusChangeHandler<AddStatusEventManualChangeEntity>, AddStatusEventManualChangeHandler>();
+            serviceCollection.AddTransient<IManualStatusChangeHandler<EditStatusEventManualChangeEntity>, EditStatusEventManualChangeHandler>();
+            serviceCollection.AddTransient<IManualStatusChangeHandler<DeleteStatusEventManualChangeEntity>, DeleteStatusEventManualChangeHandler>();
+            serviceCollection.AddTransient<IManualStatusChangeHandler<AddStatusMessageManualChangeEntity>, AddStatusMessageManualChangeHandler>();
+            serviceCollection.AddTransient<IManualStatusChangeHandler<EditStatusMessageManualChangeEntity>, EditStatusMessageManualChangeHandler>();
+            serviceCollection.AddTransient<IManualStatusChangeHandler<DeleteStatusMessageManualChangeEntity>, DeleteStatusMessageManualChangeHandler>();
+            serviceCollection.AddTransient<IManualStatusChangeHandler, ManualStatusChangeHandler>();
+            serviceCollection.AddTransient<IManualStatusChangeUpdater, ManualStatusChangeUpdater>();
         }
 
         private static void AddParsing(IServiceCollection serviceCollection)

--- a/src/StatusAggregator/LogEvents.cs
+++ b/src/StatusAggregator/LogEvents.cs
@@ -5,5 +5,6 @@ namespace StatusAggregator
     public static class LogEvents
     {
         public static EventId RegexFailure = new EventId(400, "Failed to parse incident using Regex.");
+        public static EventId ManualChangeFailure = new EventId(401, "Failed to apply a manual change.");
     }
 }

--- a/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;

--- a/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;
@@ -15,8 +14,7 @@ namespace StatusAggregator.Manual
         private readonly ITableWrapper _table;
 
         public AddStatusEventManualChangeHandler(
-            ITableWrapper table,
-            ILogger<AddStatusEventManualChangeHandler> logger)
+            ITableWrapper table)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
         }
@@ -26,7 +24,7 @@ namespace StatusAggregator.Manual
             var time = entity.Timestamp.UtcDateTime;
 
             var eventEntity = new EventEntity(
-                entity.EventAffectedComponentPath ?? throw new ArgumentNullException($"{nameof(entity)}.{nameof(entity.EventAffectedComponentPath)}"),
+                entity.EventAffectedComponentPath,
                 entity.EventAffectedComponentStatus,
                 time,
                 entity.EventIsActive ? (DateTime?)null : time);
@@ -34,7 +32,7 @@ namespace StatusAggregator.Manual
             var messageEntity = new MessageEntity(
                 eventEntity,
                 time,
-                entity.MessageContents ?? throw new ArgumentNullException($"{nameof(entity)}.{nameof(entity.MessageContents)}"));
+                entity.MessageContents);
 
             await _table.InsertAsync(messageEntity);
             await _table.InsertAsync(eventEntity);

--- a/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
@@ -10,14 +10,12 @@ namespace StatusAggregator.Manual
     public class AddStatusEventManualChangeHandler : IManualStatusChangeHandler<AddStatusEventManualChangeEntity>
     {
         private readonly ITableWrapper _table;
-        private readonly ILogger<AddStatusEventManualChangeHandler> _logger;
 
         public AddStatusEventManualChangeHandler(
             ITableWrapper table,
             ILogger<AddStatusEventManualChangeHandler> logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task Handle(AddStatusEventManualChangeEntity entity)

--- a/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusEventManualChangeHandler.cs
@@ -23,7 +23,7 @@ namespace StatusAggregator.Manual
 
         public async Task Handle(AddStatusEventManualChangeEntity entity)
         {
-            var time = entity.ChangeTimestamp;
+            var time = entity.Timestamp.UtcDateTime;
 
             var eventEntity = new EventEntity(
                 entity.EventAffectedComponentPath ?? throw new ArgumentNullException($"{nameof(entity)}.{nameof(entity.EventAffectedComponentPath)}"),

--- a/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
@@ -10,14 +10,12 @@ namespace StatusAggregator.Manual
     public class AddStatusMessageManualChangeHandler : IManualStatusChangeHandler<AddStatusMessageManualChangeEntity>
     {
         private readonly ITableWrapper _table;
-        private readonly ILogger<AddStatusMessageManualChangeEntity> _logger;
 
         public AddStatusMessageManualChangeHandler(
             ITableWrapper table,
             ILogger<AddStatusMessageManualChangeEntity> logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task Handle(AddStatusMessageManualChangeEntity entity)

--- a/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;

--- a/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public class AddStatusMessageManualChangeHandler : IManualStatusChangeHandler<AddStatusMessageManualChangeEntity>
+    {
+        private readonly ITableWrapper _table;
+        private readonly ILogger<AddStatusMessageManualChangeEntity> _logger;
+
+        public AddStatusMessageManualChangeHandler(
+            ITableWrapper table,
+            ILogger<AddStatusMessageManualChangeEntity> logger)
+        {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task Handle(AddStatusMessageManualChangeEntity entity)
+        {
+            var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+
+            var messageEntity = new MessageEntity(
+                eventRowKey,
+                entity.ChangeTimestamp,
+                entity.MessageContents);
+
+            await _table.InsertAsync(messageEntity);
+
+            var eventEntity = await _table.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey);
+            if (ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.ChangeTimestamp))
+            {
+                await _table.ReplaceAsync(eventEntity);
+            }
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/AddStatusMessageManualChangeHandler.cs
@@ -23,17 +23,19 @@ namespace StatusAggregator.Manual
 
         public async Task Handle(AddStatusMessageManualChangeEntity entity)
         {
+            var time = entity.Timestamp.UtcDateTime;
+
             var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
 
             var messageEntity = new MessageEntity(
                 eventRowKey,
-                entity.ChangeTimestamp,
+                time,
                 entity.MessageContents);
 
             await _table.InsertAsync(messageEntity);
 
             var eventEntity = await _table.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey);
-            if (ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.ChangeTimestamp))
+            if (ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, time))
             {
                 await _table.ReplaceAsync(eventEntity);
             }

--- a/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;

--- a/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;
@@ -15,8 +14,7 @@ namespace StatusAggregator.Manual
         private readonly ITableWrapper _table;
 
         public DeleteStatusEventManualChangeHandler(
-            ITableWrapper table,
-            ILogger<DeleteStatusEventManualChangeHandler> logger)
+            ITableWrapper table)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
         }

--- a/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public class DeleteStatusEventManualChangeHandler : IManualStatusChangeHandler<DeleteStatusEventManualChangeEntity>
+    {
+        private readonly ITableWrapper _table;
+        private readonly ILogger<DeleteStatusEventManualChangeHandler> _logger;
+
+        public DeleteStatusEventManualChangeHandler(
+            ITableWrapper table,
+            ILogger<DeleteStatusEventManualChangeHandler> logger)
+        {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task Handle(DeleteStatusEventManualChangeEntity entity)
+        {
+            var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+            return _table.DeleteAsync(EventEntity.DefaultPartitionKey, eventRowKey);
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusEventManualChangeHandler.cs
@@ -10,14 +10,12 @@ namespace StatusAggregator.Manual
     public class DeleteStatusEventManualChangeHandler : IManualStatusChangeHandler<DeleteStatusEventManualChangeEntity>
     {
         private readonly ITableWrapper _table;
-        private readonly ILogger<DeleteStatusEventManualChangeHandler> _logger;
 
         public DeleteStatusEventManualChangeHandler(
             ITableWrapper table,
             ILogger<DeleteStatusEventManualChangeHandler> logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task Handle(DeleteStatusEventManualChangeEntity entity)

--- a/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;

--- a/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
@@ -10,14 +10,12 @@ namespace StatusAggregator.Manual
     public class DeleteStatusMessageManualChangeHandler : IManualStatusChangeHandler<DeleteStatusMessageManualChangeEntity>
     {
         private readonly ITableWrapper _table;
-        private readonly ILogger<DeleteStatusMessageManualChangeHandler> _logger;
 
         public DeleteStatusMessageManualChangeHandler(
             ITableWrapper table,
             ILogger<DeleteStatusMessageManualChangeHandler> logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public Task Handle(DeleteStatusMessageManualChangeEntity entity)

--- a/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;
@@ -15,8 +14,7 @@ namespace StatusAggregator.Manual
         private readonly ITableWrapper _table;
 
         public DeleteStatusMessageManualChangeHandler(
-            ITableWrapper table,
-            ILogger<DeleteStatusMessageManualChangeHandler> logger)
+            ITableWrapper table)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
         }

--- a/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/DeleteStatusMessageManualChangeHandler.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public class DeleteStatusMessageManualChangeHandler : IManualStatusChangeHandler<DeleteStatusMessageManualChangeEntity>
+    {
+        private readonly ITableWrapper _table;
+        private readonly ILogger<DeleteStatusMessageManualChangeHandler> _logger;
+
+        public DeleteStatusMessageManualChangeHandler(
+            ITableWrapper table,
+            ILogger<DeleteStatusMessageManualChangeHandler> logger)
+        {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task Handle(DeleteStatusMessageManualChangeEntity entity)
+        {
+            var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+            var messageRowKey = MessageEntity.GetRowKey(eventRowKey, entity.MessageTimestamp);
+            return _table.DeleteAsync(MessageEntity.DefaultPartitionKey, messageRowKey);
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;

--- a/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public class EditStatusEventManualChangeHandler : IManualStatusChangeHandler<EditStatusEventManualChangeEntity>
+    {
+        private readonly ITableWrapper _table;
+        private readonly ILogger<EditStatusEventManualChangeHandler> _logger;
+
+        public EditStatusEventManualChangeHandler(
+            ITableWrapper table,
+            ILogger<EditStatusEventManualChangeHandler> logger)
+        {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task Handle(EditStatusEventManualChangeEntity entity)
+        {
+            var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+            var eventEntity = await _table.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey);
+            eventEntity.AffectedComponentStatus = entity.EventAffectedComponentStatus;
+            ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.ChangeTimestamp);
+
+            await _table.ReplaceAsync(eventEntity);
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
@@ -26,7 +26,7 @@ namespace StatusAggregator.Manual
             var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
             var eventEntity = await _table.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey);
             eventEntity.AffectedComponentStatus = entity.EventAffectedComponentStatus;
-            ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.ChangeTimestamp);
+            ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.Timestamp.UtcDateTime);
 
             await _table.ReplaceAsync(eventEntity);
         }

--- a/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;
@@ -15,8 +14,7 @@ namespace StatusAggregator.Manual
         private readonly ITableWrapper _table;
 
         public EditStatusEventManualChangeHandler(
-            ITableWrapper table,
-            ILogger<EditStatusEventManualChangeHandler> logger)
+            ITableWrapper table)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
         }
@@ -25,6 +23,11 @@ namespace StatusAggregator.Manual
         {
             var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
             var eventEntity = await _table.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey);
+            if (eventEntity == null)
+            {
+                throw new ArgumentException("Cannot edit an event that does not exist.");
+            }
+
             eventEntity.AffectedComponentStatus = entity.EventAffectedComponentStatus;
             ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, entity.EventIsActive, entity.Timestamp.UtcDateTime);
 

--- a/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusEventManualChangeHandler.cs
@@ -10,14 +10,12 @@ namespace StatusAggregator.Manual
     public class EditStatusEventManualChangeHandler : IManualStatusChangeHandler<EditStatusEventManualChangeEntity>
     {
         private readonly ITableWrapper _table;
-        private readonly ILogger<EditStatusEventManualChangeHandler> _logger;
 
         public EditStatusEventManualChangeHandler(
             ITableWrapper table,
             ILogger<EditStatusEventManualChangeHandler> logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task Handle(EditStatusEventManualChangeEntity entity)

--- a/src/StatusAggregator/Manual/EditStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusMessageManualChangeHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Services.Status.Table;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;

--- a/src/StatusAggregator/Manual/EditStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusMessageManualChangeHandler.cs
@@ -10,14 +10,12 @@ namespace StatusAggregator.Manual
     public class EditStatusMessageManualChangeHandler : IManualStatusChangeHandler<EditStatusMessageManualChangeEntity>
     {
         private readonly ITableWrapper _table;
-        private readonly ILogger<EditStatusMessageManualChangeHandler> _logger;
 
         public EditStatusMessageManualChangeHandler(
             ITableWrapper table,
             ILogger<EditStatusMessageManualChangeHandler> logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task Handle(EditStatusMessageManualChangeEntity entity)

--- a/src/StatusAggregator/Manual/EditStatusMessageManualChangeHandler.cs
+++ b/src/StatusAggregator/Manual/EditStatusMessageManualChangeHandler.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public class EditStatusMessageManualChangeHandler : IManualStatusChangeHandler<EditStatusMessageManualChangeEntity>
+    {
+        private readonly ITableWrapper _table;
+        private readonly ILogger<EditStatusMessageManualChangeHandler> _logger;
+
+        public EditStatusMessageManualChangeHandler(
+            ITableWrapper table,
+            ILogger<EditStatusMessageManualChangeHandler> logger)
+        {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task Handle(EditStatusMessageManualChangeEntity entity)
+        {
+            var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+            var messageEntity = await _table.RetrieveAsync<MessageEntity>(
+                MessageEntity.DefaultPartitionKey,
+                MessageEntity.GetRowKey(eventRowKey, entity.MessageTimestamp));
+
+            messageEntity.Contents = entity.MessageContents;
+
+            await _table.ReplaceAsync(messageEntity);
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/IManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/IManualStatusChangeHandler.cs
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Table;
 using System.Threading.Tasks;
 
 namespace StatusAggregator.Manual
 {
     public interface IManualStatusChangeHandler
     {
-        Task Handle(ManualStatusChangeEntity entity);
+        Task Handle(ITableWrapper table, ManualStatusChangeEntity entity);
     }
 
     public interface IManualStatusChangeHandler<T>

--- a/src/StatusAggregator/Manual/IManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/IManualStatusChangeHandler.cs
@@ -7,14 +7,27 @@ using System.Threading.Tasks;
 
 namespace StatusAggregator.Manual
 {
+    /// <summary>
+    /// Handles updating the primary storage with an instance of <see cref="ManualStatusChangeEntity"/>.
+    /// </summary>
     public interface IManualStatusChangeHandler
     {
+        /// <summary>
+        /// Updates the primary storage with <paramref name="entity"/>, which came from <paramref name="table"/>.
+        /// </summary>
         Task Handle(ITableWrapper table, ManualStatusChangeEntity entity);
     }
 
+    /// <summary>
+    /// Handles updating the primary storage with an instance of <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
     public interface IManualStatusChangeHandler<T>
         where T : ManualStatusChangeEntity
     {
+        /// <summary>
+        /// Updates the primary storage with <paramref name="entity"/>, which is a subclass of <see cref="ManualStatusChangeEntity"/>.
+        /// </summary>
         Task Handle(T entity);
     }
 }

--- a/src/StatusAggregator/Manual/IManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/IManualStatusChangeHandler.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Status.Table.Manual;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public interface IManualStatusChangeHandler
+    {
+        Task Handle(ManualStatusChangeEntity entity);
+    }
+
+    public interface IManualStatusChangeHandler<T>
+        where T : ManualStatusChangeEntity
+    {
+        Task Handle(T entity);
+    }
+}

--- a/src/StatusAggregator/Manual/IManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/IManualStatusChangeUpdater.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public interface IManualStatusChangeUpdater
+    {
+        Task<DateTime?> ProcessNewManualChanges(DateTime cursor);
+    }
+}

--- a/src/StatusAggregator/Manual/IManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/IManualStatusChangeUpdater.cs
@@ -5,6 +5,8 @@ namespace StatusAggregator.Manual
 {
     public interface IManualStatusChangeUpdater
     {
+        string Name { get; }
+
         Task<DateTime?> ProcessNewManualChanges(DateTime cursor);
     }
 }

--- a/src/StatusAggregator/Manual/IManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/IManualStatusChangeUpdater.cs
@@ -1,12 +1,24 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 
 namespace StatusAggregator.Manual
 {
+    /// <summary>
+    /// Monitors a storage for the manual status changes posted to it.
+    /// </summary>
     public interface IManualStatusChangeUpdater
     {
+        /// <summary>
+        /// An identifier for what storage that the manual status changes are being monitored from.
+        /// </summary>
         string Name { get; }
 
+        /// <summary>
+        /// Processes all manual status changes in the storage that are more recent than <paramref name="cursor"/>.
+        /// </summary>
         Task<DateTime?> ProcessNewManualChanges(DateTime cursor);
     }
 }

--- a/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
@@ -11,14 +11,11 @@ namespace StatusAggregator
 {
     public class ManualStatusChangeHandler : IManualStatusChangeHandler
     {
-        private readonly ITableWrapper _table;
-
         private IDictionary<ManualStatusChangeType, IManualStatusChangeProcessor> _processorForType;
 
         private readonly ILogger<ManualStatusChangeHandler> _logger;
 
         public ManualStatusChangeHandler(
-            ITableWrapper table,
             IManualStatusChangeHandler<AddStatusEventManualChangeEntity> addStatusEventManualChangeHandler,
             IManualStatusChangeHandler<EditStatusEventManualChangeEntity> editStatusEventManualChangeHandler,
             IManualStatusChangeHandler<DeleteStatusEventManualChangeEntity> deleteStatusEventManualChangeHandler,
@@ -27,21 +24,43 @@ namespace StatusAggregator
             IManualStatusChangeHandler<DeleteStatusMessageManualChangeEntity> deleteStatusMessageManualChangeHandler,
             ILogger<ManualStatusChangeHandler> logger)
         {
-            _table = table ?? throw new ArgumentNullException(nameof(table));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             _processorForType = new Dictionary<ManualStatusChangeType, IManualStatusChangeProcessor>
             {
-                { ManualStatusChangeType.AddStatusEvent, new ManualStatusChangeProcessor<AddStatusEventManualChangeEntity>(this, addStatusEventManualChangeHandler) },
-                { ManualStatusChangeType.EditStatusEvent, new ManualStatusChangeProcessor<EditStatusEventManualChangeEntity>(this, editStatusEventManualChangeHandler) },
-                { ManualStatusChangeType.DeleteStatusEvent, new ManualStatusChangeProcessor<DeleteStatusEventManualChangeEntity>(this, deleteStatusEventManualChangeHandler) },
-                { ManualStatusChangeType.AddStatusMessage, new ManualStatusChangeProcessor<AddStatusMessageManualChangeEntity>(this, addStatusMessageManualChangeHandler) },
-                { ManualStatusChangeType.EditStatusMessage, new ManualStatusChangeProcessor<EditStatusMessageManualChangeEntity>(this, editStatusMessageManualChangeHandler) },
-                { ManualStatusChangeType.DeleteStatusMessage, new ManualStatusChangeProcessor<DeleteStatusMessageManualChangeEntity>(this, deleteStatusMessageManualChangeHandler) }
+                {
+                    ManualStatusChangeType.AddStatusEvent,
+                    new ManualStatusChangeProcessor<AddStatusEventManualChangeEntity>(addStatusEventManualChangeHandler)
+                },
+
+                {
+                    ManualStatusChangeType.EditStatusEvent,
+                    new ManualStatusChangeProcessor<EditStatusEventManualChangeEntity>(editStatusEventManualChangeHandler)
+                },
+
+                {
+                    ManualStatusChangeType.DeleteStatusEvent,
+                    new ManualStatusChangeProcessor<DeleteStatusEventManualChangeEntity>(deleteStatusEventManualChangeHandler)
+                },
+
+                {
+                    ManualStatusChangeType.AddStatusMessage,
+                    new ManualStatusChangeProcessor<AddStatusMessageManualChangeEntity>(addStatusMessageManualChangeHandler)
+                },
+
+                {
+                    ManualStatusChangeType.EditStatusMessage,
+                    new ManualStatusChangeProcessor<EditStatusMessageManualChangeEntity>(editStatusMessageManualChangeHandler)
+                },
+
+                {
+                    ManualStatusChangeType.DeleteStatusMessage,
+                    new ManualStatusChangeProcessor<DeleteStatusMessageManualChangeEntity>(deleteStatusMessageManualChangeHandler)
+                }
             };
         }
 
-        public async Task Handle(ManualStatusChangeEntity entity)
+        public async Task Handle(ITableWrapper table, ManualStatusChangeEntity entity)
         {
             using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.ChangeTimestamp, entity.Type.ToString()))
             {
@@ -50,7 +69,7 @@ namespace StatusAggregator
                     var type = (ManualStatusChangeType)entity.Type;
                     if (_processorForType.ContainsKey(type))
                     {
-                        await _processorForType[type].GetTask(entity);
+                        await _processorForType[type].GetTask(table, entity);
                     }
                     else
                     {
@@ -66,24 +85,22 @@ namespace StatusAggregator
 
         private interface IManualStatusChangeProcessor
         {
-            Task GetTask(ManualStatusChangeEntity entity);
+            Task GetTask(ITableWrapper table, ManualStatusChangeEntity entity);
         }
 
         private class ManualStatusChangeProcessor<T> : IManualStatusChangeProcessor
             where T : ManualStatusChangeEntity
         {
-            private readonly ManualStatusChangeHandler _parent;
             private readonly IManualStatusChangeHandler<T> _handler;
 
-            public ManualStatusChangeProcessor(ManualStatusChangeHandler parent, IManualStatusChangeHandler<T> handler)
+            public ManualStatusChangeProcessor(IManualStatusChangeHandler<T> handler)
             {
-                _parent = parent;
                 _handler = handler;
             }
 
-            public async Task GetTask(ManualStatusChangeEntity entity)
+            public async Task GetTask(ITableWrapper table, ManualStatusChangeEntity entity)
             {
-                var typedEntity = await _parent._table.RetrieveAsync<T>(entity.PartitionKey, entity.RowKey);
+                var typedEntity = await table.RetrieveAsync<T>(entity.PartitionKey, entity.RowKey);
                 await _handler.Handle(typedEntity);
             }
         }

--- a/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
@@ -14,7 +14,7 @@ namespace StatusAggregator
 {
     public class ManualStatusChangeHandler : IManualStatusChangeHandler
     {
-        private IDictionary<ManualStatusChangeType, IManualStatusChangeProcessor> _processorForType;
+        private readonly IDictionary<ManualStatusChangeType, IManualStatusChangeProcessor> _processorForType;
 
         private readonly ILogger<ManualStatusChangeHandler> _logger;
 
@@ -33,39 +33,45 @@ namespace StatusAggregator
             {
                 {
                     ManualStatusChangeType.AddStatusEvent,
-                    new ManualStatusChangeProcessor<AddStatusEventManualChangeEntity>(addStatusEventManualChangeHandler)
+                    new ManualStatusChangeProcessor<AddStatusEventManualChangeEntity>(
+                        addStatusEventManualChangeHandler ?? throw new ArgumentNullException(nameof(addStatusEventManualChangeHandler)))
                 },
 
                 {
                     ManualStatusChangeType.EditStatusEvent,
-                    new ManualStatusChangeProcessor<EditStatusEventManualChangeEntity>(editStatusEventManualChangeHandler)
+                    new ManualStatusChangeProcessor<EditStatusEventManualChangeEntity>(
+                        editStatusEventManualChangeHandler ?? throw new ArgumentNullException(nameof(editStatusEventManualChangeHandler)))
                 },
 
                 {
                     ManualStatusChangeType.DeleteStatusEvent,
-                    new ManualStatusChangeProcessor<DeleteStatusEventManualChangeEntity>(deleteStatusEventManualChangeHandler)
+                    new ManualStatusChangeProcessor<DeleteStatusEventManualChangeEntity>(
+                        deleteStatusEventManualChangeHandler ?? throw new ArgumentNullException(nameof(deleteStatusEventManualChangeHandler)))
                 },
 
                 {
                     ManualStatusChangeType.AddStatusMessage,
-                    new ManualStatusChangeProcessor<AddStatusMessageManualChangeEntity>(addStatusMessageManualChangeHandler)
+                    new ManualStatusChangeProcessor<AddStatusMessageManualChangeEntity>(
+                        addStatusMessageManualChangeHandler ?? throw new ArgumentNullException(nameof(addStatusMessageManualChangeHandler)))
                 },
 
                 {
                     ManualStatusChangeType.EditStatusMessage,
-                    new ManualStatusChangeProcessor<EditStatusMessageManualChangeEntity>(editStatusMessageManualChangeHandler)
+                    new ManualStatusChangeProcessor<EditStatusMessageManualChangeEntity>(
+                        editStatusMessageManualChangeHandler ?? throw new ArgumentNullException(nameof(editStatusMessageManualChangeHandler)))
                 },
 
                 {
                     ManualStatusChangeType.DeleteStatusMessage,
-                    new ManualStatusChangeProcessor<DeleteStatusMessageManualChangeEntity>(deleteStatusMessageManualChangeHandler)
+                    new ManualStatusChangeProcessor<DeleteStatusMessageManualChangeEntity>(
+                        deleteStatusMessageManualChangeHandler ?? throw new ArgumentNullException(nameof(deleteStatusMessageManualChangeHandler)))
                 }
             };
         }
 
         public async Task Handle(ITableWrapper table, ManualStatusChangeEntity entity)
         {
-            using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.ChangeTimestamp, entity.Type.ToString()))
+            using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.Timestamp, entity.Type))
             {
                 try
                 {
@@ -76,7 +82,7 @@ namespace StatusAggregator
                     }
                     else
                     {
-                        throw new ArgumentException("Invalid change type! Cannot process manual status change!", nameof(entity));
+                        throw new ArgumentException("Invalid change type {ChangeType}! Cannot process manual status change!");
                     }
                 }
                 catch (Exception e)

--- a/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
@@ -71,7 +71,7 @@ namespace StatusAggregator
 
         public async Task Handle(ITableWrapper table, ManualStatusChangeEntity entity)
         {
-            using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.Timestamp, entity.Type))
+            using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.Timestamp, entity.Type.ToString()))
             {
                 try
                 {

--- a/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGet.Jobs.Extensions;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
+using StatusAggregator.Table;
+
+namespace StatusAggregator
+{
+    public class ManualStatusChangeHandler : IManualStatusChangeHandler
+    {
+        private readonly ITableWrapper _table;
+
+        private IDictionary<ManualStatusChangeType, IManualStatusChangeProcessor> _processorForType;
+
+        private readonly ILogger<ManualStatusChangeHandler> _logger;
+
+        public ManualStatusChangeHandler(
+            ITableWrapper table,
+            IManualStatusChangeHandler<AddStatusEventManualChangeEntity> addStatusEventManualChangeHandler,
+            IManualStatusChangeHandler<EditStatusEventManualChangeEntity> editStatusEventManualChangeHandler,
+            IManualStatusChangeHandler<DeleteStatusEventManualChangeEntity> deleteStatusEventManualChangeHandler,
+            IManualStatusChangeHandler<AddStatusMessageManualChangeEntity> addStatusMessageManualChangeHandler,
+            IManualStatusChangeHandler<EditStatusMessageManualChangeEntity> editStatusMessageManualChangeHandler,
+            IManualStatusChangeHandler<DeleteStatusMessageManualChangeEntity> deleteStatusMessageManualChangeHandler,
+            ILogger<ManualStatusChangeHandler> logger)
+        {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _processorForType = new Dictionary<ManualStatusChangeType, IManualStatusChangeProcessor>
+            {
+                { ManualStatusChangeType.AddStatusEvent, new ManualStatusChangeProcessor<AddStatusEventManualChangeEntity>(this, addStatusEventManualChangeHandler) },
+                { ManualStatusChangeType.EditStatusEvent, new ManualStatusChangeProcessor<EditStatusEventManualChangeEntity>(this, editStatusEventManualChangeHandler) },
+                { ManualStatusChangeType.DeleteStatusEvent, new ManualStatusChangeProcessor<DeleteStatusEventManualChangeEntity>(this, deleteStatusEventManualChangeHandler) },
+                { ManualStatusChangeType.AddStatusMessage, new ManualStatusChangeProcessor<AddStatusMessageManualChangeEntity>(this, addStatusMessageManualChangeHandler) },
+                { ManualStatusChangeType.EditStatusMessage, new ManualStatusChangeProcessor<EditStatusMessageManualChangeEntity>(this, editStatusMessageManualChangeHandler) },
+                { ManualStatusChangeType.DeleteStatusMessage, new ManualStatusChangeProcessor<DeleteStatusMessageManualChangeEntity>(this, deleteStatusMessageManualChangeHandler) }
+            };
+        }
+
+        public async Task Handle(ManualStatusChangeEntity entity)
+        {
+            using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.ChangeTimestamp, entity.Type.ToString()))
+            {
+                try
+                {
+                    var type = (ManualStatusChangeType)entity.Type;
+                    if (_processorForType.ContainsKey(type))
+                    {
+                        await _processorForType[type].GetTask(entity);
+                    }
+                    else
+                    {
+                        throw new ArgumentException("Invalid change type! Cannot process manual status change!", nameof(entity));
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(LogEvents.ManualChangeFailure, e, "Failed to apply manual status change!");
+                }
+            }
+        }
+
+        private interface IManualStatusChangeProcessor
+        {
+            Task GetTask(ManualStatusChangeEntity entity);
+        }
+
+        private class ManualStatusChangeProcessor<T> : IManualStatusChangeProcessor
+            where T : ManualStatusChangeEntity
+        {
+            private readonly ManualStatusChangeHandler _parent;
+            private readonly IManualStatusChangeHandler<T> _handler;
+
+            public ManualStatusChangeProcessor(ManualStatusChangeHandler parent, IManualStatusChangeHandler<T> handler)
+            {
+                _parent = parent;
+                _handler = handler;
+            }
+
+            public async Task GetTask(ManualStatusChangeEntity entity)
+            {
+                var typedEntity = await _parent._table.RetrieveAsync<T>(entity.PartitionKey, entity.RowKey);
+                await _handler.Handle(typedEntity);
+            }
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -88,6 +91,9 @@ namespace StatusAggregator
             Task GetTask(ITableWrapper table, ManualStatusChangeEntity entity);
         }
 
+        /// <summary>
+        /// Maps a <see cref="ManualStatusChangeEntity"/> to a <see cref="IManualStatusChangeHandler{T}"/>.
+        /// </summary>
         private class ManualStatusChangeProcessor<T> : IManualStatusChangeProcessor
             where T : ManualStatusChangeEntity
         {

--- a/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeHandler.cs
@@ -71,7 +71,7 @@ namespace StatusAggregator
 
         public async Task Handle(ITableWrapper table, ManualStatusChangeEntity entity)
         {
-            using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.Timestamp, entity.Type.ToString()))
+            using (_logger.Scope("Handling manual status change at timestamp {ChangeTimestamp} with type {ChangeType}", entity.Timestamp, Enum.GetName(typeof(ManualStatusChangeType), entity.Type)))
             {
                 try
                 {

--- a/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
@@ -43,7 +43,7 @@ namespace StatusAggregator.Manual
                 // If we are fetching manual changes for the first time, don't filter on the timestamp.
                 if (cursor > DateTime.MinValue)
                 {
-                    manualChangesQuery = manualChangesQuery.Where(c => c.ChangeTimestamp > cursor);
+                    manualChangesQuery = manualChangesQuery.Where(c => c.Timestamp.UtcDateTime > cursor);
                 }
                 
                 var manualChanges = manualChangesQuery.ToList();
@@ -53,9 +53,8 @@ namespace StatusAggregator.Manual
                 {
                     await _handler.Handle(_table, manualChange);
                 }
-
-                var nextCursor = manualChanges.Any() ? manualChanges.Max(c => c.Timestamp) : (DateTimeOffset?)null;
-                return nextCursor?.UtcDateTime;
+                
+                return manualChanges.Any() ? manualChanges.Max(c => c.Timestamp.UtcDateTime) : (DateTime?)null;
             }
         }
     }

--- a/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using NuGet.Jobs.Extensions;
 using NuGet.Services.Status.Table.Manual;
 using StatusAggregator.Table;

--- a/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
@@ -15,14 +15,18 @@ namespace StatusAggregator.Manual
         private readonly ILogger<ManualStatusChangeUpdater> _logger;
 
         public ManualStatusChangeUpdater(
+            string name,
             ITableWrapper table,
             IManualStatusChangeHandler handler,
             ILogger<ManualStatusChangeUpdater> logger)
         {
+            Name = name;
             _table = table ?? throw new ArgumentNullException(nameof(table));
             _handler = handler ?? throw new ArgumentNullException(nameof(handler));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
+
+        public string Name { get; }
 
         public async Task<DateTime?> ProcessNewManualChanges(DateTime cursor)
         {
@@ -44,7 +48,7 @@ namespace StatusAggregator.Manual
                 _logger.LogInformation("Processing {ManualChangesCount} manual status changes.", manualChanges.Count());
                 foreach (var manualChange in manualChanges)
                 {
-                    await _handler.Handle(manualChange);
+                    await _handler.Handle(_table, manualChange);
                 }
 
                 return manualChanges.Any() ? manualChanges.Max(c => c.ChangeTimestamp) : (DateTime?)null;

--- a/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Jobs.Extensions;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StatusAggregator.Manual
+{
+    public class ManualStatusChangeUpdater : IManualStatusChangeUpdater
+    {
+        private readonly ITableWrapper _table;
+        private readonly IManualStatusChangeHandler _handler;
+        private readonly ILogger<ManualStatusChangeUpdater> _logger;
+
+        public ManualStatusChangeUpdater(
+            ITableWrapper table,
+            IManualStatusChangeHandler handler,
+            ILogger<ManualStatusChangeUpdater> logger)
+        {
+            _table = table ?? throw new ArgumentNullException(nameof(table));
+            _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<DateTime?> ProcessNewManualChanges(DateTime cursor)
+        {
+            using (_logger.Scope("Processing manual status changes."))
+            {
+                var manualChangesQuery = _table
+                    .CreateQuery<ManualStatusChangeEntity>()
+                    .Where(c => c.PartitionKey == ManualStatusChangeEntity.DefaultPartitionKey);
+
+                // Table storage throws on queries with DateTime values that are too low.
+                // If we are fetching manual changes for the first time, don't filter on the timestamp.
+                if (cursor > DateTime.MinValue)
+                {
+                    manualChangesQuery = manualChangesQuery.Where(c => c.ChangeTimestamp > cursor);
+                }
+                
+                var manualChanges = manualChangesQuery.ToList();
+
+                _logger.LogInformation("Processing {ManualChangesCount} manual status changes.", manualChanges.Count());
+                foreach (var manualChange in manualChanges)
+                {
+                    await _handler.Handle(manualChange);
+                }
+
+                return manualChanges.Any() ? manualChanges.Max(c => c.ChangeTimestamp) : (DateTime?)null;
+            }
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
@@ -54,7 +54,8 @@ namespace StatusAggregator.Manual
                     await _handler.Handle(_table, manualChange);
                 }
 
-                return manualChanges.Any() ? manualChanges.Max(c => c.ChangeTimestamp) : (DateTime?)null;
+                var nextCursor = manualChanges.Any() ? manualChanges.Max(c => c.Timestamp) : (DateTimeOffset?)null;
+                return nextCursor?.UtcDateTime;
             }
         }
     }

--- a/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUpdater.cs
@@ -43,7 +43,7 @@ namespace StatusAggregator.Manual
                 // If we are fetching manual changes for the first time, don't filter on the timestamp.
                 if (cursor > DateTime.MinValue)
                 {
-                    manualChangesQuery = manualChangesQuery.Where(c => c.Timestamp.UtcDateTime > cursor);
+                    manualChangesQuery = manualChangesQuery.Where(c => c.Timestamp > new DateTimeOffset(cursor, TimeSpan.Zero));
                 }
                 
                 var manualChanges = manualChangesQuery.ToList();

--- a/src/StatusAggregator/Manual/ManualStatusChangeUtility.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUtility.cs
@@ -1,0 +1,27 @@
+﻿using NuGet.Services.Status.Table;
+using System;
+
+namespace StatusAggregator.Manual
+{
+    public static class ManualStatusChangeUtility
+    {
+        public static bool UpdateEventIsActive(EventEntity eventEntity, bool eventIsActive, DateTime timestamp)
+        {
+            var shouldUpdateEvent = true;
+            if (eventIsActive && eventEntity.EndTime != null)
+            {
+                throw new ArgumentException("An event cannot be reactivated!", nameof(eventIsActive));
+            }
+            else if (!eventIsActive && eventEntity.EndTime == null)
+            {
+                eventEntity.EndTime = timestamp;
+            }
+            else
+            {
+                shouldUpdateEvent = false;
+            }
+
+            return shouldUpdateEvent;
+        }
+    }
+}

--- a/src/StatusAggregator/Manual/ManualStatusChangeUtility.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUtility.cs
@@ -1,10 +1,21 @@
-﻿using NuGet.Services.Status.Table;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Status.Table;
 using System;
 
 namespace StatusAggregator.Manual
 {
     public static class ManualStatusChangeUtility
     {
+        /// <summary>
+        /// Compares <paramref name="eventEntity"/> to <paramref name="eventIsActive"/> and updates <paramref name="eventEntity"/> if they do not match.
+        /// </summary>
+        /// <param name="timestamp">A <see cref="DateTime"/> that represents when <paramref name="eventEntity"/> was closed if <paramref name="eventIsActive"/> is <c>false</c>.</param>
+        /// <returns>
+        /// Whether or not <paramref name="eventEntity"/> was updated.
+        /// If true, the changes to <paramref name="eventEntity"/> should be saved to the table.
+        /// </returns>
         public static bool UpdateEventIsActive(EventEntity eventEntity, bool eventIsActive, DateTime timestamp)
         {
             var shouldUpdateEvent = true;

--- a/src/StatusAggregator/Manual/ManualStatusChangeUtility.cs
+++ b/src/StatusAggregator/Manual/ManualStatusChangeUtility.cs
@@ -9,30 +9,42 @@ namespace StatusAggregator.Manual
     public static class ManualStatusChangeUtility
     {
         /// <summary>
-        /// Compares <paramref name="eventEntity"/> to <paramref name="eventIsActive"/> and updates <paramref name="eventEntity"/> if they do not match.
+        /// Compares <paramref name="eventEntity"/> to <paramref name="eventIsActive"/> and updates <paramref name="eventEntity"/>'s <see cref="EventEntity.EndTime"/> if it should be updated.
         /// </summary>
         /// <param name="timestamp">A <see cref="DateTime"/> that represents when <paramref name="eventEntity"/> was closed if <paramref name="eventIsActive"/> is <c>false</c>.</param>
         /// <returns>
         /// Whether or not <paramref name="eventEntity"/> was updated.
         /// If true, the changes to <paramref name="eventEntity"/> should be saved to the table.
         /// </returns>
+        /// <remarks>
+        /// An event cannot be reactivated, so <paramref name="eventEntity"/> WILL NOT be updated if it is already deactivated.
+        /// </remarks>
         public static bool UpdateEventIsActive(EventEntity eventEntity, bool eventIsActive, DateTime timestamp)
         {
-            var shouldUpdateEvent = true;
-            if (eventIsActive && eventEntity.EndTime != null)
-            {
-                throw new ArgumentException("An event cannot be reactivated!", nameof(eventIsActive));
-            }
-            else if (!eventIsActive && eventEntity.EndTime == null)
+            var shouldUpdateEvent = ShouldEventBeActive(eventEntity, eventIsActive, timestamp);
+            if (shouldUpdateEvent)
             {
                 eventEntity.EndTime = timestamp;
             }
-            else
-            {
-                shouldUpdateEvent = false;
-            }
 
             return shouldUpdateEvent;
+        }
+
+        /// <summary>
+        /// Compares <paramref name="eventEntity"/> to <paramref name="eventIsActive"/> and returns whether or not <paramref name="eventEntity"/>'s <see cref="EventEntity.EndTime"/> should be updated.
+        /// </summary>
+        /// <param name="timestamp">A <see cref="DateTime"/> that represents when <paramref name="eventEntity"/> was closed if <paramref name="eventIsActive"/> is <c>false</c>.</param>
+        /// <returns>
+        /// Whether or not <paramref name="eventEntity"/>'s <see cref="EventEntity.EndTime"/> should be updated.
+        /// </returns>
+        /// <remarks>
+        /// An event cannot be reactivated, so <paramref name="eventEntity"/> SHOULD NOT be updated if it is already deactivated.
+        /// </remarks>
+        public static bool ShouldEventBeActive(EventEntity eventEntity, bool eventIsActive, DateTime timestamp)
+        {
+            eventEntity = eventEntity ?? throw new ArgumentNullException(nameof(eventEntity));
+
+            return !eventIsActive && eventEntity.EndTime == null;
         }
     }
 }

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -118,13 +118,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.28.0-sb-tablegeo-38564</Version>
+      <Version>2.28.0-master-38796</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.28.0-sb-tablegeo-38564</Version>
+      <Version>2.28.0-master-38796</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.28.0-sb-tablegeo-38564</Version>
+      <Version>2.28.0-master-38796</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.2.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -118,13 +118,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.28.0-sb-tablegeo-37591</Version>
+      <Version>2.28.0-sb-tablegeo-38564</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.28.0-sb-tablegeo-37669</Version>
+      <Version>2.28.0-sb-tablegeo-38564</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.28.0-sb-tablegeo-37669</Version>
+      <Version>2.28.0-sb-tablegeo-38564</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.2.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -76,6 +76,7 @@
     <Compile Include="IMessageUpdater.cs" />
     <Compile Include="StatusAggregator.cs" />
     <Compile Include="StatusContractResolver.cs" />
+    <Compile Include="StatusStorageConnectionBuilder.cs" />
     <Compile Include="StatusUpdater.cs" />
     <Compile Include="Parse\AggregateIncidentParser.cs" />
     <Compile Include="Parse\IAggregateIncidentParser.cs" />
@@ -107,6 +108,12 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Autofac">
+      <Version>4.6.2</Version>
+    </PackageReference>
+    <PackageReference Include="Autofac.Extensions.DependencyInjection">
+      <Version>4.2.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>1.1.1</Version>
     </PackageReference>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -46,6 +46,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Manual\AddStatusEventManualChangeHandler.cs" />
+    <Compile Include="Manual\AddStatusMessageManualChangeHandler.cs" />
+    <Compile Include="Manual\DeleteStatusEventManualChangeHandler.cs" />
+    <Compile Include="Manual\DeleteStatusMessageManualChangeHandler.cs" />
+    <Compile Include="Manual\EditStatusEventManualChangeHandler.cs" />
+    <Compile Include="Manual\EditStatusMessageManualChangeHandler.cs" />
+    <Compile Include="Manual\IManualStatusChangeHandler.cs" />
+    <Compile Include="Manual\IManualStatusChangeUpdater.cs" />
+    <Compile Include="Manual\ManualStatusChangeHandler.cs" />
+    <Compile Include="Manual\ManualStatusChangeUpdater.cs" />
+    <Compile Include="Manual\ManualStatusChangeUtility.cs" />
     <Compile Include="NuGetServiceComponentFactory.cs" />
     <Compile Include="LogEvents.cs" />
     <Compile Include="Parse\TrafficManagerEndpointStatusIncidentParser.cs" />
@@ -82,6 +93,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Parse\ValidationDurationIncidentParser.cs" />
+    <Compile Include="Table\TableUtility.cs" />
     <Compile Include="Table\TableWrapper.cs" />
     <Compile Include="Table\TableWrapperExtensions.cs" />
   </ItemGroup>
@@ -99,13 +111,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.28.0-sb-morestatus-35915</Version>
+      <Version>2.28.0-sb-tablegeo-37591</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.28.0-sb-morestatus-35915</Version>
+      <Version>2.28.0-sb-tablegeo-37669</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.28.0-sb-morestatus-35915</Version>
+      <Version>2.28.0-sb-tablegeo-37669</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.2.0</Version>

--- a/src/StatusAggregator/StatusAggregatorConfiguration.cs
+++ b/src/StatusAggregator/StatusAggregatorConfiguration.cs
@@ -25,6 +25,11 @@ namespace StatusAggregator
         public string TableName { get; set; }
 
         /// <summary>
+        /// A connection string for the secondary storage account to use.
+        /// </summary>
+        public string StorageAccountSecondary { get; set; }
+
+        /// <summary>
         /// A list of environments to filter incidents by.
         /// See <see cref="EnvironmentFilter"/>.
         /// </summary>

--- a/src/StatusAggregator/StatusStorageConnectionBuilder.cs
+++ b/src/StatusAggregator/StatusStorageConnectionBuilder.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StatusAggregator
+{
+    public class StatusStorageConnectionBuilder
+    {
+        public Func<StatusAggregatorConfiguration, string> GetConnectionString { get; }
+        public string Name { get; }
+
+        public StatusStorageConnectionBuilder(
+            Func<StatusAggregatorConfiguration, string> getConnectionString,
+            string name)
+        {
+            GetConnectionString = getConnectionString;
+            Name = name;
+        }
+    }
+}

--- a/src/StatusAggregator/StatusStorageConnectionBuilder.cs
+++ b/src/StatusAggregator/StatusStorageConnectionBuilder.cs
@@ -25,8 +25,8 @@ namespace StatusAggregator
             string name,
             Func<StatusAggregatorConfiguration, string> getConnectionString)
         {
-            Name = name;
-            GetConnectionString = getConnectionString;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            GetConnectionString = getConnectionString ?? throw new ArgumentNullException(nameof(getConnectionString));
         }
     }
 }

--- a/src/StatusAggregator/StatusStorageConnectionBuilder.cs
+++ b/src/StatusAggregator/StatusStorageConnectionBuilder.cs
@@ -1,22 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 
 namespace StatusAggregator
 {
+    /// <summary>
+    /// Helps build a storage account from configuration.
+    /// Used exclusively by DI.
+    /// </summary>
     public class StatusStorageConnectionBuilder
     {
-        public Func<StatusAggregatorConfiguration, string> GetConnectionString { get; }
+        /// <summary>
+        /// An identifier to use as the name of this storage account.
+        /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// Describes how to access this storage account's connection string using the job's configuration.
+        /// </summary>
+        public Func<StatusAggregatorConfiguration, string> GetConnectionString { get; }
+
         public StatusStorageConnectionBuilder(
-            Func<StatusAggregatorConfiguration, string> getConnectionString,
-            string name)
+            string name,
+            Func<StatusAggregatorConfiguration, string> getConnectionString)
         {
-            GetConnectionString = getConnectionString;
             Name = name;
+            GetConnectionString = getConnectionString;
         }
     }
 }

--- a/src/StatusAggregator/Table/ITableWrapper.cs
+++ b/src/StatusAggregator/Table/ITableWrapper.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.WindowsAzure.Storage.Table;
 
-
 namespace StatusAggregator.Table
 {
     public interface ITableWrapper

--- a/src/StatusAggregator/Table/ITableWrapper.cs
+++ b/src/StatusAggregator/Table/ITableWrapper.cs
@@ -12,10 +12,22 @@ namespace StatusAggregator.Table
     {
         Task CreateIfNotExistsAsync();
 
-        Task<T> Retrieve<T>(string partitionKey, string rowKey) 
+        Task<T> RetrieveAsync<T>(string partitionKey, string rowKey) 
             where T : class, ITableEntity;
 
+        Task InsertAsync(ITableEntity tableEntity);
+
         Task InsertOrReplaceAsync(ITableEntity tableEntity);
+
+        Task ReplaceAsync(ITableEntity tableEntity);
+
+        Task MergeAsync(ITableEntity tableEntity);
+
+        Task DeleteAsync(string partitionKey, string rowKey);
+
+        Task DeleteAsync(string partitionKey, string rowKey, string eTag);
+
+        Task DeleteAsync(ITableEntity tableEntity);
 
         IQueryable<T> CreateQuery<T>() where T : ITableEntity, new();
     }

--- a/src/StatusAggregator/Table/ITableWrapper.cs
+++ b/src/StatusAggregator/Table/ITableWrapper.cs
@@ -21,8 +21,6 @@ namespace StatusAggregator.Table
 
         Task ReplaceAsync(ITableEntity tableEntity);
 
-        Task MergeAsync(ITableEntity tableEntity);
-
         Task DeleteAsync(string partitionKey, string rowKey);
 
         Task DeleteAsync(string partitionKey, string rowKey, string eTag);

--- a/src/StatusAggregator/Table/TableUtility.cs
+++ b/src/StatusAggregator/Table/TableUtility.cs
@@ -1,10 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.WindowsAzure.Storage.Table;
+
 namespace StatusAggregator.Table
 {
     public static class TableUtility
     {
+        /// <summary>
+        /// The <see cref="ITableEntity.ETag"/> to provide when the existing content in the table is unimportant.
+        /// E.g. "if match any".
+        /// </summary>
         public const string ETagWildcard = "*";
     }
 }

--- a/src/StatusAggregator/Table/TableUtility.cs
+++ b/src/StatusAggregator/Table/TableUtility.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace StatusAggregator.Table
+{
+    public static class TableUtility
+    {
+        public const string ETagWildcard = "*";
+    }
+}

--- a/src/StatusAggregator/Table/TableWrapper.cs
+++ b/src/StatusAggregator/Table/TableWrapper.cs
@@ -25,16 +25,50 @@ namespace StatusAggregator.Table
             return _table.CreateIfNotExistsAsync();
         }
 
-        public async Task<T> Retrieve<T>(string partitionKey, string rowKey) 
+        public async Task<T> RetrieveAsync<T>(string partitionKey, string rowKey) 
             where T : class, ITableEntity
         {
             var operation = TableOperation.Retrieve<T>(partitionKey, rowKey);
             return (await _table.ExecuteAsync(operation)).Result as T;
         }
 
+        public Task InsertAsync(ITableEntity tableEntity)
+        {
+            return ExecuteOperationAsync(TableOperation.Insert(tableEntity));
+        }
+
         public Task InsertOrReplaceAsync(ITableEntity tableEntity)
         {
-            var operation = TableOperation.InsertOrReplace(tableEntity);
+            return ExecuteOperationAsync(TableOperation.InsertOrReplace(tableEntity));
+        }
+
+        public Task ReplaceAsync(ITableEntity tableEntity)
+        {
+            return ExecuteOperationAsync(TableOperation.Replace(tableEntity));
+        }
+
+        public Task MergeAsync(ITableEntity tableEntity)
+        {
+            return ExecuteOperationAsync(TableOperation.Merge(tableEntity));
+        }
+
+        public Task DeleteAsync(string partitionKey, string rowKey)
+        {
+            return DeleteAsync(partitionKey, rowKey, TableUtility.ETagWildcard);
+        }
+
+        public Task DeleteAsync(string partitionKey, string rowKey, string eTag)
+        {
+            return DeleteAsync(new TableEntity(partitionKey, rowKey) { ETag = eTag });
+        }
+
+        public Task DeleteAsync(ITableEntity tableEntity)
+        {
+            return ExecuteOperationAsync(TableOperation.Delete(tableEntity));
+        }
+
+        private Task ExecuteOperationAsync(TableOperation operation)
+        {
             return _table.ExecuteAsync(operation);
         }
 

--- a/src/StatusAggregator/Table/TableWrapper.cs
+++ b/src/StatusAggregator/Table/TableWrapper.cs
@@ -47,11 +47,6 @@ namespace StatusAggregator.Table
             return ExecuteOperationAsync(TableOperation.Replace(tableEntity));
         }
 
-        public Task MergeAsync(ITableEntity tableEntity)
-        {
-            return ExecuteOperationAsync(TableOperation.Merge(tableEntity));
-        }
-
         public Task DeleteAsync(string partitionKey, string rowKey)
         {
             return DeleteAsync(partitionKey, rowKey, TableUtility.ETagWildcard);

--- a/src/StatusAggregator/Table/TableWrapperExtensions.cs
+++ b/src/StatusAggregator/Table/TableWrapperExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using NuGet.Services.Status.Table;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace StatusAggregator.Table

--- a/tests/StatusAggregator.Tests/Manual/AddStatusEventManualChangeHandlerFacts.cs
+++ b/tests/StatusAggregator.Tests/Manual/AddStatusEventManualChangeHandlerFacts.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.Status;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StatusAggregator.Tests.Manual
+{
+    public class AddStatusEventManualChangeHandlerFacts
+    {
+        public class TheHandleMethod
+        {
+            private Mock<ITableWrapper> _table;
+            private AddStatusEventManualChangeHandler _handler;
+
+            public TheHandleMethod()
+            {
+                _table = new Mock<ITableWrapper>();
+                _handler = new AddStatusEventManualChangeHandler(_table.Object);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public async Task SavesMessageAndEvent(bool eventIsActive)
+            {
+                var entity = new AddStatusEventManualChangeEntity("path", ComponentStatus.Up, "message", eventIsActive)
+                {
+                    Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
+                };
+
+                var time = entity.Timestamp.UtcDateTime;
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, time);
+
+                _table.Setup(x => x.InsertAsync(
+                    It.Is<MessageEntity>(messageEntity => 
+                        messageEntity.PartitionKey == MessageEntity.DefaultPartitionKey &&
+                        messageEntity.RowKey == MessageEntity.GetRowKey(eventRowKey, time) &&
+                        messageEntity.EventRowKey == eventRowKey &&
+                        messageEntity.Time == time &&
+                        messageEntity.Contents == entity.MessageContents
+                    )))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                _table.Setup(x => x.InsertAsync(
+                    It.Is<EventEntity>(eventEntity =>
+                        eventEntity.PartitionKey == EventEntity.DefaultPartitionKey &&
+                        eventEntity.RowKey == eventRowKey &&
+                        eventEntity.AffectedComponentPath == entity.EventAffectedComponentPath &&
+                        eventEntity.AffectedComponentStatus == entity.EventAffectedComponentStatus &&
+                        eventEntity.StartTime == time &&
+                        eventEntity.EndTime == (entity.EventIsActive ? (DateTime?)null : time)
+                    )))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                await _handler.Handle(entity);
+
+                _table.Verify();
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/Manual/AddStatusMessageManualChangeHandlerFacts.cs
+++ b/tests/StatusAggregator.Tests/Manual/AddStatusMessageManualChangeHandlerFacts.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.Status;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StatusAggregator.Tests.Manual
+{
+    public class AddStatusMessageManualChangeHandlerFacts
+    {
+        public class TheHandleMethod
+        {
+            private Mock<ITableWrapper> _table;
+            private AddStatusMessageManualChangeHandler _handler;
+
+            public TheHandleMethod()
+            {
+                _table = new Mock<ITableWrapper>();
+                _handler = new AddStatusMessageManualChangeHandler(_table.Object);
+            }
+
+            [Fact]
+            public async Task DoesNotSaveIfEventIsMissing()
+            {
+                var entity = new AddStatusMessageManualChangeEntity("path", new DateTime(2018, 8, 21), "message", false)
+                {
+                    Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
+                };
+
+                var time = entity.Timestamp.UtcDateTime;
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+
+                _table
+                    .Setup(x => x.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.FromResult<EventEntity>(null));
+
+                _table
+                    .Setup(x => x.InsertAsync(It.IsAny<MessageEntity>()))
+                    .Returns(Task.CompletedTask);
+
+                _table
+                    .Setup(x => x.InsertAsync(It.IsAny<EventEntity>()))
+                    .Returns(Task.CompletedTask);
+
+                await Assert.ThrowsAsync<ArgumentException>(() => _handler.Handle(entity));
+
+                _table.Verify(x => x.InsertAsync(It.IsAny<MessageEntity>()), Times.Never());
+                _table.Verify(x => x.InsertAsync(It.IsAny<EventEntity>()), Times.Never());
+            }
+
+            public static IEnumerable<object[]> SavesNewMessageAndUpdatesEventIfNecessary_Data
+            {
+                get
+                {
+                    foreach (var eventIsActive in new[] { false, true })
+                    {
+                        foreach (var shouldEventBeActive in new[] { false, true })
+                        {
+                            yield return new object[] { eventIsActive, shouldEventBeActive };
+                        }
+                    }
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(SavesNewMessageAndUpdatesEventIfNecessary_Data))]
+            public async Task SavesNewMessageAndUpdatesEventIfNecessary(bool eventIsActive, bool shouldEventBeActive)
+            {
+                var entity = new AddStatusMessageManualChangeEntity("path", new DateTime(2018, 8, 21), "message", shouldEventBeActive)
+                {
+                    Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
+                };
+
+                var time = entity.Timestamp.UtcDateTime;
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+
+                var existingEntity =
+                    new EventEntity(
+                        entity.EventAffectedComponentPath,
+                        (int)ComponentStatus.Up,
+                        new DateTime(2018, 8, 19),
+                        eventIsActive ? (DateTime?)null : new DateTime(2018, 8, 20));
+
+                _table
+                    .Setup(x => x.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.FromResult(existingEntity));
+
+                _table
+                    .Setup(x => x.InsertAsync(It.IsAny<MessageEntity>()))
+                    .Returns(Task.CompletedTask);
+
+                _table
+                    .Setup(x => x.ReplaceAsync(It.IsAny<EventEntity>()))
+                    .Returns(Task.CompletedTask);
+
+                await _handler.Handle(entity);
+
+                _table
+                    .Verify(
+                        x => x.InsertAsync(
+                            It.Is<MessageEntity>(message =>
+                                message.PartitionKey == MessageEntity.DefaultPartitionKey &&
+                                message.RowKey == MessageEntity.GetRowKey(eventRowKey, time) &&
+                                message.EventRowKey == eventRowKey &&
+                                message.Time == time &&
+                                message.Contents == entity.MessageContents
+                            )),
+                        Times.Once());
+
+                var shouldEventBeUpdated = ManualStatusChangeUtility.ShouldEventBeActive(existingEntity, shouldEventBeActive, time);
+
+                _table
+                    .Verify(
+                        x => x.InsertAsync(
+                            It.Is<EventEntity>(eventEntity =>
+                                eventEntity.PartitionKey == EventEntity.DefaultPartitionKey &&
+                                eventEntity.RowKey == eventRowKey &&
+                                eventEntity.AffectedComponentPath == existingEntity.AffectedComponentPath &&
+                                eventEntity.AffectedComponentStatus == existingEntity.AffectedComponentStatus &&
+                                eventEntity.StartTime == time
+                            )),
+                        shouldEventBeUpdated ? Times.Once() : Times.Never());
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/Manual/DeleteStatusEventManualChangeHandlerFacts.cs
+++ b/tests/StatusAggregator.Tests/Manual/DeleteStatusEventManualChangeHandlerFacts.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StatusAggregator.Tests.Manual
+{
+    public class DeleteStatusEventManualChangeHandlerFacts
+    {
+        public class TheHandleMethod
+        {
+            private Mock<ITableWrapper> _table;
+            private DeleteStatusEventManualChangeHandler _handler;
+
+            public TheHandleMethod()
+            {
+                _table = new Mock<ITableWrapper>();
+                _handler = new DeleteStatusEventManualChangeHandler(_table.Object);
+            }
+
+            [Fact]
+            public async Task DeletesEvent()
+            {
+                var entity = new DeleteStatusEventManualChangeEntity("path", new DateTime(2018, 8, 21));
+                
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+
+                _table
+                    .Setup(x => x.DeleteAsync(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                await _handler.Handle(entity);
+
+                _table.Verify();
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/Manual/DeleteStatusMessageManualChangeHandlerFacts.cs
+++ b/tests/StatusAggregator.Tests/Manual/DeleteStatusMessageManualChangeHandlerFacts.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StatusAggregator.Tests.Manual
+{
+    public class DeleteStatusMessageManualChangeHandlerFacts
+    {
+        public class TheHandleMethod
+        {
+            private Mock<ITableWrapper> _table;
+            private DeleteStatusMessageManualChangeHandler _handler;
+
+            public TheHandleMethod()
+            {
+                _table = new Mock<ITableWrapper>();
+                _handler = new DeleteStatusMessageManualChangeHandler(_table.Object);
+            }
+
+            [Fact]
+            public async Task DeletesEvent()
+            {
+                var entity = new DeleteStatusMessageManualChangeEntity("path", new DateTime(2018, 8, 20), new DateTime(2018, 8, 21));
+
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+                var messageRowKey = MessageEntity.GetRowKey(eventRowKey, entity.MessageTimestamp);
+
+                _table
+                    .Setup(x => x.DeleteAsync(MessageEntity.DefaultPartitionKey, messageRowKey))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                await _handler.Handle(entity);
+
+                _table.Verify();
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/Manual/EditStatusEventManualChangeHandlerFacts.cs
+++ b/tests/StatusAggregator.Tests/Manual/EditStatusEventManualChangeHandlerFacts.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.Status;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StatusAggregator.Tests.Manual
+{
+    public class EditStatusEventManualChangeHandlerFacts
+    {
+        public class TheHandleMethod
+        {
+            private Mock<ITableWrapper> _table;
+            private EditStatusEventManualChangeHandler _handler;
+
+            public TheHandleMethod()
+            {
+                _table = new Mock<ITableWrapper>();
+                _handler = new EditStatusEventManualChangeHandler(_table.Object);
+            }
+
+            [Fact]
+            public async Task ThrowsArgumentExceptionIfMissingEvent()
+            {
+                var entity = new EditStatusEventManualChangeEntity("path", ComponentStatus.Degraded, new DateTime(2018, 8, 20), false)
+                {
+                    Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
+                };
+
+                var time = entity.Timestamp.UtcDateTime;
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+
+                _table
+                    .Setup(x => x.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.FromResult<EventEntity>(null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => _handler.Handle(entity));
+            }
+
+            public static IEnumerable<object[]> EditsEvent_Data
+            {
+                get
+                {
+                    foreach (var eventIsActive in new[] { false, true })
+                    {
+                        foreach (var shouldEventBeActive in new[] { false, true })
+                        {
+                            yield return new object[] { eventIsActive, shouldEventBeActive };
+                        }
+                    }
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(EditsEvent_Data))]
+            public async Task EditsEvent(bool eventIsActive, bool shouldEventBeActive)
+            {
+                var entity = new EditStatusEventManualChangeEntity("path", ComponentStatus.Degraded, new DateTime(2018, 8, 20), shouldEventBeActive)
+                {
+                    Timestamp = new DateTimeOffset(2018, 8, 21, 0, 0, 0, TimeSpan.Zero)
+                };
+
+                var time = entity.Timestamp.UtcDateTime;
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+
+                var existingEntity =
+                    new EventEntity(
+                        entity.EventAffectedComponentPath,
+                        ComponentStatus.Up,
+                        entity.EventStartTime,
+                        eventIsActive ? (DateTime?)null : new DateTime(2018, 8, 19));
+
+                _table
+                    .Setup(x => x.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.FromResult(existingEntity));
+
+                var shouldUpdateEndTime = ManualStatusChangeUtility.ShouldEventBeActive(existingEntity, shouldEventBeActive, time);
+
+                _table
+                    .Setup(x => x.ReplaceAsync(
+                        It.Is<EventEntity>(eventEntity =>
+                            eventEntity.PartitionKey == EventEntity.DefaultPartitionKey &&
+                            eventEntity.RowKey == eventRowKey &&
+                            eventEntity.AffectedComponentPath == existingEntity.AffectedComponentPath &&
+                            eventEntity.AffectedComponentStatus == entity.EventAffectedComponentStatus &&
+                            eventEntity.StartTime == existingEntity.StartTime &&
+                            eventEntity.EndTime == (shouldUpdateEndTime ? time : existingEntity.EndTime)
+                        )))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                await _handler.Handle(entity);
+
+                _table.Verify();
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/Manual/EditStatusMessageManualChangeHandlerFacts.cs
+++ b/tests/StatusAggregator.Tests/Manual/EditStatusMessageManualChangeHandlerFacts.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using NuGet.Services.Status;
+using NuGet.Services.Status.Table;
+using NuGet.Services.Status.Table.Manual;
+using StatusAggregator.Manual;
+using StatusAggregator.Table;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StatusAggregator.Tests.Manual
+{
+    public class EditStatusMessageManualChangeHandlerFacts
+    {
+        public class TheHandleMethod
+        {
+            private Mock<ITableWrapper> _table;
+            private EditStatusMessageManualChangeHandler _handler;
+
+            public TheHandleMethod()
+            {
+                _table = new Mock<ITableWrapper>();
+                _handler = new EditStatusMessageManualChangeHandler(_table.Object);
+            }
+
+            [Fact]
+            public async Task ThrowsArgumentExceptionIfMissingEvent()
+            {
+                var entity = new EditStatusMessageManualChangeEntity("path", new DateTime(2018, 8, 20), new DateTime(2018, 8, 21), "message");
+
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+
+                _table
+                    .Setup(x => x.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.FromResult<EventEntity>(null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => _handler.Handle(entity));
+            }
+
+            [Fact]
+            public async Task ThrowsArgumentExceptionIfMissingMessage()
+            {
+                var entity = new EditStatusMessageManualChangeEntity("path", new DateTime(2018, 8, 20), new DateTime(2018, 8, 21), "message");
+
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+                var messageRowKey = MessageEntity.GetRowKey(eventRowKey, entity.MessageTimestamp);
+
+                var existingEntity =
+                    new EventEntity(
+                        entity.EventAffectedComponentPath,
+                        ComponentStatus.Up,
+                        entity.EventStartTime,
+                        null);
+
+                _table
+                    .Setup(x => x.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.FromResult(existingEntity));
+
+                _table
+                    .Setup(x => x.RetrieveAsync<MessageEntity>(MessageEntity.DefaultPartitionKey, messageRowKey))
+                    .Returns(Task.FromResult<MessageEntity>(null));
+
+                await Assert.ThrowsAsync<ArgumentException>(() => _handler.Handle(entity));
+            }
+
+            [Fact]
+            public async Task EditsMessage()
+            {
+                var entity = new EditStatusMessageManualChangeEntity("path", new DateTime(2018, 8, 20), new DateTime(2018, 8, 21), "message");
+
+                var eventRowKey = EventEntity.GetRowKey(entity.EventAffectedComponentPath, entity.EventStartTime);
+                var messageRowKey = MessageEntity.GetRowKey(eventRowKey, entity.MessageTimestamp);
+
+                var existingEntity =
+                    new EventEntity(
+                        entity.EventAffectedComponentPath,
+                        ComponentStatus.Up,
+                        entity.EventStartTime,
+                        null);
+
+                _table
+                    .Setup(x => x.RetrieveAsync<EventEntity>(EventEntity.DefaultPartitionKey, eventRowKey))
+                    .Returns(Task.FromResult(existingEntity));
+
+                var existingMessage = new MessageEntity(eventRowKey, entity.MessageTimestamp, "old message");
+
+                _table
+                    .Setup(x => x.RetrieveAsync<MessageEntity>(MessageEntity.DefaultPartitionKey, messageRowKey))
+                    .Returns(Task.FromResult(existingMessage));
+
+                _table
+                    .Setup(x => x.ReplaceAsync(
+                        It.Is<MessageEntity>(messageEntity =>
+                            messageEntity.PartitionKey == MessageEntity.DefaultPartitionKey &&
+                            messageEntity.RowKey == messageRowKey &&
+                            messageEntity.EventRowKey == eventRowKey &&
+                            messageEntity.Time == existingMessage.Time &&
+                            messageEntity.Contents == entity.MessageContents
+                        )))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                await _handler.Handle(entity);
+
+                _table.Verify();
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/Manual/ManualStatusChangeUtilityFacts.cs
+++ b/tests/StatusAggregator.Tests/Manual/ManualStatusChangeUtilityFacts.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Services.Status.Table;
+using StatusAggregator.Manual;
+using System;
+using Xunit;
+
+namespace StatusAggregator.Tests.Manual
+{
+    public class ManualStatusChangeUtilityFacts
+    {
+        public abstract class BaseMethod
+        {
+            protected abstract bool GetResult(EventEntity eventEntity, bool eventIsActive, DateTime timestamp);
+
+            protected abstract void AssertChangedTo(EventEntity eventEntity, DateTime? initialEndTime, DateTime? timestamp);
+
+            [Fact]
+            public void ThrowsIfEventIsNull()
+            {
+                Assert.Throws<ArgumentNullException>(() => GetResult(null, false, DateTime.MinValue));
+            }
+
+            [Fact]
+            public void ActiveEventStaysActive()
+            {
+                var eventEntity = new EventEntity("", 0, new DateTime(2018, 8, 17));
+
+                var result = GetResult(eventEntity, true, new DateTime(2018, 8, 18));
+
+                Assert.False(result);
+                Assert.Null(eventEntity.EndTime);
+            }
+
+            [Fact]
+            public void ActiveEventBecomesInactive()
+            {
+                DateTime? initialEndTime = null;
+                var deactivatedTime = new DateTime(2018, 8, 18);
+                var eventEntity = new EventEntity("", 0, new DateTime(2018, 8, 17), initialEndTime);
+
+                var result = GetResult(eventEntity, false, deactivatedTime);
+
+                Assert.True(result);
+                AssertChangedTo(eventEntity, initialEndTime, deactivatedTime);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void DeactivatedEventIsUnaffected(bool eventIsActive)
+            {
+                var deactivatedTime = new DateTime(2018, 8, 18);
+                var eventEntity = new EventEntity("", 0, new DateTime(2018, 8, 17), deactivatedTime);
+
+                var result = GetResult(eventEntity, eventIsActive, new DateTime(2018, 8, 19));
+
+                Assert.False(result);
+                Assert.Equal(deactivatedTime, eventEntity.EndTime);
+            }
+        }
+
+        public class TheUpdateEventIsActiveMethod : BaseMethod
+        {
+            protected override bool GetResult(EventEntity eventEntity, bool eventIsActive, DateTime timestamp)
+            {
+                return ManualStatusChangeUtility.UpdateEventIsActive(eventEntity, eventIsActive, timestamp);
+            }
+
+            protected override void AssertChangedTo(EventEntity eventEntity, DateTime? initialEndTime, DateTime? timestamp)
+            {
+                Assert.Equal(timestamp, eventEntity.EndTime);
+            }
+        }
+
+        public class TheShouldEventBeActiveMethod : BaseMethod
+        {
+            protected override bool GetResult(EventEntity eventEntity, bool eventIsActive, DateTime timestamp)
+            {
+                return ManualStatusChangeUtility.ShouldEventBeActive(eventEntity, eventIsActive, timestamp);
+            }
+
+            protected override void AssertChangedTo(EventEntity eventEntity, DateTime? initialEndTime, DateTime? timestamp)
+            {
+                Assert.Equal(initialEndTime, eventEntity.EndTime);
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -46,6 +46,13 @@
   <ItemGroup>
     <Compile Include="EventUpdaterTests.cs" />
     <Compile Include="IncidentFactoryTests.cs" />
+    <Compile Include="Manual\AddStatusEventManualChangeHandlerFacts.cs" />
+    <Compile Include="Manual\AddStatusMessageManualChangeHandlerFacts.cs" />
+    <Compile Include="Manual\DeleteStatusEventManualChangeHandlerFacts.cs" />
+    <Compile Include="Manual\DeleteStatusMessageManualChangeHandlerFacts.cs" />
+    <Compile Include="Manual\EditStatusEventManualChangeHandlerFacts.cs" />
+    <Compile Include="Manual\EditStatusMessageManualChangeHandlerFacts.cs" />
+    <Compile Include="Manual\ManualStatusChangeUtilityFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -62,13 +69,13 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.28.0-sb-morestatus-35915</Version>
+      <Version>2.28.0-sb-tablegeo-38564</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.28.0-sb-morestatus-35915</Version>
+      <Version>2.28.0-sb-tablegeo-38564</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.28.0-sb-morestatus-35915</Version>
+      <Version>2.28.0-sb-tablegeo-38564</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.3.0</Version>

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -72,10 +72,10 @@
       <Version>2.28.0-sb-tablegeo-38564</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.28.0-sb-tablegeo-38564</Version>
+      <Version>2.28.0-master-38796</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.28.0-sb-tablegeo-38564</Version>
+      <Version>2.28.0-master-38796</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.3.0</Version>


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6119

Status job now listens to multiple storage accounts for manual status changes and applies them to its primary storage.

The status of what changes have been applied from each storage is maintained using cursors.

Depends on https://github.com/NuGet/NuGet.Status/pull/57, https://github.com/NuGet/ServerCommon/pull/183