### PR TITLE
Remove direct dependency on Microsoft.Extensions.Logging 

### DIFF
--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,9 +67,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>1.0.0</Version>
-    </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-master-39280</Version>
     </PackageReference>


### PR DESCRIPTION
Remove direct dependency on Microsoft.Extensions.Logging - use package ref.