### PR TITLE
Update few Orchestrator APIs to include ValidatingType EF queries. 

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
@@ -186,7 +186,7 @@ namespace NuGet.Services.Validation.PackageSigning.ValidateCertificate
 
             // If any of the author signature's certificates are known to be revoked, invalidate any the signatures.
             // A revoked certificate is assumed to remain revoked forever.
-            var isRevalidationRequest = await _validatorStateService.IsRevalidationRequestAsync(request);
+            var isRevalidationRequest = await _validatorStateService.IsRevalidationRequestAsync(request, ValidatingType.Package);
 
             if (ShouldInvalidateSignature(signature, isRevalidationRequest))
             {

--- a/src/NuGet.Services.Validation.Orchestrator/ValidatingEntitites/IValidatingEntity.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidatingEntitites/IValidatingEntity.cs
@@ -28,5 +28,10 @@ namespace NuGet.Services.Validation.Orchestrator
         /// The time when the entity was created in Gallery.
         /// </summary>
         DateTime Created { get; }
+
+        /// <summary>
+        /// The ValidatingType.
+        /// </summary>
+        ValidatingType ValidatingType { get; }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/ValidatingEntitites/PackageValidatingEntity.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidatingEntitites/PackageValidatingEntity.cs
@@ -20,5 +20,7 @@ namespace NuGet.Services.Validation.Orchestrator
         public PackageStatus Status => EntityRecord.PackageStatusKey;
 
         public DateTime Created => EntityRecord.Created;
+
+        public ValidatingType ValidatingType => ValidatingType.Package;
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/ValidatingEntitites/SymbolPackageValidatingEntity.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidatingEntitites/SymbolPackageValidatingEntity.cs
@@ -20,5 +20,7 @@ namespace NuGet.Services.Validation.Orchestrator
         public PackageStatus Status => EntityRecord.StatusKey;
 
         public DateTime Created => EntityRecord.Created;
+
+        public ValidatingType ValidatingType => ValidatingType.SymbolPackage;
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
@@ -211,14 +211,15 @@ namespace NuGet.Services.Validation.Orchestrator
                 .PackageValidationSets
                 .AnyAsync(pvs => pvs.PackageKey == validatingEntity.Key
                     && pvs.Created > cutoffTimestamp
-                    && pvs.ValidationTrackingId != currentValidationSetTrackingId);
+                    && pvs.ValidationTrackingId != currentValidationSetTrackingId
+                    && pvs.ValidatingType == validatingEntity.ValidatingType);
         }
 
         public async Task<int> GetValidationSetCountAsync<T>(IValidatingEntity<T> validatingEntity) where T : class, IEntity
         {
             return await _validationContext
                 .PackageValidationSets
-                .CountAsync(x => x.PackageKey == validatingEntity.Key);
+                .CountAsync(x => x.PackageKey == validatingEntity.Key && x.ValidatingType == validatingEntity.ValidatingType);
         }
 
         private void AddValidationIssues(PackageValidation packageValidation, IReadOnlyList<IValidationIssue> validationIssues)

--- a/src/Validation.Common.Job/Storage/IValidatorStateService.cs
+++ b/src/Validation.Common.Job/Storage/IValidatorStateService.cs
@@ -31,17 +31,9 @@ namespace NuGet.Jobs.Validation.Storage
         /// a different validation request.
         /// </summary>
         /// <param name="request">The package validation request.</param>
+        /// <param name="validatingType">The <see cref="ValidatingType"/>.</param>
         /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package in a different validation request.</returns>
-        Task<bool> IsRevalidationRequestAsync(IValidationRequest request);
-
-        /// <summary>
-        /// Check if the request intends to revalidate a package that has already been validated by <see cref="TValidator"/> by
-        /// a different validation request.
-        /// </summary>
-        /// <param name="packageKey">The package key for the validation request.</param>
-        /// <param name="validationId">The validation id for the validation request.</param>
-        /// <returns>Whether the <see cref="TValidator"/> has already validated this request's package in a different validation request.</returns>
-        Task<bool> IsRevalidationRequestAsync(int packageKey, Guid validationId);
+        Task<bool> IsRevalidationRequestAsync(IValidationRequest request, ValidatingType validatingType);
 
         /// <summary>
         /// Persist the status of a new validation request.

--- a/src/Validation.Common.Job/Storage/ValidatorStateService.cs
+++ b/src/Validation.Common.Job/Storage/ValidatorStateService.cs
@@ -68,17 +68,18 @@ namespace NuGet.Jobs.Validation.Storage
                 .FirstOrDefaultAsync();
         }
 
-        public Task<bool> IsRevalidationRequestAsync(IValidationRequest request)
+        public Task<bool> IsRevalidationRequestAsync(IValidationRequest request, ValidatingType validatingType)
         {
-            return IsRevalidationRequestAsync(request.PackageKey, request.ValidationId);
+            return IsRevalidationRequestAsync(request.PackageKey, request.ValidationId, validatingType);
         }
 
