### PR TITLE
StatusAggregator should handle incident ingestion failures gracefully

### DIFF
--- a/src/StatusAggregator/Export/IStatusSerializer.cs
+++ b/src/StatusAggregator/Export/IStatusSerializer.cs
@@ -13,6 +13,6 @@ namespace StatusAggregator.Export
         /// <summary>
         /// Serializes <paramref name="rootComponent"/> and <paramref name="recentEvents"/> and saves to storage with a time of <paramref name="lastUpdated"/>.
         /// </summary>
-        Task Serialize(DateTime lastUpdated, IComponent rootComponent, IEnumerable<Event> recentEvents);
+        Task Serialize(DateTime lastBuilt, DateTime lastUpdated, IComponent rootComponent, IEnumerable<Event> recentEvents);
     }
 }

--- a/src/StatusAggregator/Export/IStatusSerializer.cs
+++ b/src/StatusAggregator/Export/IStatusSerializer.cs
@@ -11,8 +11,8 @@ namespace StatusAggregator.Export
     public interface IStatusSerializer
     {
         /// <summary>
-        /// Serializes <paramref name="rootComponent"/> and <paramref name="recentEvents"/> and saves to storage with a time of <paramref name="cursor"/>.
+        /// Serializes <paramref name="rootComponent"/> and <paramref name="recentEvents"/> and saves to storage with a time of <paramref name="lastUpdated"/>.
         /// </summary>
-        Task Serialize(DateTime cursor, IComponent rootComponent, IEnumerable<Event> recentEvents);
+        Task Serialize(DateTime lastUpdated, IComponent rootComponent, IEnumerable<Event> recentEvents);
     }
 }

--- a/src/StatusAggregator/Export/StatusExporter.cs
+++ b/src/StatusAggregator/Export/StatusExporter.cs
@@ -41,7 +41,7 @@ namespace StatusAggregator.Export
                 var recentEvents = _eventExporter.Export(cursor);
 
                 var lastUpdated = await _cursor.Get(StatusUpdater.LastUpdatedCursorName);
-                await _serializer.Serialize(lastUpdated, rootComponent, recentEvents);
+                await _serializer.Serialize(cursor, lastUpdated, rootComponent, recentEvents);
             }
         }
     }

