### PR TITLE
Update NuGetGallery.Core version to pull in new storage APIs

### DIFF
--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -115,7 +115,7 @@
       <Version>2.40.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-2278861</Version>
+      <Version>4.4.5-dev-2323501</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/6766.

This makes https://github.com/NuGet/NuGetGallery/pull/6812 available.