### PR TITLE
CollectAzureCdnLogs should properly handle files ending in .tmp

### DIFF
--- a/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
@@ -97,7 +97,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
             }
         }
 
-        public async Task<IEnumerable<RawLogFileInfo>> GetRawLogFiles(Uri uri)
+        public async Task<IEnumerable<Uri>> GetRawLogFiles(Uri uri)
         {
             if (uri == null)
             {
@@ -124,7 +124,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
 
                     var fileNames = directoryList.Split(Environment.NewLine.ToCharArray(),
                         StringSplitOptions.RemoveEmptyEntries);
-                    var rawLogFiles = fileNames.Select(fn => new RawLogFileInfo(new Uri(uri.EnsureTrailingSlash(), fn)));
+                    var rawLogFiles = fileNames.Select(fn => new Uri(uri.EnsureTrailingSlash(), fn));
 
                     return rawLogFiles;
                 }
@@ -132,7 +132,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
                 {
                     Logger.LogError(LogEvents.FailedBlobListing, e, "Failed to get raw log files.");
 
-                    return Enumerable.Empty<RawLogFileInfo>();
+                    return Enumerable.Empty<Uri>();
                 }
             }
         }

--- a/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
@@ -97,7 +97,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
             }
         }
 
-        public async Task<IEnumerable<Uri>> GetRawLogFiles(Uri uri)
+        public async Task<IEnumerable<Uri>> GetRawLogFileUris(Uri uri)
         {
             if (uri == null)
             {
@@ -124,9 +124,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
 
                     var fileNames = directoryList.Split(Environment.NewLine.ToCharArray(),
                         StringSplitOptions.RemoveEmptyEntries);
-                    var rawLogFiles = fileNames.Select(fn => new Uri(uri.EnsureTrailingSlash(), fn));
-
-                    return rawLogFiles;
+                    return fileNames.Select(fn => new Uri(uri.EnsureTrailingSlash(), fn));
                 }
                 catch (Exception e)
                 {

--- a/src/Stats.CollectAzureCdnLogs/IRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/IRawLogClient.cs
@@ -10,7 +10,7 @@ namespace Stats.CollectAzureCdnLogs
 {
     internal interface IRawLogClient
     {
-        Task<IEnumerable<RawLogFileInfo>> GetRawLogFiles(Uri uri);
+        Task<IEnumerable<Uri>> GetRawLogFiles(Uri uri);
         Task<Stream> OpenReadAsync(Uri uri);
         Task<bool> RenameAsync(Uri uri, string newFileName);
         Task DeleteAsync(Uri uri);

--- a/src/Stats.CollectAzureCdnLogs/IRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/IRawLogClient.cs
@@ -10,7 +10,7 @@ namespace Stats.CollectAzureCdnLogs
 {
     internal interface IRawLogClient
     {
-        Task<IEnumerable<Uri>> GetRawLogFiles(Uri uri);
+        Task<IEnumerable<Uri>> GetRawLogFileUris(Uri uri);
         Task<Stream> OpenReadAsync(Uri uri);
         Task<bool> RenameAsync(Uri uri, string newFileName);
         Task DeleteAsync(Uri uri);

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -114,15 +114,17 @@ namespace Stats.CollectAzureCdnLogs
             var azureClient = new CloudBlobRawLogClient(LoggerFactory, _cloudStorageAccount);
 
             // Collect directory listing.
-            var rawLogFiles = await ftpClient.GetRawLogFiles(_ftpServerUri);
+            var rawLogFileUris = await ftpClient.GetRawLogFiles(_ftpServerUri);
 
             // Prepare cloud storage blob container.
             var cloudBlobContainer = await azureClient.CreateContainerIfNotExistsAsync(_cloudStorageContainerName);
 
-            foreach (var rawLogFile in rawLogFiles)
+            foreach (var rawLogFileUri in rawLogFileUris)
             {
                 try
                 {
+                    var rawLogFile = new RawLogFileInfo(rawLogFileUri);
+
                     if (_azureCdnPlatform != rawLogFile.AzureCdnPlatform
                         || !_azureCdnAccountNumber.Equals(rawLogFile.AzureCdnAccountNumber, StringComparison.InvariantCultureIgnoreCase))
                     {

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -114,7 +114,7 @@ namespace Stats.CollectAzureCdnLogs
             var azureClient = new CloudBlobRawLogClient(LoggerFactory, _cloudStorageAccount);
 
             // Collect directory listing.
-            var rawLogFileUris = await ftpClient.GetRawLogFiles(_ftpServerUri);
+            var rawLogFileUris = await ftpClient.GetRawLogFileUris(_ftpServerUri);
 
             // Prepare cloud storage blob container.
             var cloudBlobContainer = await azureClient.CreateContainerIfNotExistsAsync(_cloudStorageContainerName);

--- a/src/Stats.CollectAzureCdnLogs/RawLogFileInfo.cs
+++ b/src/Stats.CollectAzureCdnLogs/RawLogFileInfo.cs
@@ -70,10 +70,8 @@ namespace Stats.CollectAzureCdnLogs
                     if (Extension.EndsWith(FileExtensions.Gzip, StringComparison.InvariantCultureIgnoreCase))
                     {
                         ContentType = _contentTypeGzip;
-                    }
-                    else
-                    {
-                        throw new InvalidRawLogFileNameException(FileName);
+
+                        return;
                     }
                 }
                 else if (lastPart.Count() == 4)
@@ -85,17 +83,13 @@ namespace Stats.CollectAzureCdnLogs
                     {
                         IsPendingDownload = true;
                         ContentType = _contentTypeGzip;
+
+                        return;
                     }
                 }
-                else
-                {
-                    throw new InvalidRawLogFileNameException(FileName);
-                }
             }
-            else
-            {
-                throw new InvalidRawLogFileNameException(FileName);
-            }
+
+            throw new InvalidRawLogFileNameException(FileName);
         }
 
         private int TryParseRollingFileNumber(string rollingFileNumberString)

--- a/tests/Tests.Stats.CollectAzureCdnLogs/RawLogFileInfoTests.cs
+++ b/tests/Tests.Stats.CollectAzureCdnLogs/RawLogFileInfoTests.cs
@@ -60,6 +60,7 @@ namespace Tests.Stats.CollectAzureCdnLogs
         [InlineData("ftp://someserver/logs/wpc_A000_20150603_0058.log")]
         [InlineData("ftp://someserver/logs/wpc_A000_20151342_0058.log.gz")]
         [InlineData("ftp://someserver/logs/wpc_A000_20150603_0058.log.download")]
+        [InlineData("ftp://someserver/logs/wpc_A000_20150603_0058.log.gz.tmp")]
         public void ThrowsWhenInvalidRawLogFileName(string uriString)
         {
             Assert.Throws<InvalidRawLogFileNameException>(() => new RawLogFileInfo(new Uri(uriString)));


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/1909: `RawLogFileInfo.TryParseFilename` now correctly throws when it encounters a log file ending in `.tmp`.
https://github.com/NuGet/Engineering/issues/1910: The job now skips files it can't process instead of processing no files when it finds one it can't process.