### PR TITLE
FailValidationWithMixedSymbols

### DIFF
--- a/src/Validation.Symbols/ITelemetryService.cs
+++ b/src/Validation.Symbols/ITelemetryService.cs
@@ -38,6 +38,7 @@ namespace Validation.Symbols
         /// <param name="packageNormalizedVersion">The package normalized version.</param>
         /// <param name="validationStatus">The validation result.</param>
         /// <param name="issue">Information about the issue id failed or empty if passed..</param>
-        void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue);
+        /// <param name="assemblyName">The assembly name.</param>
+        void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue, string assemblyName);
     }
 }

--- a/src/Validation.Symbols/ITelemetryService.cs
+++ b/src/Validation.Symbols/ITelemetryService.cs
@@ -32,13 +32,21 @@ namespace Validation.Symbols
         IDisposable TrackSymbolValidationDurationEvent(string packageId, string packageNormalizedVersion, int symbolCount);
 
         /// <summary>
-        /// Tracks the status of the validation.
+        /// Tracks the status of the validation per assembly.
         /// </summary>
         /// <param name="packageId">The package id.</param>
         /// <param name="packageNormalizedVersion">The package normalized version.</param>
         /// <param name="validationStatus">The validation result.</param>
         /// <param name="issue">Information about the issue id failed or empty if passed..</param>
         /// <param name="assemblyName">The assembly name.</param>
-        void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue, string assemblyName);
+        void TrackSymbolsAssemblyValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue, string assemblyName);
+
+        /// <summary>
+        /// Tracks the status of the validation per package.
+        /// </summary>
+        /// <param name="packageId">The package id.</param>
+        /// <param name="packageNormalizedVersion">The package normalized version.</param>
+        /// <param name="validationStatus">The validation result.</param>
+        void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus);
     }
 }

--- a/src/Validation.Symbols/SymbolsValidatorService.cs
+++ b/src/Validation.Symbols/SymbolsValidatorService.cs
@@ -64,7 +64,7 @@ namespace Validation.Symbols
                             {
                                 if (!SymbolsHaveMatchingPEFiles(pdbs, pes))
                                 {
-                                    _telemetryService.TrackSymbolsValidationResultEvent(message.PackageId, message.PackageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound));
+                                    _telemetryService.TrackSymbolsValidationResultEvent(message.PackageId, message.PackageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound), assemblyName:"");
                                     return ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound);
                                 }
                                 var targetDirectory = Settings.GetWorkingDirectory();
@@ -151,79 +151,84 @@ namespace Validation.Symbols
             {
                 foreach (string peFile in Directory.GetFiles(targetDirectory, extension, SearchOption.AllDirectories))
                 {
-                    using (var peStream = File.OpenRead(peFile))
-                    using (var peReader = new PEReader(peStream))
+                    IValidationResult validationResult;
+                    if (!IsChecksumMatch(peFile, packageId, packageNormalizedVersion, out validationResult))
                     {
-                        // This checks if portable PDB is associated with the PE file and opens it for reading. 
-                        // It also validates that it matches the PE file.
-                        // It does not validate that the checksum matches, so we need to do that in the following block.
-                        if (peReader.TryOpenAssociatedPortablePdb(peFile, File.OpenRead, out var pdbReaderProvider, out var pdbPath) &&
-                           // No need to validate embedded PDB (pdbPath == null for embedded)
-                           pdbPath != null)
-                        {
-                            // Get all checksum entries. There can be more than one. At least one must match the PDB.
-                            var checksumRecords = peReader.ReadDebugDirectory().Where(entry => entry.Type == DebugDirectoryEntryType.PdbChecksum)
-                                .Select(e => peReader.ReadPdbChecksumDebugDirectoryData(e))
-                                .ToArray();
-
-                            if (checksumRecords.Length == 0)
-                            {
-                                _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch));
-                                return ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
-                            }
-
-                            var pdbBytes = File.ReadAllBytes(pdbPath);
-                            var hashes = new Dictionary<string, byte[]>();
-
-                            using (pdbReaderProvider)
-                            {
-                                var pdbReader = pdbReaderProvider.GetMetadataReader();
-                                int idOffset = pdbReader.DebugMetadataHeader.IdStartOffset;
-
-                                foreach (var checksumRecord in checksumRecords)
-                                {
-                                    if (!hashes.TryGetValue(checksumRecord.AlgorithmName, out var hash))
-                                    {
-                                        HashAlgorithmName han = new HashAlgorithmName(checksumRecord.AlgorithmName);
-                                        using (var hashAlg = IncrementalHash.CreateHash(han))
-                                        {
-                                            hashAlg.AppendData(pdbBytes, 0, idOffset);
-                                            hashAlg.AppendData(new byte[20]);
-                                            int offset = idOffset + 20;
-                                            int count = pdbBytes.Length - offset;
-                                            hashAlg.AppendData(pdbBytes, offset, count);
-                                            hash = hashAlg.GetHashAndReset();
-                                        }
-                                        hashes.Add(checksumRecord.AlgorithmName, hash);
-                                    }
-                                    if (checksumRecord.Checksum.ToArray().SequenceEqual(hash))
-                                    {
-                                        // found the right checksum
-                                        _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Succeeded, "");
-                                        return ValidationResult.Succeeded;
-                                    }
-                                }
-
-                                // Not found any checksum record that matches the PDB.
-                                _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch));
-                                return ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
-                            }
-                        }
+                        return validationResult;
                     }
