### PR TITLE
Add -InstanceName options to JobsRunner

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -15,6 +15,7 @@ namespace NuGet.Jobs
         public const string Sleep = "Sleep";
         public const string Interval = "Interval";
         public const string ReinitializeAfterSeconds = "ReinitializeAfterSeconds";
+        public const string InstanceName = "InstanceName";
 
         public const string WhatIf = "WhatIf";
 

--- a/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
@@ -23,10 +23,9 @@ namespace NuGet.Jobs
         /// Expects the string[] to be set of pairs of argumentName and argumentValue, where, argumentName start with a hyphen
         /// </summary>
         /// <param name="commandLineArgs">Arguments passed to the job via commandline or environment variable settings</param>
-        /// <param name="jobName">Jobname to be used to infer environment variable settings</param>
         /// <param name="secretReaderFactory">Creates a secret reader.</param>
         /// <returns>Returns a dictionary of arguments</returns>
-        public static IDictionary<string, string> GetJobArgsDictionary(IServiceContainer serviceContainer, ILogger logger, string[] commandLineArgs, string jobName)
+        public static IDictionary<string, string> GetJobArgsDictionary(IServiceContainer serviceContainer, ILogger logger, string[] commandLineArgs)
         {
             if (serviceContainer == null)
             {

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -16,7 +16,7 @@ using NuGet.Services.Sql;
 
 namespace NuGet.Jobs
 {
-    using ICoreSqlConnectionFactory = NuGet.Services.Sql.ISqlConnectionFactory;
+    using ICoreSqlConnectionFactory = Services.Sql.ISqlConnectionFactory;
 
     public abstract class JobBase
     {
@@ -29,12 +29,9 @@ namespace NuGet.Jobs
 
         protected JobBase(EventSource jobEventSource)
         {
-            JobName = GetType().ToString();
             _jobEventSource = jobEventSource;
             SqlConnectionFactories = new Dictionary<string, ICoreSqlConnectionFactory>();
         }
-
-        public string JobName { get; private set; }
 
         protected ILoggerFactory LoggerFactory { get; private set; }
 

--- a/src/NuGet.Jobs.Common/JobNameTelemetryInitializer.cs
+++ b/src/NuGet.Jobs.Common/JobNameTelemetryInitializer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace NuGet.Jobs
+{
+    public class JobNameTelemetryInitializer : ITelemetryInitializer
+    {
+        private const string JobNameKey = "JobName";
+        private const string InstanceNameKey = "InstanceName";
+
+        private readonly string _jobName;
+        private readonly string _instanceName;
+
+        public JobNameTelemetryInitializer(string jobName, string instanceName)
+        {
+            _jobName = jobName ?? throw new ArgumentNullException(nameof(jobName));
+            _instanceName = instanceName ?? throw new ArgumentNullException(nameof(instanceName));
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            telemetry.Context.Properties[JobNameKey] = _jobName;
+            telemetry.Context.Properties[InstanceNameKey] = _instanceName;
+        }
+    }
+}

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -75,8 +75,15 @@ namespace NuGet.Jobs
                 _logger.LogInformation("Started...");
 
                 // Get the args passed in or provided as an env variable based on jobName as a dictionary of <string argName, string argValue>
+                var jobArgsDictionary = JobConfigurationManager.GetJobArgsDictionary(
+                    ServiceContainer,
+                    loggerFactory.CreateLogger(typeof(JobConfigurationManager)),
+                    commandLineArgs);
 
-                var jobArgsDictionary = JobConfigurationManager.GetJobArgsDictionary(ServiceContainer, loggerFactory.CreateLogger(typeof(JobConfigurationManager)), commandLineArgs, job.JobName);
+                // Determine job and instance name, for logging.
+                var jobName = job.GetType().Assembly.GetName().Name;
+                var instanceName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstanceName) ?? jobName;
+                TelemetryConfiguration.Active.TelemetryInitializers.Add(new JobNameTelemetryInitializer(jobName, instanceName));
 
                 // Setup logging
                 if (!ApplicationInsights.Initialized)

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Extensions\LoggerExtensions.cs" />
     <Compile Include="Extensions\XElementExtensions.cs" />
     <Compile Include="ISqlConnectionFactory.cs" />
+    <Compile Include="JobNameTelemetryInitializer.cs" />
     <Compile Include="JsonConfigurationJob.cs" />
     <Compile Include="SecretReader\ISecretReaderFactory.cs" />
     <Compile Include="SecretReader\SecretReaderFactory.cs" />

--- a/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.Asia.cmd
+++ b/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.Asia.cmd
@@ -9,7 +9,12 @@ cd bin
 
     title #{Jobs.Asia.search.generateauxiliarydata.Title}
 
-    start /w search.generateauxiliarydata.exe -Configuration "#{Jobs.Asia.search.generateauxiliarydata.Configuration}" -verbose true -Sleep #{Jobs.search.generateauxiliarydata.Sleep} -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
+    start /w search.generateauxiliarydata.exe ^
+        -Configuration "#{Jobs.Asia.search.generateauxiliarydata.Configuration}" ^
+        -InstanceName Search.GenerateAuxillaryData-ea ^
+        -verbose true ^
+        -Sleep #{Jobs.search.generateauxiliarydata.Sleep} ^
+        -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
 
     echo "Finished #{Jobs.Asia.search.generateauxiliarydata.Title}"
 

--- a/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.SouthEastAsia.cmd
+++ b/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.SouthEastAsia.cmd
@@ -9,7 +9,12 @@ cd bin
 
     title #{Jobs.SouthEastAsia.search.generateauxiliarydata.Title}
 
-    start /w search.generateauxiliarydata.exe -Configuration "#{Jobs.SouthEastAsia.search.generateauxiliarydata.Configuration}" -verbose true -Sleep #{Jobs.search.generateauxiliarydata.Sleep} -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
+    start /w search.generateauxiliarydata.exe ^
+        -Configuration "#{Jobs.SouthEastAsia.search.generateauxiliarydata.Configuration}" ^
+        -InstanceName Search.GenerateAuxillaryData-sea ^
+        -verbose true ^
+        -Sleep #{Jobs.search.generateauxiliarydata.Sleep} ^
+        -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
 
     echo "Finished #{Jobs.SouthEastAsia.search.generateauxiliarydata.Title}"
 

--- a/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.USSC.cmd
+++ b/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.USSC.cmd
@@ -9,7 +9,12 @@ cd bin
 
     title #{Jobs.USSC.search.generateauxiliarydata.Title}
 
-    start /w search.generateauxiliarydata.exe -Configuration "#{Jobs.USSC.search.generateauxiliarydata.Configuration}" -verbose true -Sleep #{Jobs.search.generateauxiliarydata.Sleep} -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
+    start /w search.generateauxiliarydata.exe ^
+        -Configuration "#{Jobs.USSC.search.generateauxiliarydata.Configuration}" ^
+        -InstanceName Search.GenerateAuxillaryData-ussc ^
+        -verbose true ^
+        -Sleep #{Jobs.search.generateauxiliarydata.Sleep} ^
+        -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
 
     echo "Finished #{Jobs.USSC.search.generateauxiliarydata.Title}"
 

--- a/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
+++ b/src/Search.GenerateAuxiliaryData/Scripts/Search.GenerateAuxiliaryData.cmd
@@ -1,5 +1,5 @@
 @echo OFF
-	
+
 cd bin
 
 :Top
@@ -7,7 +7,12 @@ cd bin
 
     title #{Jobs.search.generateauxiliarydata.Title}
 
-    start /w search.generateauxiliarydata.exe -Configuration "#{Jobs.search.generateauxiliarydata.Configuration}" -verbose true -Sleep #{Jobs.search.generateauxiliarydata.Sleep} -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
+    start /w search.generateauxiliarydata.exe ^
+        -Configuration "#{Jobs.search.generateauxiliarydata.Configuration}" ^
+        -InstanceName Search.GenerateAuxillaryData-usnc ^
+        -verbose true ^
+        -Sleep #{Jobs.search.generateauxiliarydata.Sleep} ^
+        -InstrumentationKey "#{Jobs.search.generateauxiliarydata.ApplicationInsightsInstrumentationKey}"
 
     echo "Finished #{Jobs.search.generateauxiliarydata.Title}"
 


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/2087

The only job today that has multiple instances per environment is the Search.AuxiliaryData job.

I made this a command line parameter instead of JSON config because a) not all jobs are on JSON config and b) logging is set up before configuration today.