### PR TITLE
Larger buffer for file and network operations.

### DIFF
--- a/src/Validation.Common.Job/FileStreamUtility.cs
+++ b/src/Validation.Common.Job/FileStreamUtility.cs
@@ -7,7 +7,7 @@ namespace NuGet.Jobs.Validation
 {
     public static class FileStreamUtility
     {
-        public const int BufferSize = 256 * 1024;
+        public const int BufferSize = 80 * 1024;
 
         public static FileStream GetTemporaryFile()
         {

--- a/src/Validation.Common.Job/FileStreamUtility.cs
+++ b/src/Validation.Common.Job/FileStreamUtility.cs
@@ -7,7 +7,7 @@ namespace NuGet.Jobs.Validation
 {
     public static class FileStreamUtility
     {
-        public const int BufferSize = 8192;
+        public const int BufferSize = 256 * 1024;
 
         public static FileStream GetTemporaryFile()
         {

--- a/src/Validation.Common.Job/PackageDownloader.cs
+++ b/src/Validation.Common.Job/PackageDownloader.cs
@@ -56,7 +56,7 @@ namespace NuGet.Jobs.Validation
                     {
                         packageStream = FileStreamUtility.GetTemporaryFile();
 
-                        await networkStream.CopyToAsync(packageStream, FileStreamUtility.BufferSize, cancellationToken);
+                        await networkStream.CopyToAsync(packageStream, 81920, cancellationToken);
                     }
                 }
 

--- a/src/Validation.Common.Job/PackageDownloader.cs
+++ b/src/Validation.Common.Job/PackageDownloader.cs
@@ -29,6 +29,9 @@ namespace NuGet.Jobs.Validation
         }
 
         public async Task<Stream> DownloadAsync(Uri packageUri, CancellationToken cancellationToken)
+            => await DownloadAsync(packageUri, cancellationToken, FileStreamUtility.BufferSize);
+
+        public async Task<Stream> DownloadAsync(Uri packageUri, CancellationToken cancellationToken, int bufferSize)
         {
             _logger.LogInformation("Attempting to download package from {PackageUri}...", packageUri);
 
@@ -56,7 +59,7 @@ namespace NuGet.Jobs.Validation
                     {
                         packageStream = FileStreamUtility.GetTemporaryFile();
 
-                        await networkStream.CopyToAsync(packageStream, FileStreamUtility.BufferSize, cancellationToken);
+                        await networkStream.CopyToAsync(packageStream, bufferSize, cancellationToken);
                     }
                 }
 

--- a/src/Validation.Common.Job/PackageDownloader.cs
+++ b/src/Validation.Common.Job/PackageDownloader.cs
@@ -56,7 +56,7 @@ namespace NuGet.Jobs.Validation
                     {
                         packageStream = FileStreamUtility.GetTemporaryFile();
 
-                        await networkStream.CopyToAsync(packageStream, 81920, cancellationToken);
+                        await networkStream.CopyToAsync(packageStream, FileStreamUtility.BufferSize, cancellationToken);
                     }
                 }
 


### PR DESCRIPTION
80k was chosen to align with default buffer size used for [`Stream`](https://github.com/dotnet/corefx/blob/8a06434b29599950571aa7975458ae5b465d1a0d/src/Common/src/CoreLib/System/IO/Stream.cs#L32-L35).
Added `PackageDownloader.DownloadAsync` overload that allows to specify buffer size. It was not exposed through interface though since there is no code that uses it, but it simplifies writing test code greatly.