### PR TITLE
RevalidateCertificate: DI scopes to fix SQL lifetimes

### DIFF
--- a/src/Validation.PackageSigning.RevalidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Job.cs
@@ -19,8 +19,6 @@ namespace Validation.PackageSigning.RevalidateCertificate
     {
         private const string RevalidationConfigurationSectionName = "RevalidateJob";
 
-        private ICertificateRevalidator _revalidator;
-
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {
             base.Init(serviceContainer, jobArgsDictionary);
@@ -30,13 +28,13 @@ namespace Validation.PackageSigning.RevalidateCertificate
         {
             using (var scope = _serviceProvider.CreateScope())
             {
-                _revalidator = _serviceProvider.GetRequiredService<ICertificateRevalidator>();
+                var revalidator = scope.ServiceProvider.GetRequiredService<ICertificateRevalidator>();
 
                 // Both of these methods only do a chunk of the possible promotion/revalidating work before
                 // completing. This "Run" method may need to run several times to promote all signatures
                 // and to revalidate all stale certificates.
-                await _revalidator.PromoteSignaturesAsync();
-                await _revalidator.RevalidateStaleCertificatesAsync();
+                await revalidator.PromoteSignaturesAsync();
+                await revalidator.RevalidateStaleCertificatesAsync();
             }
         }
 

--- a/src/Validation.PackageSigning.RevalidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Job.cs
@@ -24,17 +24,20 @@ namespace Validation.PackageSigning.RevalidateCertificate
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {
             base.Init(serviceContainer, jobArgsDictionary);
-
-            _revalidator = _serviceProvider.GetRequiredService<ICertificateRevalidator>();
         }
 
         public override async Task Run()
         {
-            // Both of these methods only do a chunk of the possible promotion/revalidating work before
-            // completing. This "Run" method may need to run several times to promote all signatures
-            // and to revalidate all stale certificates.
-            await _revalidator.PromoteSignaturesAsync();
-            await _revalidator.RevalidateStaleCertificatesAsync();
+            using (var scope = _serviceProvider.CreateScope())
+            {
+                _revalidator = _serviceProvider.GetRequiredService<ICertificateRevalidator>();
+
+                // Both of these methods only do a chunk of the possible promotion/revalidating work before
+                // completing. This "Run" method may need to run several times to promote all signatures
+                // and to revalidate all stale certificates.
+                await _revalidator.PromoteSignaturesAsync();
+                await _revalidator.RevalidateStaleCertificatesAsync();
+            }
         }
 
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)


### PR DESCRIPTION
Tracking: https://github.com/NuGet/Engineering/issues/1618

ReinitializeAfterSeconds is configured for 24h, so we need DI scopes to ensure that new SQL connections are created on each run iteration.