### PR TITLE
Harden SymbolValidator to better avoid BadImageExceptions

### DIFF
--- a/src/Validation.Symbols/SymbolsValidatorService.cs
+++ b/src/Validation.Symbols/SymbolsValidatorService.cs
@@ -264,9 +264,9 @@ namespace Validation.Symbols
         public static bool IsPortable(Stream pdbStream)
         {
             // Portable pdbs have the first four bytes "B", "S", "J", "B"
-            byte[] portableStamp = new byte[4] { 66, 83, 74, 66 };
+            var portableStamp = new byte[4] { 66, 83, 74, 66 };
 
-            byte[] currentPDBStamp = new byte[4];
+            var currentPDBStamp = new byte[4];
             pdbStream.Read(currentPDBStamp, 0, 4);
             return currentPDBStamp.SequenceEqual(portableStamp);
         }

--- a/src/Validation.Symbols/SymbolsValidatorService.cs
+++ b/src/Validation.Symbols/SymbolsValidatorService.cs
@@ -156,6 +156,12 @@ namespace Validation.Symbols
                 foreach (string peFile in Directory.GetFiles(targetDirectory, extension, SearchOption.AllDirectories))
                 {
                     IValidationResult validationResult;
+
+                    if(!IsPortable(GetSymbolPath(peFile)))
+                    {
+                        _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed);
+                        return ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_PdbIsNotPortable);
+                    }
                     if (!IsChecksumMatch(peFile, packageId, packageNormalizedVersion, out validationResult))
                     {
                         _telemetryService.TrackSymbolsValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed);
@@ -234,6 +240,40 @@ namespace Validation.Symbols
             _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_PdbIsNotPortable), assemblyName: Path.GetFileName(peFilePath));
             validationResult = ValidationResult.FailedWithIssues(ValidationIssue.SymbolErrorCode_PdbIsNotPortable);
             return false;
+        }
+
+        /// <summary>
+        /// Verifies if the pdb is portable.
+        /// </summary>
+        /// <param name="pdbPath">The pdb path.</param>
+        /// <returns>True if the pdb is portable.</returns>
+        public static bool IsPortable(string pdbPath)
+        {
+            using (var pdbStream = File.OpenRead(pdbPath))
+            {
+                return IsPortable(pdbStream);
+            }
+        }
+
+        /// <summary>
+        /// Verifies if the pdb is portable.
+        /// It does not dispose the stream.
+        /// </summary>
+        /// <param name="pdbStream">The pdbStream.</param>
+        /// <returns>True if the pdb is portable.</returns>
+        public static bool IsPortable(Stream pdbStream)
+        {
+            // Portable pdbs have the first four bytes "B", "S", "J", "B"
+            byte[] portableStamp = new byte[4] { 66, 83, 74, 66 };
+
+            byte[] currentPDBStamp = new byte[4];
+            pdbStream.Read(currentPDBStamp, 0, 4);
+            return currentPDBStamp.SequenceEqual(portableStamp);
+        }
+
+        public static string GetSymbolPath(string pePath)
+        {
+            return $"{Path.GetDirectoryName(pePath)}\\{Path.GetFileNameWithoutExtension(pePath)}.pdb";
         }
 
         /// <summary>

--- a/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
+++ b/tests/Validation.Symbols.Tests/SymbolsValidatorServiceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -161,6 +162,41 @@ namespace Validation.Symbols.Tests
                 List<string> orphanSymbols;
                 Assert.Throws<ArgumentNullException>(()=>SymbolsValidatorService.SymbolsHaveMatchingPEFiles(null, pes, out orphanSymbols));
                 Assert.Throws<ArgumentNullException>(() => SymbolsValidatorService.SymbolsHaveMatchingPEFiles(symbols, null, out orphanSymbols));
+            }
+        }
+
+        public class TheIsPortableMethod
+        {
+            [Theory]
+            [InlineData("BSJB", true)]
+            [InlineData("CBSJB", false)]
+            public void IsPortableValidation(string data, bool expectedResult)
+            {
+                // Arrange + Act
+                bool result = false;
+                using (MemoryStream memStream = new MemoryStream(Encoding.ASCII.GetBytes(data)))
+                {
+                    result = SymbolsValidatorService.IsPortable(memStream);
+                }
+
+                // Assert
+                Assert.Equal(result, expectedResult);
+            }
+        }
+
+        public class TheGetSymbolPathMethod
+        {
+            [Theory]
+            [InlineData(@"C:\A\BB\CC.dll", @"C:\A\BB\CC.pdb")]
+            [InlineData(@"C:\A\BB\cc.dll", @"C:\A\BB\cc.pdb")]
+            [InlineData(@"C:\A\BB\CC.exe", @"C:\A\BB\CC.pdb")]
+            public void IsGetSymbolPathValidation(string input, string expectedResult)
+            {
+                // Act 
+                string result = SymbolsValidatorService.GetSymbolPath(input);
+
+                // Assert
+                Assert.Equal(result, expectedResult);
             }
         }
 


### PR DESCRIPTION
The user submitted a nupkg with the dll built to have the debug directory referring a portable pdb, but the snupkg contained the windows pdb.
The TryOpenAssociatedPortablePdb is supposed to gracefully return false if the pdb is not portable but threw on this case.
Added standalone pbd validation for portability. 