### PR TITLE
Support symbol revalidation

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Services/IEntityService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Services/IEntityService.cs
@@ -17,13 +17,13 @@ namespace NuGet.Services.Validation.Orchestrator
         /// </summary>
         /// <param name="id">The id .</param>
         /// <param name="version">The version.</param>
-        /// <returns></returns>
+        /// <returns>The entity.</returns>
         IValidatingEntity<T> FindPackageByIdAndVersionStrict(string id, string version);
 
         /// <summary>
         /// Find the entity based on the key.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The entity.</returns>
         IValidatingEntity<T> FindPackageByKey(int key);
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace NuGet.Services.Validation.Orchestrator
         /// <param name="entity">The entity.</param>
         /// <param name="metadata">The metadata.</param>
         /// <param name="commitChanges">True if the changes will be commited to the database.</param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> that can be used to await for the operation completion.</returns>
         Task UpdateMetadataAsync(T entity, object metadata, bool commitChanges = true);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/Services/IEntityService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Services/IEntityService.cs
@@ -21,6 +21,12 @@ namespace NuGet.Services.Validation.Orchestrator
         IValidatingEntity<T> FindPackageByIdAndVersionStrict(string id, string version);
 
         /// <summary>
+        /// Find the entity based on the key.
+        /// </summary>
+        /// <returns></returns>
+        IValidatingEntity<T> FindPackageByKey(int key);
+
+        /// <summary>
         /// Update the status of the entity.
         /// </summary>
         /// <param name="entity"></param>

--- a/src/NuGet.Services.Validation.Orchestrator/Services/PackageEntityService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Services/PackageEntityService.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Data.Entity;
 using System.Threading.Tasks;
 using NuGetGallery;
 using NuGetGallery.Packaging;
@@ -13,16 +16,30 @@ namespace NuGet.Services.Validation.Orchestrator
     public class PackageEntityService : IEntityService<Package>
     {
         private ICorePackageService _galleryEntityService;
+        private IEntityRepository<Package> _packageRepository;
 
-        public PackageEntityService(ICorePackageService galleryEntityService)
+        public PackageEntityService(ICorePackageService galleryEntityService, IEntityRepository<Package> packageRepository)
         {
-            _galleryEntityService = galleryEntityService;
+            _galleryEntityService = galleryEntityService ?? throw new ArgumentNullException(nameof(galleryEntityService));
+            _packageRepository = packageRepository ?? throw new ArgumentNullException(nameof(packageRepository));
         }
 
         public IValidatingEntity<Package> FindPackageByIdAndVersionStrict(string id, string version)
         {
             var p = _galleryEntityService.FindPackageByIdAndVersionStrict(id, version);
             return p == null ? null : new PackageValidatingEntity(p);
+        }
+
+        public IValidatingEntity<Package> FindPackageByKey(int key)
+        {
+            var package = _packageRepository
+                   .GetAll()
+                   .Include(p => p.LicenseReports)
+                   .Include(p => p.PackageRegistration)
+                   .Include(p => p.User)
+                   .Include(p => p.SymbolPackages)
+                   .SingleOrDefault(p => p.Key == key);
+            return package == null ? null : new PackageValidatingEntity(package);
         }
 
         public async Task UpdateStatusAsync(Package entity, PackageStatus newStatus, bool commitChanges = true)

--- a/src/NuGet.Services.Validation.Orchestrator/Services/SymbolEntityService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Services/SymbolEntityService.cs
@@ -13,10 +13,13 @@ namespace NuGet.Services.Validation.Orchestrator
     /// </summary>
     public class SymbolEntityService : IEntityService<SymbolPackage>
     {
-        ICoreSymbolPackageService _galleryEntityService;
-        public SymbolEntityService(ICoreSymbolPackageService galleryEntityService)
+        private ICoreSymbolPackageService _galleryEntityService;
+        private IEntityRepository<SymbolPackage> _symbolsPackageRepository;
+
+        public SymbolEntityService(ICoreSymbolPackageService galleryEntityService, IEntityRepository<SymbolPackage> symbolsPackageRepository)
         {
             _galleryEntityService = galleryEntityService ?? throw new ArgumentNullException(nameof(galleryEntityService));
+            _symbolsPackageRepository = symbolsPackageRepository ?? throw new ArgumentNullException(nameof(symbolsPackageRepository));
         }
 
         /// <summary>
@@ -32,6 +35,14 @@ namespace NuGet.Services.Validation.Orchestrator
                 .Where(s => s.StatusKey == PackageStatus.Validating)
                 .FirstOrDefault();
 
+            return symbolPackage == null ? null : new SymbolPackageValidatingEntity(symbolPackage);
+        }
+
+        public IValidatingEntity<SymbolPackage> FindPackageByKey(int key)
+        {
+            var symbolPackage = _symbolsPackageRepository
+                   .GetAll()
+                   .SingleOrDefault(p => p.Key == key);
             return symbolPackage == null ? null : new SymbolPackageValidatingEntity(symbolPackage);
         }
 

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -96,9 +96,10 @@ namespace NuGet.Services.Validation.Orchestrator
                     }
                     else
                     {
-                        _logger.LogInformation("Could not find symbols for package {PackageId} {PackageNormalizedVersion} in DB, retrying",
+                        _logger.LogInformation("Could not find symbols for package {PackageId} {PackageNormalizedVersion} {Key} in DB, retrying",
                             message.PackageId,
-                            message.PackageNormalizedVersion);
+                            message.PackageNormalizedVersion,
+                            message.EntityKey.HasValue ? message.EntityKey.Value.ToString() : "NotSet");
 
                         return false;
                     }
