### PR TITLE
Quickfix for ValidateCertificate job issue

### DIFF
--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -99,6 +99,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Services.ServiceBus">
+      <Version>2.33.0</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
       <Version>2.33.0</Version>
     </PackageReference>

--- a/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
+++ b/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
@@ -92,6 +92,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Services.ServiceBus">
+      <Version>2.33.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Scripts\nssm.exe" />
@@ -106,7 +109,7 @@
   <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <ItemGroup>
-    <PowerShellScriptsToSign Include="RunE2ETests.ps1"/>
+    <PowerShellScriptsToSign Include="RunE2ETests.ps1" />
   </ItemGroup>
   <Import Project="$(SignPath)\sign.scripts.targets" Condition="Exists('$(SignPath)\sign.scripts.targets')" />
   <Import Project="..\..\sign.thirdparty.targets" />

--- a/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
+++ b/src/Validation.PackageSigning.ValidateCertificate/Validation.PackageSigning.ValidateCertificate.csproj
@@ -92,9 +92,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.33.0</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Scripts\nssm.exe" />


### PR DESCRIPTION
Added explicit reference to `NuGet.Services.ServiceBus` v2.33, because without it it was using 2.31 which cause it to fail to receive messages because `BrokeredMessageWrapper` from `NuGet.Services.Service` v2.31 was not implementing some properties that exist in `IBrokeredMessageWrapper` from `NuGet.Services.Contracts` v2.33.
