### PR TITLE
[Revalidation] Improve throughput by batching revalidations

### DIFF
--- a/src/NuGet.Services.Revalidate/Configuration/RevalidationQueueConfiguration.cs
+++ b/src/NuGet.Services.Revalidate/Configuration/RevalidationQueueConfiguration.cs
@@ -8,19 +8,13 @@ namespace NuGet.Services.Revalidate
     public class RevalidationQueueConfiguration
     {
         /// <summary>
+        /// The maximum number of revalidations that should be returned by <see cref="IRevalidationQueue.NextAsync"/>.
+        /// </summary>
+        public int MaxBatchSize { get; set; } = 64;
+
+        /// <summary>
         /// If non-null, this skips revalidations of packages with more than this many versions.
         /// </summary>
         public int? MaximumPackageVersions { get; set; }
-
-        /// <summary>
-        /// The maximum times that the <see cref="RevalidationQueue"/> should look for a revalidation
-        /// before giving up.
-        /// </summary>
-        public int MaximumAttempts { get; set; } = 5;
-
-        /// <summary>
-        /// The time to sleep after an initialized revalidation is deemed completed.
-        /// </summary>
-        public TimeSpan SleepBetweenAttempts { get; set; } = TimeSpan.FromSeconds(5);
     }
 }

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -69,7 +69,7 @@
     <Compile Include="Initialization\PackageRevalidationInserter.cs" />
     <Compile Include="Services\RevalidationOperation.cs" />
     <Compile Include="Services\RevalidationQueue.cs" />
-    <Compile Include="Services\RevalidationResult.cs" />
+    <Compile Include="Services\StartRevalidationStatus.cs" />
     <Compile Include="Services\RevalidationService.cs" />
     <Compile Include="Services\RevalidationJobStateService.cs" />
     <Compile Include="Services\PackageRevalidationStateService.cs" />
@@ -82,6 +82,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="Services\StartRevalidationResult.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/NuGet.Services.Revalidate/Services/IPackageRevalidationStateService.cs
+++ b/src/NuGet.Services.Revalidate/Services/IPackageRevalidationStateService.cs
@@ -34,10 +34,10 @@ namespace NuGet.Services.Revalidate
         Task<int> CountRevalidationsEnqueuedInPastHourAsync();
 
         /// <summary>
-        /// Update the package revalidation and mark is as enqueued.
+        /// Update the package revalidations and mark them as enqueued.
         /// </summary>
-        /// <param name="revalidation">The revalidation to update.</param>
-        /// <returns>A task that completes once the revalidation has been updated.</returns>
-        Task MarkPackageRevalidationAsEnqueuedAsync(PackageRevalidation revalidation);
+        /// <param name="revalidations">The revalidations to update.</param>
+        /// <returns>A task that completes once the revalidations have been updated.</returns>
+        Task MarkPackageRevalidationsAsEnqueuedAsync(IReadOnlyList<PackageRevalidation> revalidations);
     }
 }

--- a/src/NuGet.Services.Revalidate/Services/IRevalidationQueue.cs
+++ b/src/NuGet.Services.Revalidate/Services/IRevalidationQueue.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.Services.Validation;
 
@@ -9,9 +10,9 @@ namespace NuGet.Services.Revalidate
     public interface IRevalidationQueue
     {
         /// <summary>
-        /// Fetch the next package to revalidate.
+        /// Fetch the next packages to revalidate.
         /// </summary>
-        /// <returns>The next package to revalidate, or null if there are no packages to revalidate at this time.</returns>
-        Task<PackageRevalidation> NextOrNullAsync();
+        /// <returns>The next packages to revalidate, or an empty list if there are no packages to revalidate at this time.</returns>
+        Task<IReadOnlyList<PackageRevalidation>> NextAsync();
     }
 }

--- a/src/NuGet.Services.Revalidate/Services/IRevalidationStarter.cs
+++ b/src/NuGet.Services.Revalidate/Services/IRevalidationStarter.cs
@@ -20,6 +20,6 @@ namespace NuGet.Services.Revalidate
         /// 4. A revalidation could not be found at this time
         /// </summary>
         /// <returns>The result of the revalidation attempt.</returns>
-        Task<RevalidationResult> StartNextRevalidationAsync();
+        Task<StartRevalidationResult> StartNextRevalidationsAsync();
     }
 }

--- a/src/NuGet.Services.Revalidate/Services/IRevalidationThrottler.cs
+++ b/src/NuGet.Services.Revalidate/Services/IRevalidationThrottler.cs
@@ -16,8 +16,9 @@ namespace NuGet.Services.Revalidate
         /// <summary>
         /// Delay the current task to achieve the desired revalidation rate.
         /// </summary>
+        /// <param name="started">The number of revalidations started.</param>
         /// <returns>Delay the task to ensure the desired revalidation rate.</returns>
-        Task DelayUntilNextRevalidationAsync();
+        Task DelayUntilNextRevalidationAsync(int started);
 
         /// <summary>
         /// Delay the current task until when a revalidation can be retried.

--- a/src/NuGet.Services.Revalidate/Services/IRevalidationThrottler.cs
+++ b/src/NuGet.Services.Revalidate/Services/IRevalidationThrottler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace NuGet.Services.Revalidate
@@ -17,8 +18,9 @@ namespace NuGet.Services.Revalidate
         /// Delay the current task to achieve the desired revalidation rate.
         /// </summary>
         /// <param name="started">The number of revalidations started.</param>
