### PR TITLE
AggregateStatsDownloads improvements

### DIFF
--- a/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
@@ -52,7 +52,7 @@ namespace Stats.AggregateCdnDownloadsInGallery
                 SELECT Stats.[PackageRegistrationKey] AS [PackageRegistrationKey], SUM(Stats.[DownloadCount]) AS [DownloadCount]
                 FROM #AggregateCdnDownloadsInGallery AS Stats
                 GROUP BY Stats.[PackageRegistrationKey]
-            ) AS AggregateStats ON AggregateStats.[PackageRegistrationKey] = PR.[Key] 
+            ) AS AggregateStats ON AggregateStats.[PackageRegistrationKey] = PR.[Key]
 
             -- No more need for temp table
             DROP TABLE #AggregateCdnDownloadsInGallery";

--- a/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/AggregateCdnDownloadsJob.cs
@@ -179,8 +179,12 @@ namespace Stats.AggregateCdnDownloadsInGallery
 
             foreach (var packageRegistrationGroup in batch)
             {
-                // If not all the elements in a group have the same PackageId something is wrong.
-                // Data will not be ingested.
+                // The packageRegistrationGroup is created with data from Statistics db and grouped based on packageId.
+                // Each group has a key that is the packageId and has a list of packages that are the versions for the packageId that is the key.
+                // Using the packageId the packageRegistration key is found - see  packageRegistrationData = packageRegistrationLookup[packageId];
+                // Using this package registation key the data in the temp table is populated - see: row["PackageRegistrationKey"] = packageRegistrationData.Key;
+                // If not all the elements in a group have the same PackageId that will lead to have data from packageId2 version:1.0.0 to be ingested as data for packageId1: version:1.0.0
+                // In this case data will not be ingested.
                 if (packageRegistrationGroup.Select(g => g.PackageId).Distinct().Count() == 1)
                 {
                     var packageId = packageRegistrationGroup.Key.ToLowerInvariant();

--- a/src/Stats.AggregateCdnDownloadsInGallery/LogEvents.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/LogEvents.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Stats.AggregateCdnDownloadsInGallery
+{
+    public static class LogEvents
+    {
+        public static EventId IncorrectIdsInGroupBatch = new EventId(900, "The group batch to be ingested contains multiple package Ids.");
+        public static EventId DownloadCountDecreaseDetected = new EventId(901, "The download count for the package is decreasing.");
+
+    }
+}

--- a/src/Stats.AggregateCdnDownloadsInGallery/PackageRegistrationData.cs
+++ b/src/Stats.AggregateCdnDownloadsInGallery/PackageRegistrationData.cs
@@ -8,5 +8,6 @@ namespace Stats.AggregateCdnDownloadsInGallery
         public string Key { get; set; }
         public string LowercasedId { get; set; }
         public string OriginalId { get; set; }
+        public string DownloadCount { get; set; }
     }
 }

--- a/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Stats.AggregateCdnDownloadsInGallery.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Configuration\AggregateCdnDownloadsConfiguration.cs" />
     <Compile Include="DownloadCountData.cs" />
     <Compile Include="AggregateCdnDownloadsJob.cs" />
+    <Compile Include="LogEvents.cs" />
     <Compile Include="PackageRegistrationData.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR has 2 changes:
1. If the stats data for a package has less downloads than what is currently published - do not update the current data.
2. Added more telemetry. 