--- a/src/StatusAggregator/Export/StatusExporter.cs
+++ b/src/StatusAggregator/Export/StatusExporter.cs
@@ -5,11 +5,14 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NuGet.Jobs.Extensions;
+using StatusAggregator.Collector;
+using StatusAggregator.Update;
 
 namespace StatusAggregator.Export
 {
     public class StatusExporter : IStatusExporter
     {
+        private readonly ICursor _cursor;
         private readonly IComponentExporter _componentExporter;
         private readonly IEventsExporter _eventExporter;
         private readonly IStatusSerializer _serializer;
@@ -17,24 +20,28 @@ namespace StatusAggregator.Export
         private readonly ILogger<StatusExporter> _logger;
 
         public StatusExporter(
+            ICursor cursor,
             IComponentExporter componentExporter,
             IEventsExporter eventExporter,
             IStatusSerializer serializer,
             ILogger<StatusExporter> logger)
         {
+            _cursor = cursor ?? throw new ArgumentNullException(nameof(cursor));
             _componentExporter = componentExporter ?? throw new ArgumentNullException(nameof(componentExporter));
             _eventExporter = eventExporter ?? throw new ArgumentNullException(nameof(eventExporter));
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public Task Export(DateTime cursor)
+        public async Task Export(DateTime cursor)
         {
             using (_logger.Scope("Exporting service status."))
             {
                 var rootComponent = _componentExporter.Export();
                 var recentEvents = _eventExporter.Export(cursor);
-                return _serializer.Serialize(cursor, rootComponent, recentEvents);
+
+                var lastUpdated = await _cursor.Get(StatusUpdater.LastUpdatedCursorName);
+                await _serializer.Serialize(lastUpdated, rootComponent, recentEvents);
             }
         }
     }

--- a/src/StatusAggregator/Export/StatusSerializer.cs
+++ b/src/StatusAggregator/Export/StatusSerializer.cs
@@ -36,13 +36,13 @@ namespace StatusAggregator.Export
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task Serialize(DateTime cursor, IComponent rootComponent, IEnumerable<Event> recentEvents)
+        public async Task Serialize(DateTime lastUpdated, IComponent rootComponent, IEnumerable<Event> recentEvents)
         {
             ServiceStatus status;
             string statusJson;
             using (_logger.Scope("Serializing service status."))
             {
-                status = new ServiceStatus(cursor, rootComponent, recentEvents);
+                status = new ServiceStatus(lastUpdated, rootComponent, recentEvents);
                 statusJson = JsonConvert.SerializeObject(status, Settings);
             }
 

--- a/src/StatusAggregator/Export/StatusSerializer.cs
+++ b/src/StatusAggregator/Export/StatusSerializer.cs
@@ -36,13 +36,13 @@ namespace StatusAggregator.Export
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task Serialize(DateTime lastUpdated, IComponent rootComponent, IEnumerable<Event> recentEvents)
+        public async Task Serialize(DateTime lastBuilt, DateTime lastUpdated, IComponent rootComponent, IEnumerable<Event> recentEvents)
         {
             ServiceStatus status;
             string statusJson;
             using (_logger.Scope("Serializing service status."))
             {
-                status = new ServiceStatus(lastUpdated, rootComponent, recentEvents);
+                status = new ServiceStatus(lastBuilt, lastUpdated, rootComponent, recentEvents);
                 statusJson = JsonConvert.SerializeObject(status, Settings);
             }
 

--- a/src/StatusAggregator/LogEvents.cs
+++ b/src/StatusAggregator/LogEvents.cs
@@ -6,5 +6,6 @@ namespace StatusAggregator
     {
         public static EventId RegexFailure = new EventId(400, "Failed to parse incident using Regex.");
         public static EventId ManualChangeFailure = new EventId(401, "Failed to apply a manual change.");
+        public static EventId IncidentIngestionFailure = new EventId(402, "Failed to update incident API data.");
     }
 }

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -160,10 +160,10 @@
       <Version>2.29.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.29.0</Version>
+      <Version>2.37.0-sb-statusfb-2205681</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.29.0</Version>
+      <Version>2.37.0-sb-statusfb-2205681</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.2.0</Version>

--- a/src/StatusAggregator/Update/StatusUpdater.cs
+++ b/src/StatusAggregator/Update/StatusUpdater.cs
@@ -13,8 +13,7 @@ namespace StatusAggregator.Update
 {
     public class StatusUpdater : IStatusUpdater
     {
-        private const string ManualCursorBaseName = "manual";
-        private const string IncidentCursorName = "incident";
+        private const string LastUpdatedCursorName = 
 
         private readonly ICursor _cursor;
         private readonly IEntityCollector _incidentCollector;
@@ -50,8 +49,15 @@ namespace StatusAggregator.Update
                     await manualStatusChangeCollector.FetchLatest();
                 }
 
-                await _incidentCollector.FetchLatest();
-                await _activeEventUpdater.UpdateAllAsync(cursor);
+                try
+                {
+                    await _incidentCollector.FetchLatest();
+                    await _activeEventUpdater.UpdateAllAsync(cursor);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(LogEvents.IncidentIngestionFailure, e, "Failed to update incident API data.");
+                }
             }
         }
 

--- a/src/StatusAggregator/Update/StatusUpdater.cs
+++ b/src/StatusAggregator/Update/StatusUpdater.cs
@@ -53,13 +53,13 @@ namespace StatusAggregator.Update
                 {
                     await _incidentCollector.FetchLatest();
                     await _activeEventUpdater.UpdateAllAsync(cursor);
+
+                    await _cursor.Set(LastUpdatedCursorName, cursor);
                 }
                 catch (Exception e)
                 {
                     _logger.LogError(LogEvents.IncidentIngestionFailure, e, "Failed to update incident API data.");
                 }
-                
-                await _cursor.Set(LastUpdatedCursorName, cursor);
             }
         }
 

