### PR TITLE
[Orchestrator] Increase the connection limit

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -47,6 +47,11 @@ namespace NuGet.Services.Validation.Orchestrator
 {
     public class Job : JobBase
     {
+        /// <summary>
+        /// The maximum number of concurrent connections that can be established to a single server.
+        /// </summary>
+        private const int MaximumConnectionsPerServer = 64;
+
         private const string ConfigurationArgument = "Configuration";
         private const string ValidateArgument = "Validate";
 
@@ -93,6 +98,8 @@ namespace NuGet.Services.Validation.Orchestrator
 
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {
+            ServicePointManager.DefaultConnectionLimit = MaximumConnectionsPerServer;
+
             var configurationFilename = JobConfigurationManager.GetArgument(jobArgsDictionary, ConfigurationArgument);
             _validateOnly = JobConfigurationManager.TryGetBoolArgument(jobArgsDictionary, ValidateArgument, defaultValue: false);
 


### PR DESCRIPTION
The Orchestrator used the default connection limit of 2 per server. The Orchestrator processes messages in parallel, each of which may be downloading/uploading large files.

Part of https://github.com/NuGet/NuGetGallery/issues/6624

# Performance Test

I ran performance tests where I enqueued the same ~1,500 packages for validation. I then found how long it took the Orchestrator to download packages before and after this change:

Test | Average | 90%| 99% | 99.9%
-- | -- | -- | -- | --
Before | 9.64s | 19.87s | 32.58s | 37.05s
After | 6.59s | 13.90s | 24.96s | 33.14s

```
traces
| where timestamp > todatetime('2018-11-21T23:55:00.000')
| where timestamp < todatetime('2018-11-22T03:50:00.000')
| where cloud_RoleName == "NuGet.Services.Validation.Orchestrator"
| where message contains "Downloaded" and message contains "bytes in" and message contains "seconds for request"
| extend DownloadSeconds = todouble(customDimensions.DownloadElapsedTime) 
| extend AfterIncreasingConnectionLimit = iff(timestamp > todatetime('2018-11-22T02:10:00.000'), 1, 0)
| summarize count(), avg(DownloadSeconds), percentiles(DownloadSeconds, 90, 99, 99.9) by AfterIncreasingConnectionLimit
| order by AfterIncreasingConnectionLimit  asc
```

