### PR TITLE
Fix AuxData job config

### DIFF
--- a/src/Search.GenerateAuxiliaryData/Settings/dev.json
+++ b/src/Search.GenerateAuxiliaryData/Settings/dev.json
@@ -2,7 +2,7 @@
   "Initialization": {
     "AzureCdnCloudStorageAccount": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$",
     "AzureCdnCloudStorageContainerName": "nuget-cdnstats",
-    "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetdev0;AccountKey=$$Dev-NuGetDev0Storage-Key$$"
+    "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$"
   },
 
   "GalleryDb": {

--- a/src/Search.GenerateAuxiliaryData/Settings/prod.json
+++ b/src/Search.GenerateAuxiliaryData/Settings/prod.json
@@ -2,7 +2,7 @@
   "Initialization": {
     "AzureCdnCloudStorageAccount": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$",
     "AzureCdnCloudStorageContainerName": "nuget-cdnstats",
-    "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetprod0;AccountKey=$$Prod-NuGetProd0Storage-Key$$"
+    "PrimaryDestination": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$"
   },
 
   "GalleryDb": {


### PR DESCRIPTION
Issue: Copied wrong storage config during JsonConfig migration (Regression from https://github.com/NuGet/NuGet.Jobs/pull/518)
- https://github.com/NuGet/Engineering/issues/1658

Found during SQL-AAD deployments: 
- https://github.com/NuGet/Engineering/issues/1612
