### PR TITLE
Add Markdig.dll to ThirdPartyBinaries list

### DIFF
--- a/sign.thirdparty.targets
+++ b/sign.thirdparty.targets
@@ -12,6 +12,7 @@
             <ThirdPartyBinaries Include="Dapper.StrongName.dll" />
             <ThirdPartyBinaries Include="Elmah.dll" />
             <ThirdPartyBinaries Include="ICSharpCode.SharpZipLib.dll" />
+            <ThirdPartyBinaries Include="Markdig.dll" />
             <ThirdPartyBinaries Include="MarkdownSharp.dll" />
             <ThirdPartyBinaries Include="Newtonsoft.Json.dll" />
             <ThirdPartyBinaries Include="Newtonsoft.Json.Schema.dll" />


### PR DESCRIPTION
The assembly isn't being signed.

https://github.com/NuGet/Engineering/issues/1692