+        /// <param name="startDuration">How long it took it took to start the revalidations.</param>
         /// <returns>Delay the task to ensure the desired revalidation rate.</returns>
-        Task DelayUntilNextRevalidationAsync(int started);
+        Task DelayUntilNextRevalidationAsync(int started, TimeSpan startDuration);
 
         /// <summary>
         /// Delay the current task until when a revalidation can be retried.

--- a/src/NuGet.Services.Revalidate/Services/ITelemetryService.cs
+++ b/src/NuGet.Services.Revalidate/Services/ITelemetryService.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Services.Logging;
 
 namespace NuGet.Services.Revalidate
 {
     public interface ITelemetryService
     {
+        IDisposable TrackFindNextRevalidations();
+
         DurationMetric<StartNextRevalidationOperation> TrackStartNextRevalidationOperation();
 
         void TrackPackageRevalidationMarkedAsCompleted(string packageId, string normalizedVersion);

--- a/src/NuGet.Services.Revalidate/Services/PackageRevalidationStateService.cs
+++ b/src/NuGet.Services.Revalidate/Services/PackageRevalidationStateService.cs
@@ -71,9 +71,10 @@ namespace NuGet.Services.Revalidate
         {
             try
             {
+                var enqueueTime = DateTime.UtcNow;
                 foreach (var revalidation in revalidations)
                 {
-                    revalidation.Enqueued = DateTime.UtcNow;
+                    revalidation.Enqueued = enqueueTime;
                 }
 
                 await _context.SaveChangesAsync();

--- a/src/NuGet.Services.Revalidate/Services/PackageRevalidationStateService.cs
+++ b/src/NuGet.Services.Revalidate/Services/PackageRevalidationStateService.cs
@@ -67,21 +67,20 @@ namespace NuGet.Services.Revalidate
                 .CountAsync();
         }
 
-        public async Task MarkPackageRevalidationAsEnqueuedAsync(PackageRevalidation revalidation)
+        public async Task MarkPackageRevalidationsAsEnqueuedAsync(IReadOnlyList<PackageRevalidation> revalidations)
         {
             try
             {
-                revalidation.Enqueued = DateTime.UtcNow;
+                foreach (var revalidation in revalidations)
+                {
+                    revalidation.Enqueued = DateTime.UtcNow;
+                }
 
                 await _context.SaveChangesAsync();
             }
             catch (DbUpdateConcurrencyException)
             {
-                _logger.LogWarning(
-                    "Failed to update revalidation as enqueued for {PackageId} {PackageNormalizedVersion}",
-                    revalidation.PackageId,
-                    revalidation.PackageNormalizedVersion);
-
+                _logger.LogWarning("Failed to update revalidations as enqueued");
                 throw;
             }
         }

--- a/src/NuGet.Services.Revalidate/Services/RevalidationOperation.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationOperation.cs
@@ -6,8 +6,13 @@ namespace NuGet.Services.Revalidate
     public class StartNextRevalidationOperation
     {
         /// <summary>
-        /// The result of attempting to start the next revalidation.
+        /// The result of attempting to start the next revalidations.
         /// </summary>
-        public RevalidationResult Result { get; set; }
+        public StartRevalidationStatus Result { get; set; }
+
+        /// <summary>
+        /// The number of revalidations started.
+        /// </summary>
+        public int Started { get; set; }
     }
 }

--- a/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
@@ -73,7 +73,7 @@ namespace NuGet.Services.Revalidate
             return await FilterCompletedRevalidationsAsync(next);
         }
 
-        private async Task<List<PackageRevalidation>> FilterCompletedRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations)
+        private async Task<IReadOnlyList<PackageRevalidation>> FilterCompletedRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations)
         {
             var completed = new List<PackageRevalidation>();
             var uncompleted = revalidations.ToDictionary(
@@ -117,7 +117,7 @@ namespace NuGet.Services.Revalidate
                     p => p.Identity,
                     p => p.PackageStatusKey);
 
-            _logger.LogInformation("Found {RevalidationCount} revalidations' package statuses", packageStatuses.Count);
+            _logger.LogInformation("Found {PackageStatusCount} revalidations' package statuses", packageStatuses.Count);
 
             foreach (var key in uncompleted.Keys.ToList())
             {
@@ -129,6 +129,12 @@ namespace NuGet.Services.Revalidate
                     continue;
                 }
             }
+
+            _logger.LogInformation(
+                "Found {CompletedRevalidations} revalidations that can be skipped. There are {UncompletedRevalidations} " +
+                "revalidations remaining in this batch",
+                completed.Count,
+                uncompleted.Count);
 
             // Update revalidations that were determined to be completed and return the remaining revalidations.
             await MarkRevalidationsAsCompletedAsync(completed);
