### PR TITLE
Hardcode tables that can be imported by DataImporter

### DIFF
--- a/src/Stats.ImportAzureCdnStatistics/DataImporter.cs
+++ b/src/Stats.ImportAzureCdnStatistics/DataImporter.cs
@@ -10,6 +10,12 @@ namespace Stats.ImportAzureCdnStatistics
 {
     internal class DataImporter
     {
+        public enum Table
+        {
+            Fact_Dist_Download,
+            Fact_Download
+        }
+
         private readonly Func<Task<SqlConnection>> _openStatisticsSqlConnectionAsync;
         private const string _sqlSelectTop1FromTable = "SELECT TOP 1 * FROM [dbo].[{0}]";
 
@@ -18,8 +24,9 @@ namespace Stats.ImportAzureCdnStatistics
             _openStatisticsSqlConnectionAsync = openStatisticsSqlConnectionAsync;
         }
 
-        public async Task<DataTable> GetDataTableAsync(string tableName)
+        public async Task<DataTable> GetDataTableAsync(Table table)
         {
+            var tableName = table.ToString();
             var dataTable = new DataTable();
             var query = string.Format(_sqlSelectTop1FromTable, tableName);
 

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -126,7 +126,7 @@ namespace Stats.ImportAzureCdnStatistics
 
             // create facts data rows by linking source data with dimensions
             var dataImporter = new DataImporter(_openStatisticsSqlConnectionAsync);
-            var factsDataTable = await dataImporter.GetDataTableAsync("Fact_Download");
+            var factsDataTable = await dataImporter.GetDataTableAsync(DataImporter.Table.Fact_Download);
 
             var knownOperationsAvailable = operations.Any();
             var knownClientsAvailable = clients.Any();
@@ -247,7 +247,7 @@ namespace Stats.ImportAzureCdnStatistics
 
             // create facts data rows by linking source data with dimensions
             var dataImporter = new DataImporter(_openStatisticsSqlConnectionAsync);
-            var dataTable = await dataImporter.GetDataTableAsync("Fact_Dist_Download");
+            var dataTable = await dataImporter.GetDataTableAsync(DataImporter.Table.Fact_Dist_Download);
 
             var knownClientsAvailable = clients.Any();
             var knownPlatformsAvailable = platforms.Any();


### PR DESCRIPTION
It was insecure that we accepted any value for the table name.

By hardcoding the expected tables that can be imported, there is no longer any worry that unexpected tables can be imported.

https://github.com/NuGet/Engineering/issues/895