@@ -116,6 +117,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 }
 
                 var processorStats = await _validationSetProcessor.ProcessValidationsAsync(validationSet);
+                // As part of the processing the validation outcome the orchestrator will send itself a message if validation are still being processes
                 await _validationOutcomeProcessor.ProcessValidationOutcomeAsync(validationSet, symbolPackageEntity, processorStats);
             }
 

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -101,7 +101,7 @@ namespace NuGet.Services.Validation.Orchestrator
                         _logger.LogInformation("Could not find symbols for package {PackageId} {PackageNormalizedVersion} {Key} in DB, retrying",
                             message.PackageId,
                             message.PackageNormalizedVersion,
-                            message.EntityKey.HasValue ? message.EntityKey.Value.ToString() : "null");
+                            message.EntityKey.HasValue);
 
                         return false;
                     }

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -73,6 +73,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 message.PackageNormalizedVersion,
                 message.ValidationTrackingId))
             {
+                // When a message is sent from the Gallery with validation of a new entity, the EntityKey will be null because the message is sent to the service bus before the entity is persisted in the DB
+                // However when a revalidation happens or when the message is re-sent by the orchestrator the message will contain the key. In this case the key is used to find the entity to validate.
                 var symbolPackageEntity = message.EntityKey.HasValue ?
                     _gallerySymbolService.FindPackageByKey(message.EntityKey.Value):
                     _gallerySymbolService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
@@ -117,7 +119,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 }
 
                 var processorStats = await _validationSetProcessor.ProcessValidationsAsync(validationSet);