@@ -142,7 +148,7 @@ namespace NuGet.Services.Revalidate
                 foreach (var revalidation in revalidations)
                 {
                     _logger.LogInformation(
-                        "Marking package revalidation as completed as it has a repository signature or is deleted for {PackageId} {PackageNormalizedVersion}...",
+                        "Marking package {PackageId} {PackageNormalizedVersion} revalidation as completed as the package is unavailable or the package is already repository signed...",
                         revalidation.PackageId,
                         revalidation.PackageNormalizedVersion);
 
@@ -154,7 +160,7 @@ namespace NuGet.Services.Revalidate
                 foreach (var revalidation in revalidations)
                 {
                     _logger.LogInformation(
-                        "Marked package revalidation as completed as it has a repository signature or is deleted for {PackageId} {PackageNormalizedVersion}",
+                        "Marked package {PackageId} {PackageNormalizedVersion} revalidation as completed",
                         revalidation.PackageId,
                         revalidation.PackageNormalizedVersion);
 

--- a/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationQueue.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Linq;
@@ -37,106 +38,120 @@ namespace NuGet.Services.Revalidate
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<PackageRevalidation> NextOrNullAsync()
+        public async Task<IReadOnlyList<PackageRevalidation>> NextAsync()
         {
-            for (var i = 0; i < _config.MaximumAttempts; i++)
+            // Find the next package to revalidate. We will skip packages if:
+            //   1. The package has more than "MaximumPackageVersions" versions
+            //   2. The package has already been enqueued for revalidation
+            //   3. The package's revalidation was completed by an external factory (like manual admin revalidation)
+            IQueryable<PackageRevalidation> query = _validationContext.PackageRevalidations;
+
+            if (_config.MaximumPackageVersions.HasValue)
             {
-                _logger.LogInformation(
-                    "Attempting to find the next revalidation. Try {Attempt} of {MaxAttempts}",
-                    i + 1,
-                    _config.MaximumAttempts);
+                query = query.Where(
+                    r =>
+                    !_validationContext.PackageRevalidations.GroupBy(r2 => r2.PackageId)
+                    .Where(g => g.Count() > _config.MaximumPackageVersions)
+                    .Any(g => g.Key == r.PackageId));
+            }
 
-                // Find the next package to revalidate. We will skip packages if:
-                //   1. The package has more than "MaximumPackageVersions" versions
-                //   2. The package has already been enqueued for revalidation
-                //   3. The package's revalidation was completed by an external factory (like manual admin revalidation)
-                IQueryable<PackageRevalidation> query = _validationContext.PackageRevalidations;
+            var next = await query
+                .Where(r => r.Enqueued == null)
+                .Where(r => r.Completed == false)
+                .OrderBy(r => r.Key)
+                .Take(_config.MaxBatchSize)
+                .ToListAsync();
 
-                if (_config.MaximumPackageVersions.HasValue)
-                {
-                    query = query.Where(
-                        r =>
-                        !_validationContext.PackageRevalidations.GroupBy(r2 => r2.PackageId)
-                        .Where(g => g.Count() > _config.MaximumPackageVersions)
-                        .Any(g => g.Key == r.PackageId));
-                }
-
-                var next = await query
-                    .Where(r => r.Enqueued == null)
-                    .Where(r => r.Completed == false)
-                    .OrderBy(r => r.Key)
-                    .FirstOrDefaultAsync();
-
-                if (next == null)
-                {
-                    _logger.LogWarning("Could not find any incomplete revalidations");
-                    return null;
-                }
-
-                // Don't revalidate packages that already have a repository signature or that no longer exist.
-                if (await HasRepositorySignature(next) || await IsDeleted(next))
-                {
-                    await MarkAsCompleted(next);
-                    await Task.Delay(_config.SleepBetweenAttempts);
-
-                    continue;
-                }
-
-                _logger.LogInformation(
-                    "Found revalidation for {PackageId} {PackageNormalizedVersion} after {Attempt} attempts",
-                    next.PackageId,
-                    next.PackageNormalizedVersion,
-                    i + 1);
-
+            if (!next.Any())
+            {
+                _logger.LogWarning("Could not find any incomplete revalidations");
                 return next;
             }
 
-            _logger.LogInformation(
-                "Did not find any revalidations after {MaxAttempts}. Retry later...",
-                _config.MaximumAttempts);
-
-            return null;
+            // Return all the revalidations that aren't already completed.
+            return await FilterCompletedRevalidationsAsync(next);
         }
 
-        private Task<bool> HasRepositorySignature(PackageRevalidation revalidation)
+        private async Task<List<PackageRevalidation>> FilterCompletedRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations)
         {
-            return _validationContext.PackageSigningStates
-                .Where(s => s.PackageId == revalidation.PackageId)
-                .Where(s => s.PackageNormalizedVersion == revalidation.PackageNormalizedVersion)
+            // Split the list of revalidations by which ones have been completed.
+            var completed = new List<PackageRevalidation>();
+            var uncompleted = revalidations.ToDictionary(
+                r => Tuple.Create(r.PackageId, r.PackageNormalizedVersion),
+                r => r);
+
+            // Seperate out packages that already have a repository signature.
+            var hasRepositorySignatures = await _validationContext.PackageSigningStates
+                .Where(s => revalidations.Any(r => r.PackageId == s.PackageId && r.PackageNormalizedVersion == s.PackageNormalizedVersion))
                 .Where(s => s.PackageSignatures.Any(sig => sig.Type == PackageSignatureType.Repository))
-                .AnyAsync();
+                .Select(s => new { s.PackageId, s.PackageNormalizedVersion })
+                .ToListAsync();
+
+            foreach (var package in hasRepositorySignatures)
+            {
+                var key = Tuple.Create(package.PackageId, package.PackageNormalizedVersion);
+
+                completed.Add(uncompleted[key]);
+                uncompleted.Remove(key);
+            }
+
+            // Separate out packages that are no longer available. We consider that a revalidation
+            // is "completed" if a package no longer exists.
+            var packageStatuses = await _galleryContext.Set<Package>()
+                .Where(p => uncompleted.Any(r => r.Key.Item1 == p.PackageRegistration.Id && r.Key.Item2 == p.NormalizedVersion))
+                .ToDictionaryAsync(
+                    p => Tuple.Create(p.PackageRegistration.Id, p.NormalizedVersion),
+                    p => p.PackageStatusKey);
+
+            foreach (var key in uncompleted.Keys.ToList())
+            {
+                // Packages that are hard deleted won't have a status.
+                if (!packageStatuses.TryGetValue(key, out var status) || status == PackageStatus.Deleted)
+                {
+                    completed.Add(uncompleted[key]);
+                    uncompleted.Remove(key);
+                    continue;
+                }
+            }
+
+            // Update revalidations that were determined to be completed and return the remaining revalidations.
+            await MarkRevalidationsAsCompletedAsync(completed);
+            return uncompleted.Values.ToList();
         }
 
-        private async Task<bool> IsDeleted(PackageRevalidation revalidation)
+        private async Task MarkRevalidationsAsCompletedAsync(IReadOnlyList<PackageRevalidation> revalidations)
         {
-            var packageStatus = await _galleryContext.Set<Package>()
-                .Where(p => p.PackageRegistration.Id == revalidation.PackageId)
-                .Where(p => p.NormalizedVersion == revalidation.PackageNormalizedVersion)
-                .Select(p => (PackageStatus?)p.PackageStatusKey)
-                .FirstOrDefaultAsync();
-
-            return (packageStatus == null || packageStatus == PackageStatus.Deleted);
-        }
-
-        private async Task MarkAsCompleted(PackageRevalidation revalidation)
-        {
-            _logger.LogInformation(
-                "Marking package revalidation as completed as it has a repository signature or is deleted for {PackageId} {PackageNormalizedVersion}",
-                revalidation.PackageId,
-                revalidation.PackageNormalizedVersion);
-
             try
             {
-                revalidation.Completed = true;
+                foreach (var revalidation in revalidations)
+                {
+                    _logger.LogInformation(
+                        "Marking package revalidation as completed as it has a repository signature or is deleted for {PackageId} {PackageNormalizedVersion}...",
+                        revalidation.PackageId,
+                        revalidation.PackageNormalizedVersion);
+
+                    revalidation.Completed = true;
+                }
 
                 await _validationContext.SaveChangesAsync();
 
-                _telemetry.TrackPackageRevalidationMarkedAsCompleted(revalidation.PackageId, revalidation.PackageNormalizedVersion);
+                foreach (var revalidation in revalidations)
+                {
+                    _logger.LogInformation(
+                        "Marked package revalidation as completed as it has a repository signature or is deleted for {PackageId} {PackageNormalizedVersion}",
+                        revalidation.PackageId,
+                        revalidation.PackageNormalizedVersion);
+
+                    _telemetry.TrackPackageRevalidationMarkedAsCompleted(revalidation.PackageId, revalidation.PackageNormalizedVersion);
+                }
             }
-            catch (DbUpdateConcurrencyException)
+            catch (DbUpdateConcurrencyException e)
             {
-                // Swallow concurrency exceptions. The package will be marked as completed
-                // on the next iteration of "NextOrNullAsync".
+                _logger.LogError(
+                    0,
+                    e,
+                    "Failed to mark package revalidations as completed. " +
+                    $"These revalidations will be marked as completed on the next iteration of {nameof(NextAsync)}...");
             }
         }
     }

