### PR TITLE
Change the name of the Validation.Symbols to Validation.Symbols.Job.

### DIFF
--- a/NuGet.Jobs.sln
+++ b/NuGet.Jobs.sln
@@ -133,7 +133,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monitoring.RebootSearchInst
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Monitoring.RebootSearchInstance.Tests", "tests\Monitoring.RebootSearchInstance.Tests\Monitoring.RebootSearchInstance.Tests.csproj", "{21C0A0EE-8696-4013-950F-D6495D0C6E40}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Symbols", "src\Validation.Symbols\Validation.Symbols.csproj", "{2DD07A73-8C88-4429-BB24-C2813586EF92}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Symbols.Job", "src\Validation.Symbols\Validation.Symbols.Job.csproj", "{2DD07A73-8C88-4429-BB24-C2813586EF92}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validation.Symbols.Tests", "tests\Validation.Symbols.Tests\Validation.Symbols.Tests.csproj", "{640D29AB-4D1B-4FC7-AE67-AD12EE5AC503}"
 EndProject

--- a/build.ps1
+++ b/build.ps1
@@ -162,7 +162,7 @@ Invoke-BuildStep 'Creating artifacts' {
             "src/Monitoring.RebootSearchInstance/Monitoring.RebootSearchInstance.csproj", `
             "src/StatusAggregator/StatusAggregator.csproj", `
             "src/Validation.Symbols.Core/Validation.Symbols.Core.csproj", `
-            "src/Validation.Symbols/Validation.Symbols.csproj"
+            "src/Validation.Symbols/Validation.Symbols.Job.csproj"
 
         Foreach ($Project in $NuspecProjects) {
             New-Package (Join-Path $PSScriptRoot "$Project") -Configuration $Configuration -BuildNumber $BuildNumber -Version $SemanticVersion -Branch $Branch -MSBuildVersion "$msBuildVersion"

--- a/src/Validation.Symbols/Scripts/Validation.SymbolValidation.cmd
+++ b/src/Validation.Symbols/Scripts/Validation.SymbolValidation.cmd
@@ -7,7 +7,7 @@ echo "Starting job - #{Jobs.Validation.Symbols.Title}"
 
 title #{Jobs.Validation.Symbols.Title}
 
-start /w Validation.Symbols.exe ^
+start /w Validation.Symbols.Job.exe ^
     -Configuration #{Jobs.validation.SymbolValidation.Configuration} ^
     -InstrumentationKey "#{Jobs.validation.SymbolValidation.InstrumentationKey}"
 

--- a/src/Validation.Symbols/Validation.Symbols.Job.csproj
+++ b/src/Validation.Symbols/Validation.Symbols.Job.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{2DD07A73-8C88-4429-BB24-C2813586EF92}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>Validation.Symbols</RootNamespace>
-    <AssemblyName>Validation.Symbols</AssemblyName>
+    <AssemblyName>Validation.Symbols.Job</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -65,7 +65,9 @@
     <None Include="Settings\dev.json" />
     <None Include="Settings\int.json" />
     <None Include="Settings\prod.json" />
-    <None Include="Validation.Symbols.nuspec" />
+    <None Include="Validation.Symbols.Job.nuspec">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">

--- a/src/Validation.Symbols/Validation.Symbols.Job.nuspec
+++ b/src/Validation.Symbols/Validation.Symbols.Job.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Validation.Symbols</id>
+    <id>Validation.Symbols.Job</id>
     <version>$version$</version>
     <title>Validation.Symbols</title>
     <authors>.NET Foundation</authors>

--- a/tests/Validation.Symbols.Tests/Validation.Symbols.Tests.csproj
+++ b/tests/Validation.Symbols.Tests/Validation.Symbols.Tests.csproj
@@ -77,9 +77,9 @@
       <Project>{17510a22-176f-4e96-a867-e79f1b54f54f}</Project>
       <Name>Validation.Symbols.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Validation.Symbols\Validation.Symbols.csproj">
+    <ProjectReference Include="..\..\src\Validation.Symbols\Validation.Symbols.Job.csproj">
       <Project>{2dd07a73-8c88-4429-bb24-c2813586ef92}</Project>
-      <Name>Validation.Symbols</Name>
+      <Name>Validation.Symbols.Job</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Change the name of the Validation.Symbols to Validation.Symbols.Job to better support the Ev2 deployment. 