-        public Task<bool> IsRevalidationRequestAsync(int packageKey, Guid validationId)
+        private Task<bool> IsRevalidationRequestAsync(int packageKey, Guid validationId, ValidatingType validatingType)
         {
             return _validationContext
                 .ValidatorStatuses
                 .Where(s => s.PackageKey == packageKey)
                 .Where(s => s.ValidatorName == _validatorName)
+                .Where(s => s.ValidatingType == validatingType)
                 .Where(s => s.ValidationId != validationId)
                 .AnyAsync();
         }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="PackageSigning\ProcessSignature\PackageSignatureProcessorFacts.cs" />
     <Compile Include="PackageStatusProcessorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Symbol\SymbolPackageValidatingEntityFacts.cs" />
     <Compile Include="Symbol\SymbolMessageEnqueuerFacts.cs" />
     <Compile Include="Symbol\SymbolEntityServiceFacts.cs" />
     <Compile Include="Symbol\SymbolScanValidatorFacts.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolPackageValidatingEntityFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolPackageValidatingEntityFacts.cs
@@ -8,32 +8,33 @@ using Xunit;
 
 namespace NuGet.Services.Validation
 {
-    public class PackageValidatingEntityFacts
+    public class SymbolPackageValidatingEntityFacts
     {
         private const int PackageKey = 1001;
+        private const int SymbolPackageKey = 1002;
         private const string PackageId = "NuGet.Versioning";
         private const string PackageNormalizedVersion = "1.0.0";
         private static DateTime PackageCreated = new DateTime(2018, 4, 4, 4, 4, 4);
+        private static DateTime SymbolPackageCreated = new DateTime(2018, 5, 4, 4, 4, 4);
 
         [Fact]
         public void PropertiesValidation()
         {
             // Arrange
-            var package = CreatePackage();
+            var symbolPackage = CreateSymbolPackage();
 
             // Act & Assert
-            var validatingEntity = new PackageValidatingEntity(package);
+            var validatingEntity = new SymbolPackageValidatingEntity(symbolPackage);
 
-            Assert.Equal(PackageCreated, validatingEntity.Created);
-            Assert.Equal(PackageKey, validatingEntity.Key);
-            Assert.Equal(PackageId, validatingEntity.EntityRecord.PackageRegistration.Id);
-            Assert.Equal(PackageNormalizedVersion, validatingEntity.EntityRecord.NormalizedVersion);
-            Assert.Equal(ValidatingType.Package, validatingEntity.ValidatingType);
+            Assert.Equal(SymbolPackageCreated, validatingEntity.Created);
+            Assert.Equal(SymbolPackageKey, validatingEntity.Key);
+            Assert.Equal(ValidatingType.SymbolPackage, validatingEntity.ValidatingType);
+            Assert.Equal(PackageStatus.Available, validatingEntity.Status);
         }
 
-        private static Package CreatePackage()
+        private static SymbolPackage CreateSymbolPackage()
         {
-            return new Package()
+            var package =  new Package()
             {
                 NormalizedVersion = PackageNormalizedVersion,
                 PackageRegistration = new PackageRegistration()
@@ -43,6 +44,14 @@ namespace NuGet.Services.Validation
                 Key = PackageKey,
                 Created = PackageCreated
             };
+
+            return new SymbolPackage()
+            {
+                Created = SymbolPackageCreated,
+                Key = SymbolPackageKey,
+                StatusKey = PackageStatus.Available
+            };
+
         }
     }
 }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidatorStateServiceFacts.cs
@@ -177,7 +177,7 @@ namespace NuGet.Services.Validation
                 _validationContext.Mock();
 
                 // Act & Assert
-                Assert.False(await _target.IsRevalidationRequestAsync(_validationRequest.Object));
+                Assert.False(await _target.IsRevalidationRequestAsync(_validationRequest.Object, ValidatingType.Package));
             }
 
             [Fact]
@@ -198,7 +198,7 @@ namespace NuGet.Services.Validation
                     });
 
                 // Act & Assert
-                Assert.True(await _target.IsRevalidationRequestAsync(_validationRequest.Object));
+                Assert.True(await _target.IsRevalidationRequestAsync(_validationRequest.Object, ValidatingType.Package));
             }
 
             [Fact]
@@ -219,7 +219,7 @@ namespace NuGet.Services.Validation
                     });
 
                 // Act & Assert
-                Assert.False(await _target.IsRevalidationRequestAsync(_validationRequest.Object));
+                Assert.False(await _target.IsRevalidationRequestAsync(_validationRequest.Object, ValidatingType.Package));
             }
 
             [Fact]
@@ -247,7 +247,7 @@ namespace NuGet.Services.Validation
                     });
 
                 // Act & Assert
-                Assert.True(await _target.IsRevalidationRequestAsync(_validationRequest.Object));
+                Assert.True(await _target.IsRevalidationRequestAsync(_validationRequest.Object, ValidatingType.Package));
             }
 
             [Fact]
@@ -276,7 +276,7 @@ namespace NuGet.Services.Validation
                     });
 
                 // Act & Assert
-                Assert.False(await _target.IsRevalidationRequestAsync(_validationRequest.Object));
+                Assert.False(await _target.IsRevalidationRequestAsync(_validationRequest.Object, ValidatingType.Package));
             }
 
             [Fact]
@@ -312,7 +312,7 @@ namespace NuGet.Services.Validation
                     });
 
                 // Act & Assert
-                Assert.True(await _target.IsRevalidationRequestAsync(_validationRequest.Object));
+                Assert.True(await _target.IsRevalidationRequestAsync(_validationRequest.Object, ValidatingType.Package));
             }
         }
 


### PR DESCRIPTION
PackageValidation and ValidatorStatuses tables contain data for packages and symbolpackages.
A symbolpacakge and a package could have the same key. 

In this change few APIs are updated  to use validating type filter in order to keep the intended behavior. 