### PR TITLE
[Revalidation] Speed up the revalidation rate by the batch size

### DIFF
--- a/src/NuGet.Services.Revalidate/Services/RevalidationJobStateService.cs
+++ b/src/NuGet.Services.Revalidate/Services/RevalidationJobStateService.cs
@@ -104,7 +104,8 @@ namespace NuGet.Services.Revalidate
                     return false;
                 }
 
-                var nextRate = Math.Min(_config.MaxPackageEventRate, state.DesiredPackageEventRate + 1);
+                var nextRate = state.DesiredPackageEventRate + _config.Queue.MaxBatchSize;
+                nextRate = Math.Min(_config.MaxPackageEventRate, nextRate);
 
                 _logger.LogInformation(
                     "Increasing desired package event rate to {ToRate} from {FromRate}",

--- a/tests/NuGet.Services.Revalidate.Tests/Services/RevalidationJobStateServiceFacts.cs
+++ b/tests/NuGet.Services.Revalidate.Tests/Services/RevalidationJobStateServiceFacts.cs
@@ -183,7 +183,7 @@ namespace NuGet.Services.Revalidate.Tests.Services
                 await _target.IncreaseDesiredPackageEventRateAsync();
 
                 // Assert
-                Assert.Equal(124, state.DesiredPackageEventRate);
+                Assert.Equal(143, state.DesiredPackageEventRate);
                 Assert.True(result);
 
                 _state.Verify(s => s.MaybeUpdateStateAsync(It.IsAny<Func<RevalidationState, bool>>()), Times.Once);
@@ -261,6 +261,11 @@ namespace NuGet.Services.Revalidate.Tests.Services
                 {
                     MinPackageEventRate = 100,
                     MaxPackageEventRate = 500,
+
+                    Queue = new RevalidationQueueConfiguration
+                    {
+                        MaxBatchSize = 20
+                    }
                 };
 
                 _target = new RevalidationJobStateService(


### PR DESCRIPTION
Currently, the job will increase its revalidation rate by 1 revalidation per hour each time it enqueues a batch of revalidations. As a result, the job speeds up very slowly. This change makes the job increase its revalidation rate by the batch size. Meaning, the revalidation job will increase its revalidation rate by 64 revalidations per hour if it enqueues 64 revalidations.