### PR TITLE
Status Aggregator - listen to average lag of all search instances instead of max lag of any search instance

### DIFF
--- a/src/StatusAggregator/Parse/OutdatedSearchServiceInstanceIncidentParser.cs
+++ b/src/StatusAggregator/Parse/OutdatedSearchServiceInstanceIncidentParser.cs
@@ -5,18 +5,22 @@ using Microsoft.Extensions.Logging;
 using NuGet.Services.Incidents;
 using NuGet.Services.Status;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace StatusAggregator.Parse
 {
     public class OutdatedSearchServiceInstanceIncidentParser : EnvironmentPrefixIncidentParser
     {
-        private const string SubtitleRegEx = "A search service instance is using an outdated index!";
+        private const string SubtitleRegEx = "All search service instances are using an outdated index!";
 
         public OutdatedSearchServiceInstanceIncidentParser(
             IEnumerable<IIncidentParsingFilter> filters, 
             ILogger<OutdatedSearchServiceInstanceIncidentParser> logger)
-            : base(SubtitleRegEx, filters, logger)
+            : base(
+                  SubtitleRegEx, 
+                  filters.Where(f => !(f is SeverityFilter)), // The incident is always severity 4.
+                  logger)
         {
         }
 


### PR DESCRIPTION
I added a sev 4 monitor with a title of "All search service instances are using an outdated index!" that listens to average search lag instead of max search lag.

This change hooks the status job up to that monitor instead so that we will no longer see messages on the status page for single instances being out of date.