### PR TITLE
Improve on-call mitigation experience for query timeouts on report generation

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/ReportBase.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/ReportBase.cs
@@ -22,16 +22,20 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
         protected Func<Task<SqlConnection>> OpenGallerySqlConnectionAsync;
 
+        protected readonly TimeSpan CommandTimeoutSeconds;
+
         protected ReportBase(
             ILogger<ReportBase> logger,
             IEnumerable<StorageContainerTarget> targets,
             Func<Task<SqlConnection>> openStatisticsSqlConnectionAsync,
-            Func<Task<SqlConnection>> openGallerySqlConnectionAsync)
+            Func<Task<SqlConnection>> openGallerySqlConnectionAsync,
+            int commandTimeoutSeconds)
         {
             _logger = logger;
             Targets = targets.ToList().AsReadOnly();
             OpenStatisticsSqlConnectionAsync = openStatisticsSqlConnectionAsync;
             OpenGallerySqlConnectionAsync = openGallerySqlConnectionAsync;
+            CommandTimeoutSeconds = TimeSpan.FromSeconds(commandTimeoutSeconds);
         }
 
         protected async Task<CloudBlobContainer> GetBlobContainer(StorageContainerTarget target)

--- a/src/Stats.CreateAzureCdnWarehouseReports/ReportDataCollector.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/ReportDataCollector.cs
@@ -23,12 +23,12 @@ namespace Stats.CreateAzureCdnWarehouseReports
             ILogger<ReportDataCollector> logger,
             string procedureName,
             Func<Task<SqlConnection>> openGallerySqlConnectionAsync,
-            int timeout)
+            int commandTimeoutSeconds)
         {
             _logger = logger;
             _procedureName = procedureName;
             _openGallerySqlConnectionAsync = openGallerySqlConnectionAsync;
-            _commandTimeoutSeconds = timeout;
+            _commandTimeoutSeconds = commandTimeoutSeconds;
         }
 
         public async Task<DataTable> CollectAsync(DateTime reportGenerationTime, params Tuple<string, int, string>[] parameters)

--- a/src/Stats.CreateAzureCdnWarehouseReports/ReportNames.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/ReportNames.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Stats.CreateAzureCdnWarehouseReports
+{
+    internal static class ReportNames
+    {
+        public static string Extension = ".json";
+
+        public static string[] StandardReports = new []
+        {
+            NuGetClientVersion,
+            Last6Weeks,
+            RecentCommunityPopularity,
+            RecentCommunityPopularityDetail,
+            RecentPopularity,
+            RecentPopularityDetail
+        };
+
+        public static string[] AllReports = StandardReports.Concat(new[] {
+            RecentPopularityDetailByPackageId,
+            DownloadCount,
+            GalleryTotals,
+            DownloadsPerToolVersion
+        }).ToArray();
+
+        // Standard reports (ReportBuilder, ReportDataCollector)
+        public const string NuGetClientVersion = "nugetclientversion";
+        public const string Last6Weeks = "last6weeks";
+        public const string RecentCommunityPopularity = "recentcommunitypopularity";
+        public const string RecentCommunityPopularityDetail = "recentcommunitypopularitydetail";
+        public const string RecentPopularity = "recentpopularity";
+        public const string RecentPopularityDetail = "recentpopularitydetail";
+        public const string RecentPopularityDetailByPackageId = "recentpopularitydetailbypackageid";
+
+        // Custom reports (ReportBase)
+        public const string DownloadCount = "downloads.v1";
+        public const string GalleryTotals = "stats-totals";
+        public const string DownloadsPerToolVersion = "tools.v1";
+    }
+}

--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ReportBase.cs" />
     <Compile Include="ReportBuilder.cs" />
     <Compile Include="ReportDataCollector.cs" />
+    <Compile Include="ReportNames.cs" />
     <Compile Include="ReportWriter.cs" />
     <Compile Include="StorageContainerTarget.cs" />
     <Compile Include="ToolDownloadCountData.cs" />


### PR DESCRIPTION
Tracking: https://github.com/NuGet/NuGetGallery/issues/6764
Improves ability for on-call to mitigate stats report generation:
- Support `ReportName` config (single report run) for totals and per-package reports
- Use `CommandTimeout` config for totals report queries (120m, instead of hard-coded default of 30m)
- Adds duration metrics for the standard reports, in case we want finer granulation of command timeout per report in the future

In the future, we could also consider adding exception handling so that the job can continue to the next report in case of a single failure.