### PR TITLE
Hotfix: Increase command timeout for AggregateCdnDownloads query

### DIFF
--- a/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
@@ -87,7 +87,7 @@ namespace Stats.AggregateCdnDownloadsInGallery
                         _storedProcedureName,
                         transaction: transaction,
                         commandType: CommandType.StoredProcedure,
-                        commandTimeout: TimeSpan.FromMinutes(15),
+                        commandTimeout: TimeSpan.FromMinutes(30),
                         maxRetries: 3))
                     .ToList();
             }


### PR DESCRIPTION
Tracking: https://github.com/NuGet/Engineering/issues/1752

Unblocks SQL AAD for Stats.AggregateCdnDownloadsInGallery job (https://github.com/NuGet/Engineering/issues/1617)

In SSMS, the stored procedure took almost 20m to run... suggest increasing to 30m to be safe.