### PR TITLE
Improve telemetry for validation messages exceeding expected duration

### DIFF
--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -105,13 +105,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -123,7 +123,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -31,6 +31,8 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string DurationToHashPackageSeconds = OrchestratorPrefix + "DurationToHashPackageSeconds";
         private const string MessageDeliveryLag = OrchestratorPrefix + "MessageDeliveryLag";
         private const string MessageEnqueueLag = OrchestratorPrefix + "MessageEnqueueLag";
+        private const string MessageHandlerDurationSeconds = OrchestratorPrefix + "MessageHandlerDurationSeconds";
+        private const string MessageLockLost = OrchestratorPrefix + "MessageLockLost";
         private const string SymbolsMessageEnqueued = OrchestratorPrefix + "SymbolsMessageEnqueued";
 
         private const string DurationToStartPackageSigningValidatorSeconds = PackageSigningPrefix + "DurationToStartSeconds";
@@ -50,6 +52,8 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string HashAlgorithm = "HashAlgorithm";
         private const string StreamType = "StreamType";
         private const string MessageType = "MessageType";
+        private const string CallGuid = "CallGuid";
+        private const string Handled = "Handled";
         private const string ValidationId = "ValidationId";
         private const string OperationDateTime = "OperationDateTime";
 
@@ -237,6 +241,31 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                 {
                     { MessageType, typeof(TMessage).Name }
                 });
+
+        public void TrackMessageHandlerDuration<TMessage>(TimeSpan duration, Guid callGuid, bool handled)
+        {
+            _telemetryClient.TrackMetric(
+                MessageHandlerDurationSeconds,
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() },
+                    { Handled, handled.ToString() }
+                });
+        }
+
+        public void TrackMessageLockLost<TMessage>(Guid callGuid)
+        {
+            _telemetryClient.TrackMetric(
+                MessageLockLost,
+                1,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() }
+                });
+        }
 
         public void TrackEnqueueLag<TMessage>(TimeSpan enqueueLag)
             => _telemetryClient.TrackMetric(

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -81,7 +81,7 @@
       <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -112,7 +112,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -157,13 +157,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.2.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -103,16 +103,16 @@
       <Version>5.0.0-preview1.5665</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-master-2224741</Version>

--- a/src/Validation.PackageSigning.ProcessSignature/Telemetry/TelemetryService.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/Telemetry/TelemetryService.cs
@@ -16,6 +16,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.Telemetry
         private const string DurationToStripRepositorySignaturesSeconds = Prefix + "DurationToStripRepositorySignaturesSeconds";
         private const string MessageDeliveryLag = Prefix + "MessageDeliveryLag";
         private const string MessageEnqueueLag = Prefix + "MessageEnqueueLag";
+        private const string MessageHandlerDurationSeconds = Prefix + "MessageHandlerDurationSeconds";
+        private const string MessageLockLost = Prefix + "MessageLockLost";
 
         private const string PackageId = "PackageId";
         private const string NormalizedVersion = "NormalizedVersion";
@@ -26,6 +28,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.Telemetry
         private const string OutputCounterSignatureCount = "OutputCounterSignatureCount";
         private const string Changed = "Changed";
         private const string MessageType = "MessageType";
+        private const string CallGuid = "CallGuid";
+        private const string Handled = "Handled";
 
         private readonly ITelemetryClient _telemetryClient;
 
@@ -100,5 +104,30 @@ namespace NuGet.Jobs.Validation.PackageSigning.Telemetry
                 {
                     { MessageType, typeof(TMessage).Name }
                 });
+
+        public void TrackMessageHandlerDuration<TMessage>(TimeSpan duration, Guid callGuid, bool handled)
+        {
+            _telemetryClient.TrackMetric(
+                MessageHandlerDurationSeconds,
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() },
+                    { Handled, handled.ToString() }
+                });
+        }
+
+        public void TrackMessageLockLost<TMessage>(Guid callGuid)
+        {
+            _telemetryClient.TrackMetric(
+                MessageLockLost,
+                1,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() }
+                });
+        }
     }
 }

