### PR TITLE
Hotfix: revert dependency cleanup from #612

### DIFF
--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -99,7 +99,19 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Packaging">
+      <Version>5.0.0-preview1.5665</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.ServiceBus">
+      <Version>2.33.0</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
+      <Version>2.33.0</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation">
+      <Version>2.33.0</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.Validation.Issues">
       <Version>2.33.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">


### PR DESCRIPTION
Fix regression from #612, by reverting cleanup that caused downgrades in dependency versions. Applying as hotfix in master, as this blocks SQL AAD / Async Email deployments planned for this week.

Note that #668 addressed the `NuGet.Services.ServiceBus` regression, but did not include the other dependencies (`Validation`, `Validation.Issues`) which also downgraded.

Original exception from AI:
```
"Job Failed to Run": "System.TypeLoadException: Method 'get_MessageId'
  in type 'NuGet.Services.ServiceBus.BrokeredMessageWrapper'
  from assembly 'NuGet.Services.ServiceBus, Version=2.31.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
  does not have an implementation.
```

Also added back `NuGet.Packaging`, which is used directly by ProcessSignature. However, I had to bump the version up to match the new Gallery.Core dependency.