--- a/src/NuGet.Services.Revalidate/Services/RevalidationService.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationService.cs
@@ -49,14 +49,19 @@ namespace NuGet.Services.Revalidate
             {
                 _logger.LogInformation("Starting next revalidation...");
 
+                var startRevalidationsStopwatch = Stopwatch.StartNew();
                 var result = await StartNextRevalidationsAsync();
+                startRevalidationsStopwatch.Stop();
 
                 switch (result.Status)
                 {
                     case StartRevalidationStatus.RevalidationsEnqueued:
-                        _logger.LogInformation("Successfully enqueued revalidations");
+                        _logger.LogInformation(
+                            "Successfully enqueued {RevalidationsStarted} revalidations in {Duration}",
+                            result.RevalidationsStarted,
+                            startRevalidationsStopwatch.Elapsed);
 
-                        await _throttler.DelayUntilNextRevalidationAsync(result.RevalidationsStarted);
+                        await _throttler.DelayUntilNextRevalidationAsync(result.RevalidationsStarted, startRevalidationsStopwatch.Elapsed);
                         break;
 
                     case StartRevalidationStatus.RetryLater:

--- a/src/NuGet.Services.Revalidate/Services/RevalidationService.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationService.cs
@@ -49,23 +49,23 @@ namespace NuGet.Services.Revalidate
             {
                 _logger.LogInformation("Starting next revalidation...");
 
-                var result = await StartNextRevalidationAsync();
+                var result = await StartNextRevalidationsAsync();
 
-                switch (result)
+                switch (result.Status)
                 {
-                    case RevalidationResult.RevalidationEnqueued:
-                        _logger.LogInformation("Successfully enqueued revalidation");
+                    case StartRevalidationStatus.RevalidationsEnqueued:
+                        _logger.LogInformation("Successfully enqueued revalidations");
 
-                        await _throttler.DelayUntilNextRevalidationAsync();
+                        await _throttler.DelayUntilNextRevalidationAsync(result.RevalidationsStarted);
                         break;
 
-                    case RevalidationResult.RetryLater:
+                    case StartRevalidationStatus.RetryLater:
                         _logger.LogInformation("Could not start revalidation, retrying later");
 
                         await _throttler.DelayUntilRevalidationRetryAsync();
                         break;
 
-                    case RevalidationResult.UnrecoverableError:
+                    case StartRevalidationStatus.UnrecoverableError:
                     default:
                         _logger.LogCritical(
                             "Stopping revalidations due to unrecoverable or unknown result {Result}",
@@ -79,15 +79,16 @@ namespace NuGet.Services.Revalidate
             _logger.LogInformation("Finished running after {ElapsedTime}", runTime.Elapsed);
         }
 
-        private async Task<RevalidationResult> StartNextRevalidationAsync()
+        private async Task<StartRevalidationResult> StartNextRevalidationsAsync()
         {
             using (var operation = _telemetryService.TrackStartNextRevalidationOperation())
             using (var scope = _scopeFactory.CreateScope())
             {
                 var starter = scope.ServiceProvider.GetRequiredService<IRevalidationStarter>();
-                var result = await starter.StartNextRevalidationAsync();
+                var result = await starter.StartNextRevalidationsAsync();
 
-                operation.Properties.Result = result;
+                operation.Properties.Result = result.Status;
+                operation.Properties.Started = result.RevalidationsStarted;
 
                 return result;
             }

--- a/src/NuGet.Services.Revalidate/Services/RevalidationStarter.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationStarter.cs
@@ -136,6 +136,11 @@ namespace NuGet.Services.Revalidate
 
             foreach (var revalidation in revalidations)
             {
+                _logger.LogInformation(
+                    "Starting revalidation for package {PackageId} {PackageVersion}...",
+                    revalidation.PackageId,
+                    revalidation.PackageNormalizedVersion);
+
                 var message = new PackageValidationMessageData(
                     revalidation.PackageId,
                     revalidation.PackageNormalizedVersion,
@@ -144,6 +149,10 @@ namespace NuGet.Services.Revalidate
                 await _validationEnqueuer.StartValidationAsync(message);
 
                 _telemetryService.TrackPackageRevalidationStarted(revalidation.PackageId, revalidation.PackageNormalizedVersion);
+                _logger.LogInformation(
+                    "Started revalidation for package {PackageId} {PackageVersion}",
+                    revalidation.PackageId,
+                    revalidation.PackageNormalizedVersion);
             }
 
             _logger.LogInformation("Started {RevalidationCount} revalidations, marking them as enqueued...", revalidations.Count);

--- a/src/NuGet.Services.Revalidate/Services/RevalidationStarter.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationStarter.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Validation;
@@ -39,7 +41,7 @@ namespace NuGet.Services.Revalidate
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<RevalidationResult> StartNextRevalidationAsync()
+        public async Task<StartRevalidationResult> StartNextRevalidationsAsync()
         {
             try
             {
@@ -52,51 +54,61 @@ namespace NuGet.Services.Revalidate
                         "Detected that a revalidation should not be started due to result {Result}",
                         checkResult.Value);
 
-                    return checkResult.Value;
+                    switch (checkResult.Value)
+                    {
+                        case StartRevalidationStatus.RetryLater:
+                            return StartRevalidationResult.RetryLater;
+
+                        case StartRevalidationStatus.UnrecoverableError:
+                            return StartRevalidationResult.UnrecoverableError;
+
+                        default:
+                            throw new InvalidOperationException($"Unexpected status {checkResult.Value} from {nameof(CanStartRevalidationAsync)}");
+                    }
                 }
 
-                // Everything is in tip-top shape! Increase the throttling quota and start the next revalidation.
+                // Everything is in tip-top shape! Increase the throttling quota and start the next revalidations.
                 await _jobState.IncreaseDesiredPackageEventRateAsync();
 
-                var revalidation = await _revalidationQueue.NextOrNullAsync();
-                if (revalidation == null)
+                var revalidations = await _revalidationQueue.NextAsync();
+                if (!revalidations.Any())
                 {
-                    _logger.LogInformation("Could not find a package to revalidate at this time, retry later...");
+                    _logger.LogInformation("Could not find packages to revalidate at this time, retry later...");
 
-                    return RevalidationResult.RetryLater;
+                    return StartRevalidationResult.RetryLater;
                 }
 
-                return await StartRevalidationAsync(revalidation);
+                return await StartRevalidationsAsync(revalidations);
             }
             catch (Exception e)
             {
                 _logger.LogError(0, e, "Failed to start next validation due to exception, retry later...");
 
-                return RevalidationResult.RetryLater;
+                return StartRevalidationResult.RetryLater;
             }
         }
 
-        private async Task<RevalidationResult?> CanStartRevalidationAsync()
+        private async Task<StartRevalidationStatus?> CanStartRevalidationAsync()
         {
             if (!await _singletonService.IsSingletonAsync())
             {
                 _logger.LogCritical("Detected another instance of the revalidate job, cancelling revalidations!");
 
-                return RevalidationResult.UnrecoverableError;
+                return StartRevalidationStatus.UnrecoverableError;
             }
 
             if (await _jobState.IsKillswitchActiveAsync())
             {
                 _logger.LogWarning("Revalidation killswitch has been activated, retry later...");
 
-                return RevalidationResult.RetryLater;
+                return StartRevalidationStatus.RetryLater;
             }
 
             if (await _throttler.IsThrottledAsync())
             {
                 _logger.LogInformation("Revalidations have reached the desired event rate, retry later...");
 
-                return RevalidationResult.RetryLater;
+                return StartRevalidationStatus.RetryLater;
             }
 
             if (!await _healthService.IsHealthyAsync())
@@ -105,32 +117,42 @@ namespace NuGet.Services.Revalidate
 
                 await _jobState.ResetDesiredPackageEventRateAsync();
 
-                return RevalidationResult.RetryLater;
+                return StartRevalidationStatus.RetryLater;
             }
 
             if (await _jobState.IsKillswitchActiveAsync())
             {
                 _logger.LogWarning("Revalidation killswitch has been activated after the throttle and health check, retry later...");
 
-                return RevalidationResult.RetryLater;
+                return StartRevalidationStatus.RetryLater;
             }
 
             return null;
         }
 
-        private async Task<RevalidationResult> StartRevalidationAsync(PackageRevalidation revalidation)
+        private async Task<StartRevalidationResult> StartRevalidationsAsync(IReadOnlyList<PackageRevalidation> revalidations)
         {
-            var message = new PackageValidationMessageData(
-                revalidation.PackageId,
-                revalidation.PackageNormalizedVersion,
-                revalidation.ValidationTrackingId.Value);
+            _logger.LogInformation("Starting {RevalidationCount} revalidations...", revalidations.Count);
 
-            await _validationEnqueuer.StartValidationAsync(message);
-            await _packageState.MarkPackageRevalidationAsEnqueuedAsync(revalidation);
+            foreach (var revalidation in revalidations)
+            {
+                var message = new PackageValidationMessageData(
+                    revalidation.PackageId,
+                    revalidation.PackageNormalizedVersion,
+                    revalidation.ValidationTrackingId.Value);
 
-            _telemetryService.TrackPackageRevalidationStarted(revalidation.PackageId, revalidation.PackageNormalizedVersion);
+                await _validationEnqueuer.StartValidationAsync(message);
 
-            return RevalidationResult.RevalidationEnqueued;
+                _telemetryService.TrackPackageRevalidationStarted(revalidation.PackageId, revalidation.PackageNormalizedVersion);
+            }
+
+            _logger.LogInformation("Started {RevalidationCount} revalidations, marking them as enqueued...", revalidations.Count);
+
+            await _packageState.MarkPackageRevalidationsAsEnqueuedAsync(revalidations);
+
+            _logger.LogInformation("Marked {RevalidationCount} revalidations as enqueued", revalidations.Count);
+
+            return StartRevalidationResult.RevalidationsEnqueued(revalidations.Count);
         }
     }
 }

--- a/src/NuGet.Services.Revalidate/Services/RevalidationThrottler.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationThrottler.cs
@@ -59,10 +59,10 @@ namespace NuGet.Services.Revalidate
             }
         }
 