--- a/src/Validation.PackageSigning.ValidateCertificate/TelemetryService.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/TelemetryService.cs
@@ -17,6 +17,8 @@ namespace Validation.PackageSigning.ValidateCertificate
         private const string UnableToValidateCertificate = Prefix + "UnableToValidateCertificate";
         private const string MessageDeliveryLag = Prefix + "MessageDeliveryLag";
         private const string MessageEnqueueLag = Prefix + "MessageEnqueueLag";
+        private const string MessageHandlerDurationSeconds = Prefix + "MessageHandlerDurationSeconds";
+        private const string MessageLockLost = Prefix + "MessageLockLost";
 
         private const string PackageId = "PackageId";
         private const string PackageNormalizedVersion = "PackageNormalizedVersion";
@@ -24,6 +26,8 @@ namespace Validation.PackageSigning.ValidateCertificate
         private const string CertificateId = "CertificateId";
         private const string CertificateThumbprint = "CertificateThumbprint";
         private const string MessageType = "MessageType";
+        private const string CallGuid = "CallGuid";
+        private const string Handled = "Handled";
 
         private readonly TelemetryClient _telemetryClient;
 
@@ -87,5 +91,30 @@ namespace Validation.PackageSigning.ValidateCertificate
                 {
                     { MessageType, typeof(TMessage).Name }
                 });
+
+        public void TrackMessageHandlerDuration<TMessage>(TimeSpan duration, Guid callGuid, bool handled)
+        {
+            _telemetryClient.TrackMetric(
+                MessageHandlerDurationSeconds,
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() },
+                    { Handled, handled.ToString() }
+                });
+        }
+
+        public void TrackMessageLockLost<TMessage>(Guid callGuid)
+        {
+            _telemetryClient.TrackMetric(
+                MessageLockLost,
+                1,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() }
+                });
+        }
     }
 }

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.38.0</Version>
+      <Version>2.39.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Symbols/TelemetryService.cs
+++ b/src/Validation.Symbols/TelemetryService.cs
@@ -16,6 +16,8 @@ namespace Validation.Symbols
         private const string SymbolValidationDuration = Prefix + "SymbolValidationDurationInSeconds";
         private const string MessageDeliveryLag = Prefix + "MessageDeliveryLag";
         private const string MessageEnqueueLag = Prefix + "MessageEnqueueLag";
+        private const string MessageHandlerDurationSeconds = Prefix + "MessageHandlerDurationSeconds";
+        private const string MessageLockLost = Prefix + "MessageLockLost";
         private const string SymbolValidationResult = Prefix + "SymbolValidationResult";
         private const string SymbolAssemblyValidationResult = Prefix + "SymbolAssemblyValidationResult";
 
@@ -26,6 +28,8 @@ namespace Validation.Symbols
         private const string ValidationResult = "ValidationResult";
         private const string Issue = "Issue";
         private const string AssemblyName = "AssemblyName";
+        private const string CallGuid = "CallGuid";
+        private const string Handled = "Handled";
 
         private readonly ITelemetryClient _telemetryClient;
 
@@ -115,5 +119,30 @@ namespace Validation.Symbols
                 {
                     { MessageType, typeof(TMessage).Name }
                 });
+
+        public void TrackMessageHandlerDuration<TMessage>(TimeSpan duration, Guid callGuid, bool handled)
+        {
+            _telemetryClient.TrackMetric(
+                MessageHandlerDurationSeconds,
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() },
+                    { Handled, handled.ToString() }
+                });
+        }
+
+        public void TrackMessageLockLost<TMessage>(Guid callGuid)
+        {
+            _telemetryClient.TrackMetric(
+                MessageLockLost,
+                1,
+                new Dictionary<string, string>
+                {
+                    { MessageType, typeof(TMessage).Name },
+                    { CallGuid, callGuid.ToString() }
+                });
+        }
     }
 }


### PR DESCRIPTION
Today, we have to parse Application Insights logs to figure out how a message handler's duration. This makes it impossible to dashboard and monitor. This metric will let us detect messages that caused deadlettering by exceeding their expected duration.

Orchestrator build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2234528&view=logs
Jobs build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2234529&view=logs
DEV Deployment: https://octopus.nuget.org/app#/projects/jobs-process-signature/releases/4.1.0-loshar-update-sb-2234529/deployments/Deployments-8655

Depends on https://github.com/NuGet/ServerCommon/pull/230
Part of https://github.com/NuGet/NuGetGallery/issues/6624