### PR TITLE
[Revalidation] Add configurable overrides for revalidation rates

### DIFF
--- a/src/NuGet.Services.Revalidate/Job.cs
+++ b/src/NuGet.Services.Revalidate/Job.cs
@@ -42,8 +42,6 @@ namespace NuGet.Services.Revalidate
         private string _preinstalledSetPath;
         private bool _initialize;
         private bool _verifyInitialization;
-        private int? _overrideMinPackageEventRate;
-        private int? _overrideMaxPackageEventRate;
 
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {
@@ -52,8 +50,6 @@ namespace NuGet.Services.Revalidate
             _preinstalledSetPath = JobConfigurationManager.TryGetArgument(jobArgsDictionary, RebuildPreinstalledSetArgumentName);
             _initialize = JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, InitializeArgumentName);
             _verifyInitialization = JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, VerifyInitializationArgumentName);
-            _overrideMinPackageEventRate = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, OverrideMinPackageEventRate);
-            _overrideMaxPackageEventRate = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, OverrideMaxPackageEventRate);
         }
 
         public override async Task Run()
@@ -119,11 +115,6 @@ namespace NuGet.Services.Revalidate
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
             services.Configure<RevalidationConfiguration>(configurationRoot.GetSection(JobConfigurationSectionName));
-            services.Configure<RevalidationConfiguration>(config =>
-            {
-                config.MinPackageEventRate = _overrideMinPackageEventRate ?? config.MinPackageEventRate;
-                config.MaxPackageEventRate = _overrideMaxPackageEventRate ?? config.MaxPackageEventRate;
-            });
 
             services.AddSingleton(provider => provider.GetRequiredService<IOptionsSnapshot<RevalidationConfiguration>>().Value);
             services.AddSingleton(provider => provider.GetRequiredService<IOptionsSnapshot<RevalidationConfiguration>>().Value.Initialization);

--- a/src/NuGet.Services.Revalidate/Job.cs
+++ b/src/NuGet.Services.Revalidate/Job.cs
@@ -32,8 +32,6 @@ namespace NuGet.Services.Revalidate
         private const string RebuildPreinstalledSetArgumentName = "RebuildPreinstalledSet";
         private const string InitializeArgumentName = "Initialize";
         private const string VerifyInitializationArgumentName = "VerifyInitialization";
-        private const string OverrideMinPackageEventRate = "OverrideMinPackageEventRate";
-        private const string OverrideMaxPackageEventRate = "OverrideMaxPackageEventRate";
 
         private const string JobConfigurationSectionName = "RevalidateJob";
 

--- a/src/NuGet.Services.Revalidate/Scripts/NuGet.Services.Revalidate.cmd
+++ b/src/NuGet.Services.Revalidate/Scripts/NuGet.Services.Revalidate.cmd
@@ -9,6 +9,8 @@ title #{Jobs.nuget.services.revalidate.Title}
 
 start /w NuGet.Services.Revalidate.exe ^
     -Configuration #{Jobs.nuget.services.revalidate.Configuration} ^
+    -OverrideMinPackageEventRate #{Jobs.nuget.services.revalidation.MinPackageEventRate} ^
+    -OverrideMaxPackageEventRate #{Jobs.nuget.services.revalidation.MaxPackageEventRate} ^
     -InstrumentationKey "#{Jobs.nuget.services.revalidate.InstrumentationKey}"
 
 echo "Finished #{Jobs.nuget.services.revalidate.Title}"

--- a/src/NuGet.Services.Revalidate/Scripts/NuGet.Services.Revalidate.cmd
+++ b/src/NuGet.Services.Revalidate/Scripts/NuGet.Services.Revalidate.cmd
@@ -9,8 +9,6 @@ title #{Jobs.nuget.services.revalidate.Title}
 
 start /w NuGet.Services.Revalidate.exe ^
     -Configuration #{Jobs.nuget.services.revalidate.Configuration} ^
-    -OverrideMinPackageEventRate #{Jobs.nuget.services.revalidation.MinPackageEventRate} ^
-    -OverrideMaxPackageEventRate #{Jobs.nuget.services.revalidation.MaxPackageEventRate} ^
     -InstrumentationKey "#{Jobs.nuget.services.revalidate.InstrumentationKey}"
 
 echo "Finished #{Jobs.nuget.services.revalidate.Title}"

--- a/src/NuGet.Services.Revalidate/Settings/dev.json
+++ b/src/NuGet.Services.Revalidate/Settings/dev.json
@@ -16,8 +16,8 @@
       "ComponentPath": "NuGet/Package Publishing"
     },
 
-    "MinPackageEventRate": 120,
-    "MaxPackageEventRate": 400,
+    "MinPackageEventRate": "#{Jobs.nuget.services.revalidation.MinPackageEventRate}",
+    "MaxPackageEventRate": "#{Jobs.nuget.services.revalidation.MaxPackageEventRate}",
 
     "RetryLaterSleep": "00:00:30",
 

--- a/src/NuGet.Services.Revalidate/Settings/int.json
+++ b/src/NuGet.Services.Revalidate/Settings/int.json
@@ -16,8 +16,8 @@
       "ComponentPath": "NuGet/Package Publishing"
     },
 
-    "MinPackageEventRate": 120,
-    "MaxPackageEventRate": 400,
+    "MinPackageEventRate": "#{Jobs.nuget.services.revalidation.MinPackageEventRate}",
+    "MaxPackageEventRate": "#{Jobs.nuget.services.revalidation.MaxPackageEventRate}",
 
     "RetryLaterSleep": "00:00:30",
 

--- a/src/NuGet.Services.Revalidate/Settings/prod.json
+++ b/src/NuGet.Services.Revalidate/Settings/prod.json
@@ -16,8 +16,8 @@
       "ComponentPath": "NuGet/Package Publishing"
     },
 
-    "MinPackageEventRate": 120,
-    "MaxPackageEventRate": 400,
+    "MinPackageEventRate": "#{Jobs.nuget.services.revalidation.MinPackageEventRate}",
+    "MaxPackageEventRate": "#{Jobs.nuget.services.revalidation.MaxPackageEventRate}",
 
     "RetryLaterSleep": "00:00:30",
 


### PR DESCRIPTION
This will let us speed up/slow down the revalidation job by changing Octopus variables and creating a new deployment.

Addresses https://github.com/NuGet/Engineering/issues/1789