-        public async Task DelayUntilNextRevalidationAsync()
+        public async Task DelayUntilNextRevalidationAsync(int revalidationsStarted)
         {
             var desiredHourlyRate = await _jobState.GetDesiredPackageEventRateAsync();
-            var sleepDuration = TimeSpan.FromHours(1.0 / desiredHourlyRate);
+            var sleepDuration = TimeSpan.FromHours((float)revalidationsStarted / desiredHourlyRate);
 
             _logger.LogInformation("Delaying until next revalidation by sleeping for {SleepDuration}...", sleepDuration);
 

--- a/src/NuGet.Services.Revalidate/Services/RevalidationThrottler.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationThrottler.cs
@@ -9,6 +9,8 @@ namespace NuGet.Services.Revalidate
 {
     public class RevalidationThrottler : IRevalidationThrottler
     {
+        private static readonly TimeSpan MinimumDelayUntilNextRevalidations = TimeSpan.FromSeconds(5);
+
         private readonly IRevalidationJobStateService _jobState;
         private readonly IPackageRevalidationStateService _packageState;
         private readonly IGalleryService _gallery;
@@ -59,10 +61,20 @@ namespace NuGet.Services.Revalidate
             }
         }
 
-        public async Task DelayUntilNextRevalidationAsync(int revalidationsStarted)
+        public async Task DelayUntilNextRevalidationAsync(int revalidationsStarted, TimeSpan startDuration)
         {
             var desiredHourlyRate = await _jobState.GetDesiredPackageEventRateAsync();
-            var sleepDuration = TimeSpan.FromHours((float)revalidationsStarted / desiredHourlyRate);
+
+            // Calculate the time to sleep. If this batch started 50 revalidations in 30 seconds and we would like
+            // to achieve 1,000 revalidations per hour, we should sleep for 2.5 minutes:
+            //
+            // (50/1000) * 60 - (30/60) = 2.5
+            var sleepDuration = TimeSpan.FromHours((float)revalidationsStarted / desiredHourlyRate) - startDuration;
+            if (sleepDuration < MinimumDelayUntilNextRevalidations)
+            {
+                _logger.LogWarning($"The delay until next revalidation is too small, overriding it to {MinimumDelayUntilNextRevalidations}!");
+                sleepDuration = MinimumDelayUntilNextRevalidations;
+            }
 
             _logger.LogInformation("Delaying until next revalidation by sleeping for {SleepDuration}...", sleepDuration);
 

--- a/src/NuGet.Services.Revalidate/Services/StartRevalidationResult.cs
+++ b/src/NuGet.Services.Revalidate/Services/StartRevalidationResult.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Services.Revalidate
+{
+    /// <summary>
+    /// The result of <see cref="IRevalidationStarter.StartNextRevalidationsAsync"/>.
+    /// </summary>
+    public class StartRevalidationResult
+    {
+        /// <summary>
+        /// A revalidation could not be enqueued at this time. The revalidations should be retried later.
+        /// </summary>
+        public static readonly StartRevalidationResult RetryLater = new StartRevalidationResult(StartRevalidationStatus.RetryLater);
+
+        /// <summary>
+        /// This instance of the revalidation job has reached an unrecoverable state and MUST stop.
+        /// </summary>
+        public static readonly StartRevalidationResult UnrecoverableError = new StartRevalidationResult(StartRevalidationStatus.UnrecoverableError);
+
+        private StartRevalidationResult(StartRevalidationStatus status, int revalidationsStarted = 0)
+        {
+            if (revalidationsStarted < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(revalidationsStarted));
+            }
+
+            Status = status;
+            RevalidationsStarted = revalidationsStarted;
+        }
+
+        /// <summary>
+        /// Constructs a result that indicates one or more revalidations were successfully enqueued.
+        /// </summary>
+        /// <param name="revalidationsStarted">The number of revalidations that were enqueued.</param>
+        /// <returns>The constructed revalidation result.</returns>
+        public static StartRevalidationResult RevalidationsEnqueued(int revalidationsStarted)
+        {
+            return new StartRevalidationResult(StartRevalidationStatus.RevalidationsEnqueued, revalidationsStarted);
+        }
+
+        /// <summary>
+        /// The status of starting revalidations.
+        /// </summary>
+        public StartRevalidationStatus Status { get; }
+
+        /// <summary>
+        /// The number of revalidations that were started.
+        /// </summary>
+        public int RevalidationsStarted { get; }
+    }
+}

--- a/src/NuGet.Services.Revalidate/Services/StartRevalidationStatus.cs
+++ b/src/NuGet.Services.Revalidate/Services/StartRevalidationStatus.cs
@@ -4,17 +4,17 @@
 namespace NuGet.Services.Revalidate
 {
     /// <summary>
-    /// The result from <see cref="IRevalidationService.StartNextRevalidationAsync"/>
+    /// The result from <see cref="IRevalidationStarter.StartNextRevalidationsAsync"/>
     /// </summary>
-    public enum RevalidationResult
+    public enum StartRevalidationStatus
     {
         /// <summary>
-        /// A revalidation was successfully enqueued.
+        /// One or more revalidations were successfully enqueued.
         /// </summary>
-        RevalidationEnqueued,
+        RevalidationsEnqueued,
 
         /// <summary>
-        /// A revalidation could not be enqueued at this time. The revalidation should be retried later.
+        /// A revalidation could not be enqueued at this time. The revalidations should be retried later.
         /// </summary>
         RetryLater,
 

--- a/src/NuGet.Services.Revalidate/Services/TelemetryService.cs
+++ b/src/NuGet.Services.Revalidate/Services/TelemetryService.cs
@@ -11,6 +11,7 @@ namespace NuGet.Services.Revalidate
     {
         private const string RevalidationPrefix = "Revalidation.";
 
+        private const string DurationToFindRevalidations = RevalidationPrefix + "DurationToFindRevalidationsSeconds";
         private const string DurationToStartNextRevalidation = RevalidationPrefix + "DurationToStartNextRevalidationSeconds";
         private const string PackageRevalidationMarkedAsCompleted = RevalidationPrefix + "PackageRevalidationMarkedAsCompleted";
         private const string PackageRevalidationStarted = RevalidationPrefix + "PackageRevalidationStarted";
@@ -24,6 +25,11 @@ namespace NuGet.Services.Revalidate
         public TelemetryService(ITelemetryClient client)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
+        }
+
+        public IDisposable TrackFindNextRevalidations()
+        {
+            return _client.TrackDuration(DurationToFindRevalidations);
         }
 
         public DurationMetric<StartNextRevalidationOperation> TrackStartNextRevalidationOperation()

--- a/src/NuGet.Services.Revalidate/Settings/dev.json
+++ b/src/NuGet.Services.Revalidate/Settings/dev.json
@@ -27,9 +27,8 @@
     },
 
     "Queue": {
-      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions},
-      "MaximumAttempts": 5,
-      "SleepBetweenAttempts": "00:00:30"
+      "MaxBatchSize": #{Jobs.nuget.services.revalidate.MaxBatchSize},
+      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions}
     }
   },
 

