### PR TITLE
Status Aggregator - Better detect noisy incidents and do not post messages for them

### DIFF
--- a/src/StatusAggregator/EventUpdater.cs
+++ b/src/StatusAggregator/EventUpdater.cs
@@ -66,11 +66,17 @@ namespace StatusAggregator
                     return false;
                 }
 
-                var shouldDeactivate = !incidentsLinkedToEventQuery
-                        .Where(i => i.IsActive || i.MitigationTime > cursor - _eventEndDelay)
-                        .ToList()
-                        .Any();
+                var hasActiveIncidents = incidentsLinkedToEventQuery
+                    .Where(i => i.IsActive)
+                    .ToList()
+                    .Any();
 
+                var hasRecentIncidents = incidentsLinkedToEventQuery
+                    .Where(i => i.MitigationTime > cursor - _eventEndDelay)
+                    .ToList()
+                    .Any();
+
+                var shouldDeactivate = !(hasActiveIncidents || hasRecentIncidents);
                 if (shouldDeactivate)
                 {
                     _logger.LogInformation("Deactivating event because its incidents are inactive and too old.");

--- a/src/StatusAggregator/EventUpdater.cs
+++ b/src/StatusAggregator/EventUpdater.cs
@@ -66,6 +66,10 @@ namespace StatusAggregator
                     return false;
                 }
 
+                // We are querying twice here because table storage ignores rows where a column specified by a query is null.
+                // MitigationTime is null when IsActive is true.
+                // If we do not query separately here, rows where IsActive is true will be ignored in query results.
+
                 var hasActiveIncidents = incidentsLinkedToEventQuery
                     .Where(i => i.IsActive)
                     .ToList()

--- a/src/StatusAggregator/IncidentUpdater.cs
+++ b/src/StatusAggregator/IncidentUpdater.cs
@@ -16,7 +16,6 @@ namespace StatusAggregator
     public class IncidentUpdater : IIncidentUpdater
     {
         private readonly ITableWrapper _table;
-        private readonly IEventUpdater _eventUpdater;
         private readonly IAggregateIncidentParser _aggregateIncidentParser;
         private readonly IIncidentApiClient _incidentApiClient;
         private readonly IIncidentFactory _incidentFactory;
@@ -26,7 +25,6 @@ namespace StatusAggregator
 
         public IncidentUpdater(
             ITableWrapper table,
-            IEventUpdater eventUpdater,
             IIncidentApiClient incidentApiClient,
             IAggregateIncidentParser aggregateIncidentParser,
             IIncidentFactory incidentFactory,
@@ -34,7 +32,6 @@ namespace StatusAggregator
             ILogger<IncidentUpdater> logger)
         {
             _table = table ?? throw new ArgumentNullException(nameof(table));
-            _eventUpdater = eventUpdater ?? throw new ArgumentNullException(nameof(eventUpdater));
             _incidentApiClient = incidentApiClient ?? throw new ArgumentNullException(nameof(incidentApiClient));
             _aggregateIncidentParser = aggregateIncidentParser ?? throw new ArgumentNullException(nameof(aggregateIncidentParser));
             _incidentFactory = incidentFactory ?? throw new ArgumentNullException(nameof(incidentFactory));

--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -164,7 +164,7 @@ namespace StatusAggregator
         }
 
         private const int _defaultEventStartMessageDelayMinutes = 15;
-        private const int _defaultEventEndDelayMinutes = 10;
+        private const int _defaultEventEndDelayMinutes = 15;
         private const int _defaultEventVisibilityPeriod = 10;
 
         private static void AddConfiguration(IServiceCollection serviceCollection, IDictionary<string, string> jobArgsDictionary)

--- a/src/StatusAggregator/MessageUpdater.cs
+++ b/src/StatusAggregator/MessageUpdater.cs
@@ -51,6 +51,10 @@ namespace StatusAggregator
 
                 var incidentsLinkedToEventQuery = _table.GetIncidentsLinkedToEvent(eventEntity);
 
+                // We are querying twice here because table storage ignores rows where a column specified by a query is null.
+                // MitigationTime is null when IsActive is true.
+                // If we do not query separately here, rows where IsActive is true will be ignored in query results.
+
                 var hasCurrentlyActiveIncidents = incidentsLinkedToEventQuery
                     .Where(i => i.IsActive)
                     .ToList()


### PR DESCRIPTION
Previously
- events are closed if they haven't had a linked incident that was active more than 10 minutes ago
- post a message for an event if it is older than 15 minutes

As a caveat of this logic, a message would be posted for any event that had incidents active for more than five minutes. This is too noisy.

Now
- events are closed if they haven't had a linked incident that was active more than 15 minutes ago
- post a message for an event if it is older than 15 minutes and ***has active incidents***

With this new logic, if an incident is active for more than 15 minutes, it will post a message. If an incident is mitigated in less than 15 minutes, it will only post a message if another incident related to the same component is created less than fifteen minutes later.

This would have correctly ignored the incidents last night and not posted a message for them.

Also fixed a bug with active events not being deactivated correctly.