--- a/src/StatusAggregator/Update/StatusUpdater.cs
+++ b/src/StatusAggregator/Update/StatusUpdater.cs
@@ -13,7 +13,7 @@ namespace StatusAggregator.Update
 {
     public class StatusUpdater : IStatusUpdater
     {
-        private const string LastUpdatedCursorName = 
+        public const string LastUpdatedCursorName = "updated";
 
         private readonly ICursor _cursor;
         private readonly IEntityCollector _incidentCollector;
@@ -58,6 +58,8 @@ namespace StatusAggregator.Update
                 {
                     _logger.LogError(LogEvents.IncidentIngestionFailure, e, "Failed to update incident API data.");
                 }
+                
+                await _cursor.Set(LastUpdatedCursorName, cursor);
             }
         }
 

--- a/tests/StatusAggregator.Tests/Export/StatusExporterTests.cs
+++ b/tests/StatusAggregator.Tests/Export/StatusExporterTests.cs
@@ -31,13 +31,13 @@ namespace StatusAggregator.Tests.Export
                 EventExporter
                     .Setup(x => x.Export(cursor))
                     .Returns(events);
-                
-                await Exporter.Export(cursor);
 
                 var lastUpdated = new DateTime(2018, 9, 12);
                 Cursor
                     .Setup(x => x.Get(StatusUpdater.LastUpdatedCursorName))
                     .ReturnsAsync(lastUpdated);
+
+                await Exporter.Export(cursor);
 
                 Serializer
                     .Verify(

--- a/tests/StatusAggregator.Tests/Export/StatusExporterTests.cs
+++ b/tests/StatusAggregator.Tests/Export/StatusExporterTests.cs
@@ -41,7 +41,7 @@ namespace StatusAggregator.Tests.Export
 
                 Serializer
                     .Verify(
-                        x => x.Serialize(lastUpdated, component, events),
+                        x => x.Serialize(cursor, lastUpdated, component, events),
                         Times.Once());
             }
         }