--- a/src/NuGet.Services.Revalidate/Settings/int.json
+++ b/src/NuGet.Services.Revalidate/Settings/int.json
@@ -27,9 +27,8 @@
     },
 
     "Queue": {
-      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions},
-      "MaximumAttempts": 5,
-      "SleepBetweenAttempts": "00:00:30"
+      "MaxBatchSize": #{Jobs.nuget.services.revalidate.MaxBatchSize},
+      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions}
     }
   },
 

--- a/src/NuGet.Services.Revalidate/Settings/prod.json
+++ b/src/NuGet.Services.Revalidate/Settings/prod.json
@@ -27,9 +27,8 @@
     },
 
     "Queue": {
-      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions},
-      "MaximumAttempts": 5,
-      "SleepBetweenAttempts": "00:00:30"
+      "MaxBatchSize": #{Jobs.nuget.services.revalidate.MaxBatchSize},
+      "MaximumPackageVersions": #{Jobs.nuget.services.revalidate.MaximumPackageVersions}
     }
   },
 

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -157,13 +157,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.29.0</Version>
+      <Version>2.33.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.29.0</Version>
+      <Version>2.33.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.29.0</Version>
+      <Version>2.33.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.2.0</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.27.0</Version>
+      <Version>2.33.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/tests/NuGet.Services.Revalidate.Tests/Services/RevalidationServiceFacts.cs
+++ b/tests/NuGet.Services.Revalidate.Tests/Services/RevalidationServiceFacts.cs
@@ -98,7 +98,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
 
                 _telemetryService.Verify(t => t.TrackStartNextRevalidationOperation(), Times.Once);
                 _scopeFactory.Verify(f => f.CreateScope(), Times.Once);
