### PR TITLE
[Process Signature] Strip valid repository signatures

### DIFF
--- a/src/Validation.PackageSigning.ProcessSignature/ProcessSignatureConfiguration.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/ProcessSignatureConfiguration.cs
@@ -22,6 +22,12 @@ namespace NuGet.Jobs.Validation.PackageSigning
         public string V3ServiceIndexUrl { get; set; }
 
         /// <summary>
+        /// If true, revalidating a package will strip its repository signature and then apply a new repository signature,
+        /// even if current repository signature is valid. This mode should be disabled unless absolutely necessary!
+        /// </summary>
+        public bool StripValidRepositorySignatures { get; set; }
+
+        /// <summary>
         /// Whether repository signatures should be persisted to the database. Disable this if repository signing
         /// is in test mode and repository signed packages are not published.
         /// </summary>

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/dev.json
@@ -23,6 +23,7 @@
       "cf6ce6768ef858a3a667be1af8aa524d386c7f59a34542713f5dfb0d79acf3dd"
     ],
     "V3ServiceIndexUrl": "https://apidev.nugettest.org/v3/index.json",
+    "StripValidRepositorySignatures": true,
     "CommitRepositorySignatures": true
   },
 

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/int.json
@@ -23,6 +23,7 @@
       "cf6ce6768ef858a3a667be1af8aa524d386c7f59a34542713f5dfb0d79acf3dd"
     ],
     "V3ServiceIndexUrl": "https://apiint.nugettest.org/v3/index.json",
+    "StripValidRepositorySignatures": true,
     "CommitRepositorySignatures": true
   },
 

--- a/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
+++ b/src/Validation.PackageSigning.ProcessSignature/Settings/prod.json
@@ -23,6 +23,7 @@
       "0e5f38f57dc1bcc806d8494f4f90fbcedd988b46760709cbeec6f4219aa6157d"
     ],
     "V3ServiceIndexUrl": "https://api.nuget.org/v3/index.json",
+    "StripValidRepositorySignatures": true,
     "CommitRepositorySignatures": true
   },
 

--- a/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
+++ b/src/Validation.PackageSigning.ProcessSignature/SignatureValidator.cs
@@ -495,6 +495,25 @@ namespace NuGet.Jobs.Validation.PackageSigning.ProcessSignature
                 context.Message.PackageVersion,
                 context.Message.ValidationId);
 
+            // If configured, strip valid repository signatures from packages to force a new repository signature to be applied.
+            if (_configuration.Value.StripValidRepositorySignatures)
+            {
+                // Packages' signatures are validated twice: once before the package is repository signed, and once after. We do not
+                // want to strip the newly applied repository signature, so we will only strip in the "before" case. We can detect the
+                // "after" case as it requires the presence of a repository signature.
+                if (!context.Message.RequireRepositorySignature)
+                {
+                    _logger.LogWarning(
+                        $"The {nameof(ProcessSignatureConfiguration.StripValidRepositorySignatures)} configuration is enabled, " +
+                        "stripping the valid repository signature from package {PackageId} {PackageVersion} for validation {ValidationId}.",
+                        context.Message.PackageId,
+                        context.Message.PackageVersion,
+                        context.Message.ValidationId);
+
+                    return false;
+                }
+            }
+
             return true;
         }
 


### PR DESCRIPTION
Add a config to strip valid repository signatures. This will be used to re-reposign Microsoft packages.

Part of https://github.com/NuGet/Engineering/issues/1964