### PR TITLE
Hotfix: fix StatusAggregator AggregationProvider query

### DIFF
--- a/src/StatusAggregator/Factory/IncidentFactory.cs
+++ b/src/StatusAggregator/Factory/IncidentFactory.cs
@@ -42,7 +42,7 @@ namespace StatusAggregator.Factory
                     input.Id,
                     groupEntity,
                     affectedPath,
-                    (ComponentStatus)input.AffectedComponentStatus,
+                    input.AffectedComponentStatus,
                     input.StartTime,
                     input.EndTime);
 


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/1846
This table storage query was misbehaving when `input.EndTime == null`.
It should be hotfixed because this means the job will be down whenever the site is having issues.

See me offline if you want a more detailed explanation.
TL;DR: table storage behaves very oddly with `null` values.