-                _throttler.Verify(t => t.DelayUntilNextRevalidationAsync(123), Times.Once);
+                _throttler.Verify(t => t.DelayUntilNextRevalidationAsync(123, It.IsAny<TimeSpan>()), Times.Once);
 
                 Assert.Equal(StartRevalidationStatus.RevalidationsEnqueued, _operation.Properties.Result);
             }

--- a/tests/NuGet.Services.Revalidate.Tests/Services/RevalidationServiceFacts.cs
+++ b/tests/NuGet.Services.Revalidate.Tests/Services/RevalidationServiceFacts.cs
@@ -46,8 +46,8 @@ namespace NuGet.Services.Revalidate.Tests.Services
                     .ReturnsAsync(true);
 
                 _starter
-                    .Setup(s => s.StartNextRevalidationAsync())
-                    .ReturnsAsync(RevalidationResult.UnrecoverableError);
+                    .Setup(s => s.StartNextRevalidationsAsync())
+                    .ReturnsAsync(StartRevalidationResult.UnrecoverableError);
 
                 // Act
                 await _target.RunAsync();
@@ -56,7 +56,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
                 _telemetryService.Verify(t => t.TrackStartNextRevalidationOperation(), Times.Once);
                 _scopeFactory.Verify(f => f.CreateScope(), Times.Once);
 
