### PR TITLE
Recognize "NuGet VS VSIX" as valid NuGet client

### DIFF
--- a/src/Stats.Warehouse/Programmability/Functions/dbo.IsNuGetClient.sql
+++ b/src/Stats.Warehouse/Programmability/Functions/dbo.IsNuGetClient.sql
@@ -14,6 +14,9 @@ BEGIN
 			CHARINDEX('NuGet Cross-Platform Command Line', @ClientName) > 0
 		OR	CHARINDEX('NuGet Client V3', @ClientName) > 0
 
+			-- VS NuGet 4.6+
+		OR	CHARINDEX('NuGet VS VSIX', @ClientName) > 0
+
 			-- VS NuGet 2.8+
 		OR	CHARINDEX('NuGet VS PowerShell Console', @ClientName) > 0
 		OR	CHARINDEX('NuGet VS Packages Dialog - Solution', @ClientName) > 0


### PR DESCRIPTION
We should really avoid changing user agent all the time.

This sql function is used in a computed column, so updating the function will require us to drop indices on the db, drop the column, push the updated sql function, recreate the column, and recreate the indices...