### PR TITLE
Fixing file system watcher leak for PackageLag monitor.

### DIFF
--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -76,7 +76,7 @@ namespace NuGet.Jobs
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(Environment.CurrentDirectory)
-                .AddJsonFile(configurationFilename, optional: false, reloadOnChange: true);
+                .AddJsonFile(configurationFilename, optional: false, reloadOnChange: false);
 
             var uninjectedConfiguration = builder.Build();
 

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -124,7 +124,7 @@ namespace NuGet.Services.Validation.Orchestrator
             Logger.LogInformation("Using the {ConfigurationFilename} configuration file", configurationFilename);
             var builder = new ConfigurationBuilder()
                 .SetBasePath(Environment.CurrentDirectory)
-                .AddJsonFile(configurationFilename, optional: false, reloadOnChange: true);
+                .AddJsonFile(configurationFilename, optional: false, reloadOnChange: false);
 
             var uninjectedConfiguration = builder.Build();
 

--- a/src/PackageLagMonitor/Job.cs
+++ b/src/PackageLagMonitor/Job.cs
@@ -40,6 +40,7 @@ namespace NuGet.Jobs.Montoring.PackageLag
         private ICatalogClient _catalogClient;
         private IServiceProvider _serviceProvider;
         private PackageLagMonitorConfiguration _configuration;
+        private IConfigurationBuilder _builder = null;
 
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {
@@ -60,7 +61,7 @@ namespace NuGet.Jobs.Montoring.PackageLag
             Logger.LogInformation("Using the {ConfigurationFilename} configuration file", configurationFilename);
             var builder = new ConfigurationBuilder()
                 .SetBasePath(Environment.CurrentDirectory)
-                .AddJsonFile(configurationFilename, optional: false, reloadOnChange: true);
+                .AddJsonFile(configurationFilename, optional: false, reloadOnChange: false);
 
             var uninjectedConfiguration = builder.Build();
 
@@ -68,11 +69,11 @@ namespace NuGet.Jobs.Montoring.PackageLag
             var cachingSecretReaderFactory = new CachingSecretReaderFactory(secretReaderFactory, KeyVaultSecretCachingTimeout);
             var secretInjector = cachingSecretReaderFactory.CreateSecretInjector(cachingSecretReaderFactory.CreateSecretReader());
 
-            builder = new ConfigurationBuilder()
+            var injectedBuilder = new ConfigurationBuilder()
                 .SetBasePath(Environment.CurrentDirectory)
                 .AddInjectedJsonFile(configurationFilename, secretInjector);
 
-            return builder.Build();
+            return injectedBuilder.Build();
         }
 
         private IServiceProvider GetServiceProvider(IConfigurationRoot configurationRoot)

--- a/src/PackageLagMonitor/Job.cs
+++ b/src/PackageLagMonitor/Job.cs
@@ -40,7 +40,6 @@ namespace NuGet.Jobs.Montoring.PackageLag
         private ICatalogClient _catalogClient;
         private IServiceProvider _serviceProvider;
         private PackageLagMonitorConfiguration _configuration;
-        private IConfigurationBuilder _builder = null;
 
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {

--- a/src/PackageLagMonitor/Job.cs
+++ b/src/PackageLagMonitor/Job.cs
@@ -68,11 +68,11 @@ namespace NuGet.Jobs.Montoring.PackageLag
             var cachingSecretReaderFactory = new CachingSecretReaderFactory(secretReaderFactory, KeyVaultSecretCachingTimeout);
             var secretInjector = cachingSecretReaderFactory.CreateSecretInjector(cachingSecretReaderFactory.CreateSecretReader());
 
-            var injectedBuilder = new ConfigurationBuilder()
+            builder = new ConfigurationBuilder()
                 .SetBasePath(Environment.CurrentDirectory)
                 .AddInjectedJsonFile(configurationFilename, secretInjector);
 
-            return injectedBuilder.Build();
+            return builder.Build();
         }
 
         private IServiceProvider GetServiceProvider(IConfigurationRoot configurationRoot)


### PR DESCRIPTION
We were leaking file system watchers on every Init call, most likely due to event listeners causing GC to not clean them up.

This fixes that leak. This should be replicated to JsonConfigurationJob at some point, as JsonConfigurationJob base also has this issue.

@dtivel @chenriksson @joelverhagen @loic-sharma 