-                // As part of the processing the validation outcome the orchestrator will send itself a message if validation are still being processes
+                // As part of the processing the validation outcome the orchestrator will send itself a message if validation are still being processed.
                 await _validationOutcomeProcessor.ProcessValidationOutcomeAsync(validationSet, symbolPackageEntity, processorStats);
             }
 

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -75,9 +75,9 @@ namespace NuGet.Services.Validation.Orchestrator
             {
                 // When a message is sent from the Gallery with validation of a new entity, the EntityKey will be null because the message is sent to the service bus before the entity is persisted in the DB
                 // However when a revalidation happens or when the message is re-sent by the orchestrator the message will contain the key. In this case the key is used to find the entity to validate.
-                var symbolPackageEntity = message.EntityKey.HasValue ?
-                    _gallerySymbolService.FindPackageByKey(message.EntityKey.Value):
-                    _gallerySymbolService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
+                var symbolPackageEntity = message.EntityKey.HasValue
+                    ? _gallerySymbolService.FindPackageByKey(message.EntityKey.Value)
+                    : _gallerySymbolService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
 
                 if (symbolPackageEntity == null)
                 {
@@ -101,7 +101,7 @@ namespace NuGet.Services.Validation.Orchestrator
                         _logger.LogInformation("Could not find symbols for package {PackageId} {PackageNormalizedVersion} {Key} in DB, retrying",
                             message.PackageId,
                             message.PackageNormalizedVersion,
-                            message.EntityKey.HasValue ? message.EntityKey.Value.ToString() : "NotSet");
+                            message.EntityKey.HasValue ? message.EntityKey.Value.ToString() : "null");
 
                         return false;
                     }

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -73,7 +73,9 @@ namespace NuGet.Services.Validation.Orchestrator
                 message.PackageNormalizedVersion,
                 message.ValidationTrackingId))
             {
-                var symbolPackageEntity = _gallerySymbolService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
+                var symbolPackageEntity = message.EntityKey.HasValue ?
+                    _gallerySymbolService.FindPackageByKey(message.EntityKey.Value):
+                    _gallerySymbolService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
 
                 if (symbolPackageEntity == null)
                 {

--- a/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolScanValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolScanValidator.cs
@@ -113,7 +113,7 @@ namespace NuGet.Services.Validation.Symbols
         {
             var symbolPackage = _symbolPackageService
                 .FindSymbolPackagesByIdAndVersion(request.PackageId,request.PackageVersion)
-                .FirstOrDefault(sp => sp.StatusKey == PackageStatus.Validating);
+                .FirstOrDefault(sp => sp.Key == request.PackageKey);
 
             if (symbolPackage == null)
             {

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
@@ -264,7 +264,12 @@ namespace NuGet.Services.Validation.Orchestrator
             // Schedule another check if we haven't reached the validation set timeout yet.
             if (validationSetDuration <= _validationConfiguration.TimeoutValidationSetAfter)
             {
-                var messageData = new PackageValidationMessageData(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, validationSet.ValidatingType);
+                var messageData = new PackageValidationMessageData(
+                    validationSet.PackageId,
+                    validationSet.PackageNormalizedVersion,
+                    validationSet.ValidationTrackingId,
+                    validationSet.ValidatingType,
+                    entityKey: validationSet.PackageKey);
                 var postponeUntil = DateTimeOffset.UtcNow + _validationConfiguration.ValidationMessageRecheckPeriod;
 
                 await _validationEnqueuer.StartValidationAsync(messageData, postponeUntil);

--- a/src/Validation.Symbols/ISymbolsFileService.cs
+++ b/src/Validation.Symbols/ISymbolsFileService.cs
@@ -18,13 +18,15 @@ namespace Validation.Symbols
         /// <returns>The snupkg stream.</returns>
         Task<Stream> DownloadNupkgFileAsync(string packageId, string packageNormalizedVersion, CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Downloads the snupkg file.
-        /// </summary>
-        /// <param name="packageId">The package id.</param>
-        /// <param name="packageNormalizedVersion">The package normalized version.</param>
-        /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The nupkg stream.</returns>
-        Task<Stream> DownloadSnupkgFileAsync(string packageId, string packageNormalizedVersion, CancellationToken cancellationToken);
+        ///// <summary>
+        ///// Downloads the snupkg file.
+        ///// </summary>
+        ///// <param name="packageId">The package id.</param>
+        ///// <param name="packageNormalizedVersion">The package normalized version.</param>
+        ///// <param name="cancellationToken">Cancellation token.</param>
+        ///// <returns>The nupkg stream.</returns>
+        //Task<Stream> DownloadSnupkgFileAsync(string packageId, string packageNormalizedVersion, CancellationToken cancellationToken);
+
+        Task<Stream> DownloadSnupkgFileAsync(string snupkgUri, CancellationToken cancellationToken);
     }
 }

--- a/src/Validation.Symbols/ISymbolsFileService.cs
+++ b/src/Validation.Symbols/ISymbolsFileService.cs
@@ -23,7 +23,7 @@ namespace Validation.Symbols
         /// </summary>
         /// <param name="snupkgUri">The uri of the snupkg.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        /// <returns>The stream downloaded.</returns>
+        /// <returns>The snupkg stream.</returns>
         Task<Stream> DownloadSnupkgFileAsync(string snupkgUri, CancellationToken cancellationToken);
     }
 }

--- a/src/Validation.Symbols/ISymbolsFileService.cs
+++ b/src/Validation.Symbols/ISymbolsFileService.cs
@@ -18,15 +18,12 @@ namespace Validation.Symbols
         /// <returns>The snupkg stream.</returns>
         Task<Stream> DownloadNupkgFileAsync(string packageId, string packageNormalizedVersion, CancellationToken cancellationToken);
 
-        ///// <summary>
-        ///// Downloads the snupkg file.
-        ///// </summary>
-        ///// <param name="packageId">The package id.</param>
-        ///// <param name="packageNormalizedVersion">The package normalized version.</param>
-        ///// <param name="cancellationToken">Cancellation token.</param>
-        ///// <returns>The nupkg stream.</returns>
-        //Task<Stream> DownloadSnupkgFileAsync(string packageId, string packageNormalizedVersion, CancellationToken cancellationToken);
-
+        /// <summary>
+        /// Downloads the snupkg file.
+        /// </summary>
+        /// <param name="snupkgUri">The uri of the snupkg.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>The stream downloaded.</returns>
         Task<Stream> DownloadSnupkgFileAsync(string snupkgUri, CancellationToken cancellationToken);
     }
 }

