### PR TITLE
[Revalidation] Skip packages with many versions

### DIFF
--- a/src/NuGet.Services.Revalidate/Configuration/RevalidationQueueConfiguration.cs
+++ b/src/NuGet.Services.Revalidate/Configuration/RevalidationQueueConfiguration.cs
@@ -8,6 +8,11 @@ namespace NuGet.Services.Revalidate
     public class RevalidationQueueConfiguration
     {
         /// <summary>
+        /// If non-null, this skips revalidations of packages with more than this many versions.
+        /// </summary>
+        public int? MaximumPackageVersions { get; set; }
+
+        /// <summary>
         /// The maximum times that the <see cref="RevalidationQueue"/> should look for a revalidation
         /// before giving up.
         /// </summary>

--- a/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
@@ -56,7 +56,7 @@ namespace NuGet.Services.Revalidate
                     query = query.Where(
                         r =>
                         !_validationContext.PackageRevalidations.GroupBy(r2 => r2.PackageId)
-                        .Where(g => g.Count() > 200)
+                        .Where(g => g.Count() > _config.MaximumPackageVersions)
                         .Any(g => g.Key == r.PackageId));
                 }
 

--- a/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
@@ -45,7 +45,22 @@ namespace NuGet.Services.Revalidate
                     i + 1,
                     _config.MaximumAttempts);
 
-                var next = await _validationContext.PackageRevalidations
+                // Find the next package to revalidate. We will skip packages if:
+                //   1. The package has more than "MaximumPackageVersions" versions
+                //   2. The package has already been enqueued for revalidation
+                //   3. The package's revalidation was completed by an external factory (like manual admin revalidation)
+                IQueryable<PackageRevalidation> query = _validationContext.PackageRevalidations;
+
+                if (_config.MaximumPackageVersions.HasValue)
+                {
+                    query = query.Where(
+                        r =>
+                        !_validationContext.PackageRevalidations.GroupBy(r2 => r2.PackageId)
+                        .Where(g => g.Count() > 200)
+                        .Any(g => g.Key == r.PackageId));
+                }
+
+                var next = await query
                     .Where(r => r.Enqueued == null)
                     .Where(r => r.Completed == false)
                     .OrderBy(r => r.Key)

--- a/src/NuGet.Services.Revalidate/Settings/dev.json
+++ b/src/NuGet.Services.Revalidate/Settings/dev.json
@@ -27,6 +27,7 @@
     },
 
     "Queue": {
+      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions},
       "MaximumAttempts": 5,
       "SleepBetweenAttempts": "00:00:30"
     }

--- a/src/NuGet.Services.Revalidate/Settings/int.json
+++ b/src/NuGet.Services.Revalidate/Settings/int.json
@@ -27,6 +27,7 @@
     },
 
     "Queue": {
+      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions},
       "MaximumAttempts": 5,
       "SleepBetweenAttempts": "00:00:30"
     }

--- a/src/NuGet.Services.Revalidate/Settings/prod.json
+++ b/src/NuGet.Services.Revalidate/Settings/prod.json
@@ -27,6 +27,7 @@
     },
 
     "Queue": {
+      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions},
       "MaximumAttempts": 5,
       "SleepBetweenAttempts": "00:00:30"
     }


### PR DESCRIPTION
This change allows the revalidation job to skip packages with many versions. This generates the following query:

```sql
SELECT TOP (1) [t0].[Key], [t0].[PackageId], [t0].[PackageNormalizedVersion], [t0].[Enqueued], [t0].[ValidationTrackingId], [t0].[Completed], [t0].[RowVersion]
FROM [PackageRevalidations] AS [t0]
WHERE (NOT ([t0].[Completed] = 1)) AND ([t0].[Enqueued] IS NULL) AND (NOT (EXISTS(
    SELECT NULL AS [EMPTY]
    FROM (
        SELECT COUNT(*) AS [value], [t1].[PackageId]
        FROM [PackageRevalidations] AS [t1]
        GROUP BY [t1].[PackageId]
        ) AS [t2]
    WHERE ([t2].[PackageId] = [t0].[PackageId]) AND ([t2].[value] > @p0)
    )))
ORDER BY [t0].[Key]
```