--- a/tests/StatusAggregator.Tests/Export/StatusSerializerTests.cs
+++ b/tests/StatusAggregator.Tests/Export/StatusSerializerTests.cs
@@ -20,14 +20,15 @@ namespace StatusAggregator.Tests.Export
             [Fact]
             public async Task SerializesStatus()
             {
+                var lastBuilt = new DateTime(2018, 11, 13);
                 var lastUpdated = new DateTime(2018, 9, 13);
                 var component = new TestComponent("hi", new[] { new TestComponent("yo"), new TestComponent("what's up") });
                 var events = new[] { new Event("", lastUpdated, lastUpdated, new[] { new Message(lastUpdated, "howdy") }) };
 
-                var expectedStatus = new ServiceStatus(lastUpdated, component, events);
+                var expectedStatus = new ServiceStatus(lastBuilt, lastUpdated, component, events);
                 var expectedJson = JsonConvert.SerializeObject(expectedStatus, StatusSerializer.Settings);
 
-                await Serializer.Serialize(lastUpdated, component, events);
+                await Serializer.Serialize(lastBuilt, lastUpdated, component, events);
 
                 Container
                     .Verify(

--- a/tests/StatusAggregator.Tests/Export/StatusSerializerTests.cs
+++ b/tests/StatusAggregator.Tests/Export/StatusSerializerTests.cs
@@ -20,14 +20,14 @@ namespace StatusAggregator.Tests.Export
             [Fact]
             public async Task SerializesStatus()
             {
-                var cursor = new DateTime(2018, 9, 13);
+                var lastUpdated = new DateTime(2018, 9, 13);
                 var component = new TestComponent("hi", new[] { new TestComponent("yo"), new TestComponent("what's up") });
-                var events = new[] { new Event("", cursor, cursor, new[] { new Message(cursor, "howdy") }) };
+                var events = new[] { new Event("", lastUpdated, lastUpdated, new[] { new Message(lastUpdated, "howdy") }) };
 
-                var expectedStatus = new ServiceStatus(cursor, component, events);
+                var expectedStatus = new ServiceStatus(lastUpdated, component, events);
                 var expectedJson = JsonConvert.SerializeObject(expectedStatus, StatusSerializer.Settings);
 
-                await Serializer.Serialize(cursor, component, events);
+                await Serializer.Serialize(lastUpdated, component, events);
 
                 Container
                     .Verify(

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -106,23 +106,11 @@
     <PackageReference Include="Moq">
       <Version>4.7.145</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.29.0</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Status">
-      <Version>2.29.0</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.29.0</Version>
-    </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.4.0</Version>
-    </PackageReference>
-    <PackageReference Include="WindowsAzure.Storage">
-      <Version>9.2.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.0</Version>

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Update\AggregationEntityUpdaterTests.cs" />
     <Compile Include="Update\EventMessagingUpdaterTests.cs" />
     <Compile Include="Update\IncidentUpdaterTests.cs" />
+    <Compile Include="Update\StatusUpdaterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\StatusAggregator\StatusAggregator.csproj">

--- a/tests/StatusAggregator.Tests/Update/StatusUpdaterTests.cs
+++ b/tests/StatusAggregator.Tests/Update/StatusUpdaterTests.cs
@@ -26,7 +26,7 @@ namespace StatusAggregator.Tests.Update
                     .ReturnsAsync(new DateTime(2018, 11, 12))
                     .Verifiable();
 
-                ManualStatusChangeCollector1
+                ManualStatusChangeCollector2
                     .Setup(x => x.FetchLatest())
                     .ReturnsAsync(new DateTime(2018, 11, 13))
                     .Verifiable();
@@ -62,7 +62,7 @@ namespace StatusAggregator.Tests.Update
                     .ReturnsAsync(new DateTime(2018, 11, 12))
                     .Verifiable();
 
-                ManualStatusChangeCollector1
+                ManualStatusChangeCollector2
                     .Setup(x => x.FetchLatest())
                     .ReturnsAsync(new DateTime(2018, 11, 13))
                     .Verifiable();
@@ -99,7 +99,7 @@ namespace StatusAggregator.Tests.Update
                     .ReturnsAsync(new DateTime(2018, 11, 12))
                     .Verifiable();
 
-                ManualStatusChangeCollector1
+                ManualStatusChangeCollector2
                     .Setup(x => x.FetchLatest())
                     .ReturnsAsync(new DateTime(2018, 11, 13))
                     .Verifiable();
@@ -188,6 +188,7 @@ namespace StatusAggregator.Tests.Update
                 {
                     // null enumerable
                     yield return new object[] { typeof(ArgumentNullException), null };
+
                     // empty enumerable
                     yield return new object[] { typeof(ArgumentException), new IEntityCollector[0] };
 
@@ -212,15 +213,13 @@ namespace StatusAggregator.Tests.Update
             [Fact]
             public void ThrowsWithoutActiveEventUpdater()
             {
-                var incidentCollector = new Mock<IEntityCollector>();
-                incidentCollector
-                    .Setup(x => x.Name)
-                    .Returns(IncidentEntityCollectorProcessor.IncidentsCollectorName);
-
                 Assert.Throws<ArgumentNullException>(
                     () => new StatusUpdater(
                         Mock.Of<ICursor>(),
-                        new[] { incidentCollector.Object },
+                        new[]
+                        {
+                            CreateCollectorWithName(IncidentEntityCollectorProcessor.IncidentsCollectorName).Object
+                        },
                         null,
                         Mock.Of<ILogger<StatusUpdater>>()));
             }
@@ -228,15 +227,13 @@ namespace StatusAggregator.Tests.Update
             [Fact]
             public void ThrowsWithoutLogger()
             {
-                var incidentCollector = new Mock<IEntityCollector>();
-                incidentCollector
-                    .Setup(x => x.Name)
-                    .Returns(IncidentEntityCollectorProcessor.IncidentsCollectorName);
-
                 Assert.Throws<ArgumentNullException>(
                     () => new StatusUpdater(
                         Mock.Of<ICursor>(),
-                        new[] { incidentCollector.Object },
+                        new[] 
+                        {
+                            CreateCollectorWithName(IncidentEntityCollectorProcessor.IncidentsCollectorName).Object
+                        },
                         Mock.Of<IActiveEventEntityUpdater>(),
                         null));
             }

--- a/tests/StatusAggregator.Tests/Update/StatusUpdaterTests.cs
+++ b/tests/StatusAggregator.Tests/Update/StatusUpdaterTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StatusAggregator.Collector;
+using StatusAggregator.Update;
+using Xunit;
+
+namespace StatusAggregator.Tests.Update
+{
+    public class StatusUpdaterTests
+    {
+        public class StatusUpdaterTest
+        {
+            public Mock<ICursor> Cursor { get; }
+            public Mock<IEnumerable<IEntityCollector>> Collectors { get; }
+        }
+
+        public class TheConstructor
+        {
+            [Fact]
+            public void ThrowsWithoutCursor()
+            {
+                var incidentCollector = new Mock<IEntityCollector>();
+                incidentCollector
+                    .Setup(x => x.Name)
+                    .Returns(IncidentEntityCollectorProcessor.IncidentsCollectorName);
+
+                Assert.Throws<ArgumentNullException>(
+                    () => new StatusUpdater(
+                        null,
+                        new[] { incidentCollector.Object },
+                        Mock.Of<IActiveEventEntityUpdater>(),
+                        Mock.Of<ILogger<StatusUpdater>>()));
+            }
+
+            public static IEnumerable<object[]> ThrowsWithoutCollectors_Data
+            {
+                get
+                {
+                    // null enumerable
+                    yield return new object[] { typeof(ArgumentNullException), null };
+                    // empty enumerable
+                    yield return new object[] { typeof(ArgumentException), new IEntityCollector[0] };
+                    // enumerable without incident collector
+                    yield return new object[] { typeof(ArgumentException), };
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(ThrowsWithoutCollectors_Data))]
+            public void ThrowsWithoutCollectors(Type exceptionType, IEnumerable<IEntityCollector> collectors)
+            {
+                Assert.Throws(
+                    exceptionType,
+                    () => new StatusUpdater(
+                        Mock.Of<ICursor>(),
+                        collectors,
+                        Mock.Of<IActiveEventEntityUpdater>(),
+                        Mock.Of<ILogger<StatusUpdater>>()));
+            }
+
+            [Fact]
+            public void ThrowsWithoutActiveEventUpdater()
+            {
+                var incidentCollector = new Mock<IEntityCollector>();
+                incidentCollector
+                    .Setup(x => x.Name)
+                    .Returns(IncidentEntityCollectorProcessor.IncidentsCollectorName);
+
+                Assert.Throws<ArgumentNullException>(
+                    () => new StatusUpdater(
+                        Mock.Of<ICursor>(),
+                        new[] { incidentCollector.Object },
+                        null,
+                        Mock.Of<ILogger<StatusUpdater>>()));
+            }
+
+            [Fact]
+            public void ThrowsWithoutLogger()
+            {
+                var incidentCollector = new Mock<IEntityCollector>();
+                incidentCollector
+                    .Setup(x => x.Name)
+                    .Returns(IncidentEntityCollectorProcessor.IncidentsCollectorName);
+
+                Assert.Throws<ArgumentNullException>(
+                    () => new StatusUpdater(
+                        Mock.Of<ICursor>(),
+                        new[] { incidentCollector.Object },
+                        Mock.Of<IActiveEventEntityUpdater>(),
+                        null));
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/NuGet/NuGetGallery/issues/6549

**Before:**
If StatusAggregator fails to fetch new incidents, it throws and does not save the status blob.

**After:**
An additional field, `LastBuilt` is added to show when the blob was last built. If StatusAggregator fails to fetch new incidents, it still saves the status blob and increments `LastBuilt`, but does not increment `LastUpdated`.