--- a/src/Validation.Symbols/ISymbolsValidatorService.cs
+++ b/src/Validation.Symbols/ISymbolsValidatorService.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Jobs.Validation.Symbols.Core;
 using NuGet.Services.Validation;
 
 namespace Validation.Symbols
@@ -12,12 +11,11 @@ namespace Validation.Symbols
     public interface ISymbolsValidatorService
     {
         /// <summary>
-        /// Validates the symbols against the PE files. 
+        /// Validates the symbol package.
         /// </summary>
-        /// <param name="packageId">The package Id.</param>
-        /// <param name="packageNormalizedVersion">The package normalized version.</param>
-        /// <param name="token">A cancellation token to be used for cancellation of the async execution.</param>
-        /// <returns></returns>
-        Task<IValidationResult> ValidateSymbolsAsync(string packageId, string packageNormalizedVersion, CancellationToken token);
+        /// <param name="message">The <see cref="SymbolsValidatorMessage"/> regarding to the symbols pacakge to be validated..</param>
+        /// <param name="token">Cancellation token.</param>
+        /// <returns>The validation result.</returns>
+        Task<IValidationResult> ValidateSymbolsAsync(SymbolsValidatorMessage message, CancellationToken token);
     }
 }

--- a/src/Validation.Symbols/Job.cs
+++ b/src/Validation.Symbols/Job.cs
@@ -40,11 +40,7 @@ namespace Validation.Symbols
                     configurationAccessor.Value.ValidationPackageConnectionString,
                     readAccessGeoRedundant: false), c.GetRequiredService<IDiagnosticsService>());
 
-                var symbolValidationStorageService = new CloudBlobCoreFileStorageService(new CloudBlobClientWrapper(
-                    configurationAccessor.Value.ValidationSymbolsConnectionString,
-                    readAccessGeoRedundant: false), c.GetRequiredService<IDiagnosticsService>());
-
-                return new SymbolsFileService(packageStorageService, packageValidationStorageService, symbolValidationStorageService);
+                return new SymbolsFileService(packageStorageService, packageValidationStorageService, c.GetRequiredService<IFileDownloader>());
             });
             services.AddSingleton(new TelemetryClient());
         }

--- a/src/Validation.Symbols/Settings/dev.json
+++ b/src/Validation.Symbols/Settings/dev.json
@@ -13,6 +13,7 @@
     "PackageConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$",
     "ValidationSymbolsConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetdevlegacy;AccountKey=$$Dev-NuGetDevLegacyStorage-Key$$"
   },