-                    _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound));
-                    return ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound);
                 }
             }
-            // If did not return there were not any PE files to validate. In this case return error to not proceeed with an ingestion.
-            _logger.LogError("{ValidatorName}: There were not any dll or exe files found locally." +
-                             "This could indicate an issue in the execution or the package was not correct created. PackageId {PackageId} PackageNormalizedVersion {PackageNormalizedVersion}. " +
-                             "SymbolCount: {SymbolCount}",
-                             ValidatorName.SymbolsValidator,
-                             packageId,
-                             packageNormalizedVersion,
-                             Directory.GetFiles(targetDirectory, SymbolExtensionPattern, SearchOption.AllDirectories));
-            _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound));
-            return ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound);
+            _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Succeeded, issue:"", assemblyName:"");
+            return ValidationResult.Succeeded;
+        }
+
+        private bool IsChecksumMatch(string peFilePath, string packageId, string packageNormalizedVersion, out IValidationResult validationResult)
+        {
+            validationResult = ValidationResult.Succeeded;
+            using (var peStream = File.OpenRead(peFilePath))
+            using (var peReader = new PEReader(peStream))
+            {
+                // This checks if portable PDB is associated with the PE file and opens it for reading. 
+                // It also validates that it matches the PE file.
+                // It does not validate that the checksum matches, so we need to do that in the following block.
+                if (peReader.TryOpenAssociatedPortablePdb(peFilePath, File.OpenRead, out var pdbReaderProvider, out var pdbPath) &&
+                   // No need to validate embedded PDB (pdbPath == null for embedded)
+                   pdbPath != null)
+                {
+                    // Get all checksum entries. There can be more than one. At least one must match the PDB.
+                    var checksumRecords = peReader.ReadDebugDirectory().Where(entry => entry.Type == DebugDirectoryEntryType.PdbChecksum)
+                        .Select(e => peReader.ReadPdbChecksumDebugDirectoryData(e))
+                        .ToArray();
+
+                    if (checksumRecords.Length == 0)
+                    {
+                        _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch), assemblyName: Path.GetFileName(peFilePath));
+                        validationResult = ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
+                        return false;
+                    }
+
+                    var pdbBytes = File.ReadAllBytes(pdbPath);
+                    var hashes = new Dictionary<string, byte[]>();
+
+                    using (pdbReaderProvider)
+                    {
+                        var pdbReader = pdbReaderProvider.GetMetadataReader();
+                        int idOffset = pdbReader.DebugMetadataHeader.IdStartOffset;
+
+                        foreach (var checksumRecord in checksumRecords)
+                        {
+                            if (!hashes.TryGetValue(checksumRecord.AlgorithmName, out var hash))
+                            {
+                                HashAlgorithmName han = new HashAlgorithmName(checksumRecord.AlgorithmName);
+                                using (var hashAlg = IncrementalHash.CreateHash(han))
+                                {
+                                    hashAlg.AppendData(pdbBytes, 0, idOffset);
+                                    hashAlg.AppendData(new byte[20]);
+                                    int offset = idOffset + 20;
+                                    int count = pdbBytes.Length - offset;
+                                    hashAlg.AppendData(pdbBytes, offset, count);
+                                    hash = hashAlg.GetHashAndReset();
+                                }
+                                hashes.Add(checksumRecord.AlgorithmName, hash);
+                            }
+                            if (checksumRecord.Checksum.ToArray().SequenceEqual(hash))
+                            {
+                                // found the right checksum
+                                _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion,  ValidationStatus.Succeeded, issue:"", assemblyName:Path.GetFileName(peFilePath));
+                                return true;
+                            }
+                        }
+
+                        // Not found any checksum record that matches the PDB.
+                        _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch), assemblyName: Path.GetFileName(peFilePath));
+                        validationResult = ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
+                        return false;
+                    }
+                }
+            }
+            _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound), assemblyName: Path.GetFileName(peFilePath));
+            validationResult = ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_MatchingPortablePDBNotFound);
+            return false;
         }
 
         /// <summary>

--- a/src/Validation.Symbols/TelemetryService.cs
+++ b/src/Validation.Symbols/TelemetryService.cs
@@ -24,6 +24,7 @@ namespace Validation.Symbols
         private const string SymbolCount = "SymbolCount";
         private const string ValidationResult = "ValidationResult";
         private const string Issue = "Issue";
