### PR TITLE
 Remove branch name from package ID and pack symbols orchestrator

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -151,7 +151,8 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.csproj", `
             "src/CopyAzureContainer/CopyAzureContainer.csproj", `
             "src/NuGetCDNRedirect/NuGetCDNRedirect.csproj", `
-            "src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj", `
+            "src/NuGet.Services.Validation.Orchestrator/Validation.Orchestrator.nuspec", `
+            "src/NuGet.Services.Validation.Orchestrator/Validation.SymbolsOrchestrator.nuspec", `
             "src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj", `
             "src/Stats.CollectAzureChinaCDNLogs/Stats.CollectAzureChinaCDNLogs.csproj", `
             "src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj", `

--- a/src/ArchivePackages/ArchivePackages.nuspec
+++ b/src/ArchivePackages/ArchivePackages.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>ArchivePackages.$branch$</id>
+    <id>ArchivePackages</id>
     <version>$version$</version>
     <title>ArchivePackages</title>
     <authors>.NET Foundation</authors>

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.nuspec
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Gallery.CredentialExpiration.$branch$</id>
+    <id>Gallery.CredentialExpiration</id>
     <version>$version$</version>
     <title>Gallery.CredentialExpiration</title>
     <authors>.NET Foundation</authors>

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -126,12 +126,20 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="Scripts\Functions.ps1" />
+    <None Include="Scripts\PostDeploy.ps1" />
+    <None Include="Scripts\PreDeploy.ps1" />
+    <None Include="Scripts\RunE2ETests.ps1" />
+    <None Include="Scripts\Validation.Orchestrator.cmd" />
     <None Include="symbolsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Validation.Orchestrator.nuspec" />
+    <None Include="Validation.SymbolsOrchestrator.nuspec" />
+    <None Include="Scripts\nssm.exe" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">