+  "PackageDownloadTimeout": "00:10:00",
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
   "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",

--- a/src/Validation.Symbols/Settings/int.json
+++ b/src/Validation.Symbols/Settings/int.json
@@ -13,7 +13,7 @@
     "PackageConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$",
     "ValidationSymbolsConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetint0;AccountKey=$$Int-NuGetInt0Storage-Key$$"
   },
-
+  "PackageDownloadTimeout": "00:10:00",
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
   "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",

--- a/src/Validation.Symbols/Settings/prod.json
+++ b/src/Validation.Symbols/Settings/prod.json
@@ -13,7 +13,7 @@
     "PackageConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$",
     "ValidationSymbolsConnectionString": "DefaultEndpointsProtocol=https;AccountName=nugetgallery;AccountKey=$$Prod-NuGetGalleryStorage-Key$$"
   },
-
+  "PackageDownloadTimeout": "00:10:00",
   "KeyVault_VaultName": "#{Deployment.Azure.KeyVault.VaultName}",
   "KeyVault_ClientId": "#{Deployment.Azure.KeyVault.ClientId}",
   "KeyVault_CertificateThumbprint": "#{Deployment.Azure.KeyVault.CertificateThumbprint}",

--- a/src/Validation.Symbols/SymbolsValidatorMessageHandler.cs
+++ b/src/Validation.Symbols/SymbolsValidatorMessageHandler.cs
@@ -86,7 +86,7 @@ namespace Validation.Symbols
                     return true;
                 }
 
-                var validationResult = await _symbolValidatorService.ValidateSymbolsAsync(message.PackageId, message.PackageNormalizedVersion, CancellationToken.None);
+                var validationResult = await _symbolValidatorService.ValidateSymbolsAsync(message, CancellationToken.None);
 
                 if (validationResult.Status == ValidationStatus.Failed || validationResult.Status == ValidationStatus.Succeeded)
                 {

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
@@ -101,8 +101,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 var stream = new MemoryStream(Encoding.ASCII.GetBytes(content));
 
                 var corePackageService = new Mock<ICorePackageService>();
-                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
-                var entityPackageService = new PackageEntityService(corePackageService.Object, mockIPackageEntityRepository.Object);
+                var mockPackageEntityRepository = new Mock<IEntityRepository<Package>>();
+                var entityPackageService = new PackageEntityService(corePackageService.Object, mockPackageEntityRepository.Object);
 
                 PackageFileServiceMock
                     .Setup(x => x.DownloadPackageFileToDiskAsync(ValidationSet))

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
@@ -101,7 +101,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 var stream = new MemoryStream(Encoding.ASCII.GetBytes(content));
 
                 var corePackageService = new Mock<ICorePackageService>();
-                var entityPackageService = new PackageEntityService(corePackageService.Object);
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
+                var entityPackageService = new PackageEntityService(corePackageService.Object, mockIPackageEntityRepository.Object);
 
                 PackageFileServiceMock
                     .Setup(x => x.DownloadPackageFileToDiskAsync(ValidationSet))

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Services/PackageEntityServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Services/PackageEntityServiceFacts.cs
@@ -25,8 +25,9 @@ namespace NuGet.Services.Validation
             {
                 // Arrange
                 var mockCorePackageService = new Mock<ICorePackageService>();
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
                 mockCorePackageService.Setup(c => c.FindPackageByIdAndVersionStrict(It.IsAny<string>(), It.IsAny<string>())).Returns((Package)null);
-                var service = new PackageEntityService(mockCorePackageService.Object);
+                var service = new PackageEntityService(mockCorePackageService.Object, mockIPackageEntityRepository.Object);
 
                 // Act & Assert
                 var result = service.FindPackageByIdAndVersionStrict("Id", "version");
@@ -41,8 +42,9 @@ namespace NuGet.Services.Validation
                 var package = CreatePackage();
 
                 var mockCorePackageService = new Mock<ICorePackageService>();
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
                 mockCorePackageService.Setup(c => c.FindPackageByIdAndVersionStrict(PackageId, PackageNormalizedVersion)).Returns(package);
-                var service = new PackageEntityService(mockCorePackageService.Object);
+                var service = new PackageEntityService(mockCorePackageService.Object, mockIPackageEntityRepository.Object);
 
                 // Act & Assert
                 var result = service.FindPackageByIdAndVersionStrict(PackageId, PackageNormalizedVersion);
@@ -63,8 +65,9 @@ namespace NuGet.Services.Validation
                 // Arrange
                 var package = CreatePackage();
                 var mockCorePackageService = new Mock<ICorePackageService>();
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
                 mockCorePackageService.Setup(c => c.UpdatePackageStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), true)).Returns(Task.CompletedTask);