-                Assert.Equal(RevalidationResult.UnrecoverableError, _operation.Properties.Result);
+                Assert.Equal(StartRevalidationStatus.UnrecoverableError, _operation.Properties.Result);
             }
 
             [Fact]
@@ -68,8 +68,8 @@ namespace NuGet.Services.Revalidate.Tests.Services
                     .ReturnsAsync(true);
 
                 _starter
-                    .Setup(s => s.StartNextRevalidationAsync())
-                    .ReturnsAsync(RevalidationResult.RetryLater);
+                    .Setup(s => s.StartNextRevalidationsAsync())
+                    .ReturnsAsync(StartRevalidationResult.RetryLater);
 
                 // Act & Assert
                 await _target.RunAsync();
@@ -78,7 +78,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
                 _scopeFactory.Verify(f => f.CreateScope(), Times.Once);
                 _throttler.Verify(t => t.DelayUntilRevalidationRetryAsync(), Times.Once);
 
-                Assert.Equal(RevalidationResult.RetryLater, _operation.Properties.Result);
+                Assert.Equal(StartRevalidationStatus.RetryLater, _operation.Properties.Result);
             }
 
             [Fact]
@@ -90,17 +90,17 @@ namespace NuGet.Services.Revalidate.Tests.Services
                     .ReturnsAsync(true);
 
                 _starter
-                    .Setup(s => s.StartNextRevalidationAsync())
-                    .ReturnsAsync(RevalidationResult.RevalidationEnqueued);
+                    .Setup(s => s.StartNextRevalidationsAsync())
+                    .ReturnsAsync(StartRevalidationResult.RevalidationsEnqueued(123));
 
                 // Act & Assert
                 await _target.RunAsync();
 
                 _telemetryService.Verify(t => t.TrackStartNextRevalidationOperation(), Times.Once);
                 _scopeFactory.Verify(f => f.CreateScope(), Times.Once);
-                _throttler.Verify(t => t.DelayUntilNextRevalidationAsync(), Times.Once);
+                _throttler.Verify(t => t.DelayUntilNextRevalidationAsync(123), Times.Once);
 
-                Assert.Equal(RevalidationResult.RevalidationEnqueued, _operation.Properties.Result);
+                Assert.Equal(StartRevalidationStatus.RevalidationsEnqueued, _operation.Properties.Result);
             }
         }
 
@@ -178,27 +178,6 @@ namespace NuGet.Services.Revalidate.Tests.Services
                 var exception = new Exception();
 
                 if (initializedThrows) _jobState.Setup(s => s.IsInitializedAsync()).ThrowsAsync(exception);
-            }
-
-            protected void SetupUnrecoverableErrorResult()
-            {
-                _starter
-                    .Setup(s => s.StartNextRevalidationAsync())
-                    .ReturnsAsync(RevalidationResult.UnrecoverableError);
-            }
-
-            protected void SetupRetryLaterResult()
-            {
-                _starter
-                    .Setup(s => s.StartNextRevalidationAsync())
-                    .ReturnsAsync(RevalidationResult.RetryLater);
-            }
-
-            protected void SetupRevalidationEnqueuedResult()
-            {
-                _starter
-                    .Setup(s => s.StartNextRevalidationAsync())
-                    .ReturnsAsync(RevalidationResult.RevalidationEnqueued);
             }
         }
     }


### PR DESCRIPTION
Increase the throughput of the revalidation job by batching revalidations. The revalidation job does a bunch of work before enqueueing revalidations as it must:

1. Ensure the revalidation job hasn't been killswitched
2. Verify that the ingestion pipeline is healthy
3. Verify that the desired package event rate hasn't been reached

This change amortizes that work by enqueueing revalidations in batches. Also, the job now takes into account how long it spent enqueueing revalidations when deciding how long to sleep for.

Addresses https://github.com/NuGet/Engineering/issues/1877