### PR TITLE
Fix for statistics pipline to display proper last 6 weeks data around the new year

### DIFF
--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportLast6Weeks.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportLast6Weeks.sql
@@ -23,7 +23,7 @@ BEGIN
 
 	WITH WeekLookup AS 
 	(
-        -- If we just take all the rows between @MinDate and @MaxDate from Dimension_Date table
+		-- If we just take all the rows between @MinDate and @MaxDate from Dimension_Date table
 		-- we might end up the days from the week that contains 1st of January to have two
 		-- different week numbers:
 		-- 12/30/2018 -> 53rd of 2018

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportLast6Weeks.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportLast6Weeks.sql
@@ -19,23 +19,26 @@ BEGIN
 		AND	[Year] = @MinYear
 
 	DECLARE @Cursor DATETIME = (SELECT ISNULL(MAX([Position]), @ReportGenerationTime) FROM [dbo].[Cursors] (NOLOCK) WHERE [Name] = 'GetDirtyPackageId')
-	DECLARE @MaxDate DATE = DATEADD(DAY, 42, @MinDate)
+	DECLARE @MaxDate DATE = DATEADD(DAY, 42, @MinDate);
 
+	WITH WeekLookup AS 
+	(
+		SELECT d.[Id], dd.[WeekOfYear], dd.[Year]
+		FROM [dbo].[Dimension_Date] AS d WITH(NOLOCK)
+		CROSS APPLY
+		(
+			SELECT TOP(1) [WeekOfYear], [Year]
+			FROM [dbo].[Dimension_Date] AS d2 WITH(NOLOCK)
+			WHERE d2.[Date] <= d.[Date] AND d2.[DayOfWeek] = 1
+			ORDER BY d2.[Date] DESC
+		) AS dd
+		WHERE d.[Date] >= @MinDate AND d.[Date] < @MaxDate AND d.[Date] <= @Cursor
+	)
 	SELECT	D.[Year],
 			D.[WeekOfYear],
-			SUM(ISNULL(Facts.[DownloadCount], 0)) 'Downloads'
+			SUM(ISNULL(Facts.[DownloadCount], 0)) AS [Downloads]
 	FROM	[dbo].[Fact_Download] AS Facts (NOLOCK)
-
-	INNER JOIN	[dbo].[Dimension_Date] AS D (NOLOCK)
-	ON			D.[Id] = Facts.[Dimension_Date_Id]
-
-	WHERE	D.[Date] IS NOT NULL
-			AND ISNULL(D.[Date], CONVERT(DATE, '1900-01-01')) >= CAST(@MinDate AS DATE)
-			AND ISNULL(D.[Date], CONVERT(DATE, DATEADD(day, 1, @ReportGenerationTime))) < CAST(@ReportGenerationTime AS DATE)
-			AND Facts.[Timestamp] <= @Cursor
-			AND Facts.[Timestamp] <= @MaxDate
-
-	GROUP BY	D.[Year], D.[WeekOfYear]
-	ORDER BY	[Year], [WeekOfYear]
-
+	INNER JOIN WeekLookup AS D ON D.Id = Facts.Dimension_Date_Id
+	GROUP BY D.[Year], D.[WeekOfYear]
+	ORDER BY [Year], [WeekOfYear]
 END

--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportLast6Weeks.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.DownloadReportLast6Weeks.sql
@@ -23,6 +23,10 @@ BEGIN
 
 	WITH WeekLookup AS 
 	(
+	    -- Around new year we might have an issue where week start and week end have different
+		-- [WeekOfYear] and [Year] values, which cause same week to be represented twice in
+		-- the result set. This CTE makes sure that all days within one week have same
+		-- [WeekOfYear] and [Year] values around new year (taken from the first day of that week).
 		SELECT d.[Id], dd.[WeekOfYear], dd.[Year]
 		FROM [dbo].[Dimension_Date] AS d WITH(NOLOCK)
 		CROSS APPLY


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/6836

### Fix for the `DownloadReportLast6Weeks` sproc

Changed the way `[dbo].[Fact_Download]` is joined to `[dbo].[Dimension_Date]`: instead of direct join, a `WeekLookup` CTE is introduced that limits the date range by itself and corrects the week number for dates around new year. 

In dev new sproc produces the following output:

|Year|WeekOfYear|Downloads
--|--|--
2018|51|762
2018|52|5036
2018|53|3720
2019|2|3437
2019|3|9691
2019|4|2995

Old sproc output:

|Year|WeekOfYear|Downloads|
--|--|--
2018|51|762
2018|52|5036
2018|53|514
2019|1|3206
2019|2|3437
2019|3|9691

### Code fix
Not needed anymore since all is handled in SQL.