-                var service = new PackageEntityService(mockCorePackageService.Object);
+                var service = new PackageEntityService(mockCorePackageService.Object, mockIPackageEntityRepository.Object);
 
                 // Act & Assert
                 var result = service.UpdateStatusAsync(package, PackageStatus.Available, true);
@@ -82,7 +85,8 @@ namespace NuGet.Services.Validation
                 // Arrange
                 var package = CreatePackage();
                 var mockCorePackageService = new Mock<ICorePackageService>();
-                var service = new PackageEntityService(mockCorePackageService.Object);
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
+                var service = new PackageEntityService(mockCorePackageService.Object, mockIPackageEntityRepository.Object);
 
                 // Act & Assert
                 var result = service.UpdateMetadataAsync(package, null, true);
@@ -97,7 +101,8 @@ namespace NuGet.Services.Validation
                 // Arrange
                 var package = CreatePackage();
                 var mockCorePackageService = new Mock<ICorePackageService>();
-                var service = new PackageEntityService(mockCorePackageService.Object);
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
+                var service = new PackageEntityService(mockCorePackageService.Object, mockIPackageEntityRepository.Object);
 
                 // Act & Assert
                 var result = service.UpdateMetadataAsync(package, "NotMetadata", true);
@@ -122,7 +127,8 @@ namespace NuGet.Services.Validation
                 };
 
                 var mockCorePackageService = new Mock<ICorePackageService>();
-                var service = new PackageEntityService(mockCorePackageService.Object);
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
+                var service = new PackageEntityService(mockCorePackageService.Object, mockIPackageEntityRepository.Object);
 
                 // Act & Assert
                 var result = service.UpdateMetadataAsync(package, metadata, true);
@@ -147,8 +153,9 @@ namespace NuGet.Services.Validation
                 };
 
                 var mockCorePackageService = new Mock<ICorePackageService>();
+                var mockIPackageEntityRepository = new Mock<IEntityRepository<Package>>();
                 mockCorePackageService.Setup(c => c.UpdatePackageStreamMetadataAsync(package, metadata, true)).Returns(Task.CompletedTask);
-                var service = new PackageEntityService(mockCorePackageService.Object);
+                var service = new PackageEntityService(mockCorePackageService.Object, mockIPackageEntityRepository.Object);
 
                 // Act & Assert
                 var result = service.UpdateMetadataAsync(package, metadata, true);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Services/SymbolEntityServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Services/SymbolEntityServiceFacts.cs
@@ -266,13 +266,15 @@ namespace NuGet.Services.Validation.Orchestrator.Tests.Symbol
         public abstract class FactsBase
         {
             protected readonly Mock<ICoreSymbolPackageService> _coreSymbolPackageService;
-           
+            protected readonly Mock<IEntityRepository<SymbolPackage>> _symbolEntityRepository;
+
             protected readonly SymbolEntityService _target;
 
             public FactsBase(ITestOutputHelper output)
             {
                 _coreSymbolPackageService = new Mock<ICoreSymbolPackageService>();
-                _target = new SymbolEntityService(_coreSymbolPackageService.Object);
+                _symbolEntityRepository = new Mock<IEntityRepository<SymbolPackage>>();
+                _target = new SymbolEntityService(_coreSymbolPackageService.Object, _symbolEntityRepository.Object);
             }
         }
     }

