### PR TITLE
[Orchestrator] Track package backup durations

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -18,11 +18,18 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         void TrackDurationToValidationSetCreation(TimeSpan duration);
 
         /// <summary>
+        /// Track how long a package's backup takes.
+        /// </summary>
+        /// <param name="validationSet">The validation set that requested the backup.</param>
+        /// <returns>Reports the duration when disposed.</returns>
+        IDisposable TrackDurationToBackupPackage(PackageValidationSet validationSet);
+
+        /// <summary>
         /// A counter metric emitted when a package changes package status. This metric is not emitted if package status
         /// does not change. This metric is emitted for revalidation if the terminal state changes.
         /// </summary>
         /// <param name="fromStatus">The status that the package moved from.</param>
-        /// <param name="toStatus">The status that the package moved tp.</param>
+        /// <param name="toStatus">The status that the package moved to.</param>
         void TrackPackageStatusChange(PackageStatus fromStatus, PackageStatus toStatus);
 
         /// <summary>

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -16,6 +16,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string PackageCertificatesPrefix = "PackageCertificates.";
 
         private const string DurationToValidationSetCreationSeconds = OrchestratorPrefix + "DurationToValidationSetCreationSeconds";
+        private const string DurationToBackupPackageSeconds = OrchestratorPrefix + "DurationToBackupPackageSeconds";
         private const string PackageStatusChange = OrchestratorPrefix + "PackageStatusChange";
         private const string TotalValidationDurationSeconds = OrchestratorPrefix + "TotalValidationDurationSeconds";
         private const string SentValidationTakingTooLongMessage = OrchestratorPrefix + "SentValidationTakingTooLongMessage";
@@ -84,6 +85,18 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
             _telemetryClient.TrackMetric(
                 DurationToValidationSetCreationSeconds,
                 duration.TotalSeconds);
+        }
+
+        public IDisposable TrackDurationToBackupPackage(PackageValidationSet validationSet)
+        {
+            return _telemetryClient.TrackDuration(
+                DurationToBackupPackageSeconds,
+                new Dictionary<string, string>
+                {
+                    { ValidationTrackingId, validationSet.ValidationTrackingId.ToString() },
+                    { PackageId, validationSet.PackageId },
+                    { NormalizedVersion, validationSet.PackageNormalizedVersion }
+                });
         }
 
         public void TrackPackageStatusChange(PackageStatus fromStatus, PackageStatus toStatus)

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
@@ -118,19 +118,22 @@ namespace NuGet.Services.Validation.Orchestrator
 
         public async Task BackupPackageFileFromValidationSetPackageAsync(PackageValidationSet validationSet)
         {
-            _logger.LogInformation(
-                "Backing up package for validation set {ValidationTrackingId} ({PackageId} {PackageVersion}).",
-                validationSet.ValidationTrackingId,
-                validationSet.PackageId,
-                validationSet.PackageNormalizedVersion);
-
-            var packageUri = await GetPackageForValidationSetReadUriAsync(
-                validationSet,
-                DateTimeOffset.UtcNow.Add(AccessDuration));
-
-            using (var packageStream = await _fileDownloader.DownloadAsync(packageUri, CancellationToken.None))
+            using (_telemetryService.TrackDurationToBackupPackage(validationSet))
             {
-                await StorePackageFileInBackupLocationAsync(validationSet, packageStream);
+                _logger.LogInformation(
+                    "Backing up package for validation set {ValidationTrackingId} ({PackageId} {PackageVersion}).",
+                    validationSet.ValidationTrackingId,
+                    validationSet.PackageId,
+                    validationSet.PackageNormalizedVersion);
+
+                var packageUri = await GetPackageForValidationSetReadUriAsync(
+                    validationSet,
+                    DateTimeOffset.UtcNow.Add(AccessDuration));
+
+                using (var packageStream = await _fileDownloader.DownloadAsync(packageUri, CancellationToken.None))
+                {
+                    await StorePackageFileInBackupLocationAsync(validationSet, packageStream);
+                }
             }
         }
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
@@ -112,6 +112,15 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 .Returns(Task.CompletedTask)
                 .Verifiable();
 
+            var backupDurationMetric = new Mock<IDisposable>(MockBehavior.Strict);
+            backupDurationMetric
+                .Setup(m => m.Dispose())
+                .Verifiable();
+
+            _telemetryService
+                .Setup(t => t.TrackDurationToBackupPackage(_validationSet))
+                .Returns(backupDurationMetric.Object);
+
             var before = DateTimeOffset.UtcNow;
             await _target.BackupPackageFileFromValidationSetPackageAsync(_validationSet);
             var after = DateTimeOffset.UtcNow;


### PR DESCRIPTION
Package backups exceeding the expected duration may be causing message duplication in the Orchestrator. This adds more telemetry around package backups for future investigations.

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2234533&view=logs
Deployment: https://octopus.nuget.org/app#/projects/jobs-validation-orchestrator/releases/0.1.0-loshar-track-backup-2234533/deployments/Deployments-8656

Part of https://github.com/NuGet/NuGetGallery/issues/6624