+        private const string AssemblyName = "AssemblyName";
 
         private readonly ITelemetryClient _telemetryClient;
 
@@ -68,7 +69,7 @@ namespace Validation.Symbols
                 });
         }
 
-        public void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue)
+        public void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue, string assemblyName)
         {
             _telemetryClient.TrackMetric(
                 SymbolValidationResult,
@@ -78,7 +79,8 @@ namespace Validation.Symbols
                     { ValidationResult, validationStatus.ToString() },
                     { Issue, issue },
                     { PackageId, packageId },
-                    { PackageNormalizedVersion, packageNormalizedVersion }
+                    { PackageNormalizedVersion, packageNormalizedVersion },
+                    { AssemblyName, assemblyName }
                 });
         }
 

--- a/src/Validation.Symbols/TelemetryService.cs
+++ b/src/Validation.Symbols/TelemetryService.cs
@@ -17,6 +17,7 @@ namespace Validation.Symbols
         private const string MessageDeliveryLag = Prefix + "MessageDeliveryLag";
         private const string MessageEnqueueLag = Prefix + "MessageEnqueueLag";
         private const string SymbolValidationResult = Prefix + "SymbolValidationResult";
+        private const string SymbolAssemblyValidationResult = Prefix + "SymbolAssemblyValidationResult";
 
         private const string PackageId = "PackageId";
         private const string PackageNormalizedVersion = "PackageNormalizedVersion";
@@ -69,10 +70,10 @@ namespace Validation.Symbols
                 });
         }
 
-        public void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue, string assemblyName)
+        public void TrackSymbolsAssemblyValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus, string issue, string assemblyName)
         {
             _telemetryClient.TrackMetric(
-                SymbolValidationResult,
+                SymbolAssemblyValidationResult,
                 1,
                 new Dictionary<string, string>
                 {
@@ -81,6 +82,19 @@ namespace Validation.Symbols
                     { PackageId, packageId },
                     { PackageNormalizedVersion, packageNormalizedVersion },
                     { AssemblyName, assemblyName }
+                });
+        }
+
+        public void TrackSymbolsValidationResultEvent(string packageId, string packageNormalizedVersion, ValidationStatus validationStatus)
+        {
+            _telemetryClient.TrackMetric(
+                SymbolValidationResult,
+                1,
+                new Dictionary<string, string>
+                {
+                    { ValidationResult, validationStatus.ToString() },
+                    { PackageId, packageId },
+                    { PackageNormalizedVersion, packageNormalizedVersion }
                 });
         }
 

--- a/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
+++ b/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
@@ -128,7 +128,8 @@ namespace Validation.Symbols.Tests
                 string[] pes = new string[] { @"lib\math\foo.dll", @"lib\math\bar.exe", @"lib\math2\bar2.exe" };
 
                 // Act
-                var result = SymbolsValidatorService.SymbolsHaveMatchingPEFiles(symbols, pes);
+                List<string> orphanSymbols;
+                var result = SymbolsValidatorService.SymbolsHaveMatchingPEFiles(symbols, pes, out orphanSymbols);
 
                 // Assert
                 Assert.True(result);
@@ -142,7 +143,8 @@ namespace Validation.Symbols.Tests
                 string[] pes = new string[] { @"lib\math\foo.dll", @"lib\math\bar.exe", @"lib\math2\bar2.exe" };
 
                 // Act
-                var result = SymbolsValidatorService.SymbolsHaveMatchingPEFiles(symbols, pes);
+                List<string> orphanSymbols;
+                var result = SymbolsValidatorService.SymbolsHaveMatchingPEFiles(symbols, pes, out orphanSymbols);
 
                 // Assert
                 Assert.False(result);
@@ -156,8 +158,9 @@ namespace Validation.Symbols.Tests
                 string[] pes = new string[] { @"lib\math\foo.dll", @"lib\math\bar.exe", @"lib\math2\bar2.exe" };
 
                 // Act + Assert
-                Assert.Throws<ArgumentNullException>(()=>SymbolsValidatorService.SymbolsHaveMatchingPEFiles(null, pes));
-                Assert.Throws<ArgumentNullException>(() => SymbolsValidatorService.SymbolsHaveMatchingPEFiles(symbols, null));
+                List<string> orphanSymbols;
+                Assert.Throws<ArgumentNullException>(()=>SymbolsValidatorService.SymbolsHaveMatchingPEFiles(null, pes, out orphanSymbols));
+                Assert.Throws<ArgumentNullException>(() => SymbolsValidatorService.SymbolsHaveMatchingPEFiles(symbols, null, out orphanSymbols));
             }
         }
 


### PR DESCRIPTION
Fix the case when a symbol package has both symbols that pass validation and symbols that fail validation. 
The validation should fail in this case. 