--- a/tests/Validation.Symbols.Tests/SymbolsValidatorMessageHandlerTests.cs
+++ b/tests/Validation.Symbols.Tests/SymbolsValidatorMessageHandlerTests.cs
@@ -113,7 +113,7 @@ namespace Validation.Symbols.Tests
                 { State = ValidationStatus.Incomplete };
 
                 _validatorStateService.Setup(s => s.GetStatusAsync(It.IsAny<Guid>())).ReturnsAsync(status);
-                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ValidationResult.Incomplete);
+                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<SymbolsValidatorMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(ValidationResult.Incomplete);
 
                 var handler = new SymbolsValidatorMessageHandler(_logger.Object, _symbolService.Object, _validatorStateService.Object);
 
@@ -122,7 +122,7 @@ namespace Validation.Symbols.Tests
 
                 // Assert
                 Assert.False(result);
-                _symbolService.Verify(ss => ss.ValidateSymbolsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+                _symbolService.Verify(ss => ss.ValidateSymbolsAsync(It.IsAny<SymbolsValidatorMessage>(), It.IsAny<CancellationToken>()), Times.Once);
             }
 
             [Fact]
@@ -134,7 +134,7 @@ namespace Validation.Symbols.Tests
 
                 _validatorStateService.Setup(s => s.GetStatusAsync(It.IsAny<Guid>())).ReturnsAsync(status);
                 _validatorStateService.Setup(s => s.SaveStatusAsync(It.IsAny<ValidatorStatus>())).ReturnsAsync(SaveStatusResult.Success);
-                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(ValidationResult.Succeeded);
+                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<SymbolsValidatorMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(ValidationResult.Succeeded);
 
                 var handler = new SymbolsValidatorMessageHandler(_logger.Object, _symbolService.Object, _validatorStateService.Object);
 
@@ -156,7 +156,7 @@ namespace Validation.Symbols.Tests
                 _validatorStateService.Setup(s => s.GetStatusAsync(It.IsAny<Guid>())).ReturnsAsync(status);
                 _validatorStateService.Setup(s => s.SaveStatusAsync(It.IsAny<ValidatorStatus>())).ReturnsAsync(SaveStatusResult.Success);
 
-                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
+                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<SymbolsValidatorMessage>(), It.IsAny<CancellationToken>())).
                     ReturnsAsync(ValidationResult.FailedWithIssues(ValidationIssue.Unknown));
 
                 var handler = new SymbolsValidatorMessageHandler(_logger.Object, _symbolService.Object, _validatorStateService.Object);
@@ -180,7 +180,7 @@ namespace Validation.Symbols.Tests
                 _validatorStateService.Setup(s => s.GetStatusAsync(It.IsAny<Guid>())).ReturnsAsync(status);
                 _validatorStateService.Setup(s => s.SaveStatusAsync(It.IsAny<ValidatorStatus>())).ReturnsAsync(SaveStatusResult.StaleStatus);
 
-                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
+                _symbolService.Setup(s => s.ValidateSymbolsAsync(It.IsAny<SymbolsValidatorMessage>(), It.IsAny<CancellationToken>())).
                     ReturnsAsync(ValidationResult.Succeeded);
 
                 var handler = new SymbolsValidatorMessageHandler(_logger.Object, _symbolService.Object, _validatorStateService.Object);