--- a/src/NuGet.Services.Validation.Orchestrator/Scripts/Functions.ps1
+++ b/src/NuGet.Services.Validation.Orchestrator/Scripts/Functions.ps1
@@ -13,13 +13,7 @@ Function Uninstall-NuGetService() {
 }
 
 Function Install-NuGetService() {
-	Param (
-		[string]$ServiceName,
-		[string]$ServiceTitle,
-		[string]$ScriptToRun,
-		[Parameter(Mandatory=$false)][string]$Username,
-		[Parameter(Mandatory=$false)][string]$Password
-	)
+	Param ([string]$ServiceName, [string]$ServiceTitle, [string]$ScriptToRun)
 
 	Write-Host Installing service $ServiceName...
 
@@ -27,12 +21,7 @@ Function Install-NuGetService() {
 	cmd /C $installService
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
-	sc.exe failure $ServiceName reset= 30 actions= restart/5000
-
-	if ($Username) {
-		Write-Host Running service under specific credentials.
-		sc.exe config "$ServiceName" obj= "$Username" password= "$Password"
-	}
+	sc.exe failure $ServiceName reset= 30 actions= restart/5000 
 
 	# Run service
 	net start $ServiceName

--- a/src/NuGet.Services.Validation.Orchestrator/Scripts/PostDeploy.ps1
+++ b/src/NuGet.Services.Validation.Orchestrator/Scripts/PostDeploy.ps1
@@ -9,12 +9,10 @@ $currentDirectory = [string](Get-Location)
 $jobsToInstall.Split("{;}") | %{
 	$serviceName = $_
 	$serviceTitle = $OctopusParameters["Jobs.$serviceName.Title"]
-	$serviceUsername = $OctopusParameters["Jobs.$serviceName.Username"]
-	$servicePassword = $OctopusParameters["Jobs.$serviceName.Password"]
 	$scriptToRun = $OctopusParameters["Jobs.$serviceName.Script"]
 	$scriptToRun = "$currentDirectory\$scriptToRun"
 
-	Install-NuGetService -ServiceName $serviceName -ServiceTitle $serviceTitle -ScriptToRun $scriptToRun -Username $serviceUsername -Password $servicePassword
+	Install-NuGetService -ServiceName $serviceName -ServiceTitle $serviceTitle -ScriptToRun $scriptToRun
 }
 
 Write-Host Installed services.

--- a/src/NuGet.Services.Validation.Orchestrator/Validation.Orchestrator.nuspec
+++ b/src/NuGet.Services.Validation.Orchestrator/Validation.Orchestrator.nuspec
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Validation.Orchestrator.$branch$</id>
+    <id>Validation.SymbolsOrchestrator</id>
     <version>$version$</version>
-    <title>Validation.Orchestrator</title>
+    <title>Validation.SymbolsOrchestrator</title>
     <authors>.NET Foundation</authors>
     <owners>.NET Foundation</owners>
-    <description>Validation.Orchestrator</description>
+    <description>Validation.SymbolsOrchestrator</description>
     <copyright>Copyright .NET Foundation</copyright>
   </metadata>
   <files>

--- a/src/NuGet.Services.Validation.Orchestrator/Validation.SymbolsOrchestrator.nuspec
+++ b/src/NuGet.Services.Validation.Orchestrator/Validation.SymbolsOrchestrator.nuspec
@@ -1,24 +1,22 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Stats.ImportAzureCdnStatistics</id>
+    <id>Validation.Orchestrator</id>
     <version>$version$</version>
-    <title>Stats.ImportAzureCdnStatistics</title>
+    <title>Validation.Orchestrator</title>
     <authors>.NET Foundation</authors>
     <owners>.NET Foundation</owners>
-    <description>Stats.ImportAzureCdnStatistics</description>
+    <description>Validation.Orchestrator</description>
     <copyright>Copyright .NET Foundation</copyright>
   </metadata>
   <files>
     <file src="bin\$configuration$\*.*" target="bin"/>
 	
-    <file src="Scripts\Stats.ImportAzureCdnStatistics.cmd" />
-	
+    <file src="Scripts\Validation.Orchestrator.cmd" />
     <file src="Scripts\Functions.ps1" />
     <file src="Scripts\PreDeploy.ps1" />
     <file src="Scripts\PostDeploy.ps1" />
+    <file src="Scripts\RunE2ETests.ps1" />
     <file src="Scripts\nssm.exe" />
-
-    <file src="Settings\*.json" target="bin" />
   </files>
 </package>

--- a/src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.nuspec
+++ b/src/NuGet.SupportRequests.Notifications/NuGet.SupportRequests.Notifications.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>NuGet.SupportRequests.Notifications.$branch$</id>
+    <id>SupportRequests.Notifications</id>
     <version>$version$</version>
     <title>NuGet.SupportRequests.Notifications</title>
     <authors>.NET Foundation</authors>

--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
@@ -214,6 +214,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Connected Services\Application Insights\ConnectedService.json" />
+    <None Include="NuGetCDNRedirect.nuspec" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.nuspec
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>NuGetCDNRedirect.$branch$</id>
+    <id>NuGetCDNRedirect</id>
     <version>$version$</version>
     <title>NuGetCDNRedirect</title>
     <authors>.NET Foundation</authors>

--- a/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.nuspec
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Stats.AggregateCdnDownloadsInGallery.$branch$</id>
+    <id>Stats.AggregateCdnDownloadsInGallery</id>
     <version>$version$</version>
     <title>Stats.AggregateCdnDownloadsInGallery</title>
     <authors>.NET Foundation</authors>

--- a/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.nuspec
+++ b/src/Stats.CollectAzureCdnLogs/Stats.CollectAzureCdnLogs.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Stats.CollectAzureCdnLogs.$branch$</id>
+    <id>Stats.CollectAzureCdnLogs</id>
     <version>$version$</version>
     <title>Stats.CollectAzureCdnLogs</title>
     <authors>.NET Foundation</authors>

--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.nuspec
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Stats.CreateAzureCdnWarehouseReports.$branch$</id>
+    <id>Stats.CreateAzureCdnWarehouseReports</id>
     <version>$version$</version>
     <title>Stats.CreateAzureCdnWarehouseReports</title>
     <authors>.NET Foundation</authors>

--- a/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.nuspec
+++ b/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Stats.RollUpDownloadFacts.$branch$</id>
+    <id>Stats.RollUpDownloadFacts</id>
     <version>$version$</version>
     <title>Stats.RollUpDownloadFacts</title>
     <authors>.NET Foundation</authors>

--- a/src/StatusAggregator/StatusAggregator.nuspec
+++ b/src/StatusAggregator/StatusAggregator.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>StatusAggregator.$branch$</id>
+    <id>StatusAggregator</id>
     <version>$version$</version>
     <title>ArchivePackages</title>
     <authors>.NET Foundation</authors>

--- a/src/UpdateLicenseReports/UpdateLicenseReports.nuspec
+++ b/src/UpdateLicenseReports/UpdateLicenseReports.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>UpdateLicenseReports.$branch$</id>
+    <id>UpdateLicenseReports</id>
     <version>$version$</version>
     <title>UpdateLicenseReports</title>
     <authors>.NET Foundation</authors>

--- a/src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj
+++ b/src/Validation.PackageSigning.ProcessSignature/Validation.PackageSigning.ProcessSignature.csproj
@@ -66,6 +66,7 @@
     <None Include="App.config" />
     <None Include="Scripts\*" />
     <None Include="Settings\*" />
+    <None Include="Validation.PackageSigning.ProcessSignature.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
@@ -102,7 +103,7 @@
   <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
   <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <ItemGroup>
-    <PowerShellScriptsToSign Include="RunE2ETests.ps1"/>
+    <PowerShellScriptsToSign Include="RunE2ETests.ps1" />
   </ItemGroup>
   <Import Project="$(SignPath)\sign.scripts.targets" Condition="Exists('$(SignPath)\sign.scripts.targets')" />
   <Import Project="..\..\sign.thirdparty.targets" />


### PR DESCRIPTION
In Ev2, the package name related to the Ev2 configuration name. The convention is that it is the same string. This means that the branch name (most of these cases) or environment/instance (orchestrator and symbols orchestrator) can't be part of the package ID. We pack symbols orchestrator and orchestrator separately because from the deployment side we see these as different services that just happen to share bits.

For the cases where I removed `$branch$`, I need to update the Octopus configuration.

Progress on https://github.com/NuGet/Engineering/issues/2117.