--- a/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
+++ b/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
@@ -18,6 +18,7 @@ namespace Validation.Symbols.Tests
     {
         private const string PackageId = "Pack";
         private const string PackageNormalizedVersion = "1.2.3";
+        private static readonly SymbolsValidatorMessage Message = new SymbolsValidatorMessage(new Guid(), 1, PackageId, PackageNormalizedVersion, "https://dummy.snupkg");
 
         public sealed class TheValidateSymbolsAsyncMethod : FactBase
         {
@@ -26,13 +27,13 @@ namespace Validation.Symbols.Tests
             {
                 // Arrange
                 _symbolsFileService.
-                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
+                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).
                     ThrowsAsync(new FileNotFoundException("Snupkg not found"));
 
                 var service = new SymbolsValidatorService(_symbolsFileService.Object, _zipService.Object, _telemetryService.Object, _logger.Object);
 
                 // Act 
-                var  result = await service.ValidateSymbolsAsync(PackageId, PackageNormalizedVersion, CancellationToken.None);
+                var  result = await service.ValidateSymbolsAsync(Message, CancellationToken.None);
 
                 // Assert 
                 Assert.Equal(ValidationResult.Failed.Status, result.Status);
@@ -47,13 +48,13 @@ namespace Validation.Symbols.Tests
                     ThrowsAsync(new FileNotFoundException("Nupkg not found"));
 
                 _symbolsFileService.
-                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
+                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).
                     ReturnsAsync(new MemoryStream());
 
                 var service = new SymbolsValidatorService(_symbolsFileService.Object, _zipService.Object, _telemetryService.Object, _logger.Object);
 
                 // Act 
-                var result = await service.ValidateSymbolsAsync(PackageId, PackageNormalizedVersion, CancellationToken.None);
+                var result = await service.ValidateSymbolsAsync(Message, CancellationToken.None);
 
                 // Assert 
                 Assert.Equal(ValidationResult.Failed.Status, result.Status);
@@ -69,7 +70,7 @@ namespace Validation.Symbols.Tests
                     ReturnsAsync(new MemoryStream());
 
                 _symbolsFileService.
-                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
+                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).
                     ReturnsAsync(new MemoryStream());
 
                 _zipService.Setup(s => s.ReadFilesFromZipStream(It.IsAny<Stream>(), It.IsAny<string[]>())).Returns(new List<string>()
@@ -81,7 +82,7 @@ namespace Validation.Symbols.Tests
                 var service = new SymbolsValidatorService(_symbolsFileService.Object, _zipService.Object, _telemetryService.Object, _logger.Object);
 
                 // Act 
-                var result = await service.ValidateSymbolsAsync(PackageId, PackageNormalizedVersion, CancellationToken.None);
+                var result = await service.ValidateSymbolsAsync(Message, CancellationToken.None);
 
                 // Assert 
                 Assert.Equal(ValidationResult.Failed.Status, result.Status);
@@ -97,7 +98,7 @@ namespace Validation.Symbols.Tests
                     ReturnsAsync(new MemoryStream());
 
                 _symbolsFileService.
-                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).
+                    Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).
                     ReturnsAsync(new MemoryStream());
 
                 _zipService.Setup(s => s.ReadFilesFromZipStream(It.IsAny<Stream>(), It.IsAny<string[]>())).Returns(new List<string>()
@@ -109,7 +110,7 @@ namespace Validation.Symbols.Tests
                 var service = new TestSymbolsValidatorService(_symbolsFileService.Object, _zipService.Object, _telemetryService.Object, _logger.Object);
 
                 // Act 
-                var result = await service.ValidateSymbolsAsync(PackageId, PackageNormalizedVersion, CancellationToken.None);
+                var result = await service.ValidateSymbolsAsync(Message, CancellationToken.None);
 
                 // Assert 
                 Assert.Equal(ValidationResult.Succeeded.Status, result.Status);

--- a/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
+++ b/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
@@ -28,7 +28,7 @@ namespace Validation.Symbols.Tests
                 // Arrange
                 _symbolsFileService.
                     Setup(sfs => sfs.DownloadSnupkgFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).
-                    ThrowsAsync(new FileNotFoundException("Snupkg not found"));
+                    ThrowsAsync(new InvalidOperationException("Snupkg not found"));
 
                 var service = new SymbolsValidatorService(_symbolsFileService.Object, _zipService.Object, _telemetryService.Object, _logger.Object);
 


### PR DESCRIPTION
In order to support symbol revalidation the PackageValidationMessageData was updated to include the entity key. With this change integrate the message key in the symbol orchestrator logic. 

Also change the SymbolsValidator to use the validation set as the container to download the symbols package from not the validation root container. 