### PR TITLE
More data with telemetry

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/EntityStatusProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/EntityStatusProcessor.cs
@@ -85,7 +85,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
             if (fromStatus != PackageStatus.FailedValidation)
             {
-                _telemetryService.TrackPackageStatusChange(fromStatus, PackageStatus.FailedValidation);
+                _telemetryService.TrackPackageStatusChange(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, fromStatus, PackageStatus.FailedValidation);
             }
         }
 
@@ -109,7 +109,7 @@ namespace NuGet.Services.Validation.Orchestrator
             // 5) Emit telemetry and clean up.
             if (fromStatus != PackageStatus.Available)
             {
-                _telemetryService.TrackPackageStatusChange(fromStatus, PackageStatus.Available);
+                _telemetryService.TrackPackageStatusChange(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, fromStatus, PackageStatus.Available);
 
                 _logger.LogInformation("Deleting from the source for package {PackageId} {PackageVersion}, validation set {ValidationSetId}",
                     validationSet.PackageId,

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/BaseSignatureProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/BaseSignatureProcessor.cs
@@ -87,7 +87,7 @@ namespace NuGet.Services.Validation.PackageSigning.ProcessSignature
 
             // Kick off the verification process. Note that the jobs will not verify the package until the
             // state of this validator has been persisted to the database.
-            using (_telemetryService.TrackDurationToStartPackageSigningValidator())
+            using (_telemetryService.TrackDurationToStartPackageSigningValidator(request.PackageId, request.PackageVersion))
             {
                 await _signatureVerificationEnqueuer.EnqueueProcessSignatureAsync(request, RequiresRepositorySignature);
 

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/PackageCertificatesValidator.cs
@@ -201,7 +201,7 @@ namespace NuGet.Services.Validation.PackageSigning.ValidateCertificate
 
             if (certificates.Any())
             {
-                using (_telemetryService.TrackDurationToStartPackageCertificatesValidator())
+                using (_telemetryService.TrackDurationToStartPackageCertificatesValidator(request.PackageId, request.PackageVersion))
                 {
                     await StartCertificateValidationsAsync(request, certificates);
 

--- a/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolsIngester.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolsIngester.cs
@@ -78,7 +78,7 @@ namespace NuGet.Services.Validation.Symbols
                 return result;
             }
 
-            _telemetryService.TrackSymbolsMessageEnqueued(ValidatorName.SymbolsIngester, request.ValidationId);
+            _telemetryService.TrackSymbolsMessageEnqueued(request.PackageId, request.PackageVersion, ValidatorName.SymbolsIngester, request.ValidationId);
             var message = await _symbolMessageEnqueuer.EnqueueSymbolsIngestionMessageAsync(request);
 
             var newSymbolsRequest = SymbolsValidationEntitiesService.CreateFromValidationRequest(request, SymbolsPackageIngestRequestStatus.Ingesting, message.RequestName);

--- a/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolsValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolsValidator.cs
@@ -84,7 +84,7 @@ namespace NuGet.Services.Validation.Symbols
 
             // Due to race conditions or failure of method TryAddValidatorStatusAsync the same message can be enqueued multiple times
             // Log this information to postmortem evaluate this behavior
-            _telemetryService.TrackSymbolsMessageEnqueued(ValidatorName.SymbolsValidator, request.ValidationId);
+            _telemetryService.TrackSymbolsMessageEnqueued(request.PackageId, request.PackageVersion, ValidatorName.SymbolsValidator, request.ValidationId);
             await _symbolMessageEnqueuer.EnqueueSymbolsValidationMessageAsync(request);
 
             var result = await _validatorStateService.TryAddValidatorStatusAsync(request, validatorStatus, ValidationStatus.Incomplete);

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -28,6 +28,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// A counter metric emitted when a package changes package status. This metric is not emitted if package status
         /// does not change. This metric is emitted for revalidation if the terminal state changes.
         /// </summary>
+        /// <param name="packageId">Id of the package that changed status.</param>
+        /// <param name="normalizedVersion">Normalized version of the package that changed status.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID in scope of which change occurred.</param>
         /// <param name="fromStatus">The status that the package moved from.</param>
         /// <param name="toStatus">The status that the package moved to.</param>
         void TrackPackageStatusChange(string packageId, string normalizedVersion, Guid validationTrackingId, PackageStatus fromStatus, PackageStatus toStatus);
@@ -36,6 +39,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// The total duration of all validators. This is the time that the validation set is first created until all of
         /// the validators have completed. This metric is also emitted for revalidations.
         /// </summary>
+        /// <param name="packageId">Id of the package which was being validated.</param>
+        /// <param name="normalizedVersion">Normalized version of the package which was being validated.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID for which the duration was reported.</param>
         /// <param name="duration">The duration.</param>
         /// <param name="isSuccess">Whether or not all of the validations succeeded.</param>
         void TrackTotalValidationDuration(string packageId, string normalizedVersion, Guid validationTrackingId, TimeSpan duration, bool isSuccess);
@@ -54,6 +60,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// A counter metric emitted when a validation is past its validator's <see cref="ValidationConfigurationItem.TrackAfter"/>
         /// configuration.
         /// </summary>
+        /// <param name="packageId">Id of the package for which validator is running too long.</param>
+        /// <param name="normalizedVersion">Normalized version of the package for which validator is running too long.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID in scope of which validator that timed out runs.</param>
         /// <param name="validatorType">The validator type (name).</param>
         void TrackValidatorTimeout(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType);
 
@@ -61,6 +70,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// The total duration of a single validator. This is the time from when the validation is first started until
         /// when the validation either completes or times out.
         /// </summary>
+        /// <param name="packageId">Id of the package which was being validated.</param>
+        /// <param name="normalizedVersion">Normalized version of the package which was being validated.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID in scope of which validator had run.</param>
         /// <param name="duration">The duration.</param>
         /// <param name="validatorType">The validator type (name).</param>
         /// <param name="isSuccess">Whether or not the validation succeeded.</param>
@@ -69,6 +81,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <summary>
         /// A counter metric emitted when a validator is started.
         /// </summary>
+        /// <param name="packageId">Id of the package that is being validated.</param>
+        /// <param name="normalizedVersion">Normalized version of the package that is being validated.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID in scope of which validator runs.</param>
         /// <param name="validatorType">The validator type (name).</param>
         void TrackValidatorStarted(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType);
 
@@ -88,6 +103,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// issues. A count of zero is emitted if the validator does not produce any issues. This metric is not emitted
         /// if the validation is still at a non-terminal state.
         /// </summary>
+        /// <param name="packageId">Id of the package for which issues were reported.</param>
+        /// <param name="normalizedVersion">Normalized version of the package for which issues were reported.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID in scope of which validator had run.</param>
         /// <param name="count">The number of issues.</param>
         /// <param name="validatorType">The validator type (name) that returned the issue list.</param>
         /// <param name="isSuccess">Whether or not the validation succeeded.</param>
@@ -96,6 +114,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <summary>
         /// A counter metric emitted when a validation issue is created.
         /// </summary>
+        /// <param name="packageId">Id of the package for which issue is reported.</param>
+        /// <param name="normalizedVersion">Normalized version of the package for which issue is reported.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID in scope of which validator had run.</param>
         /// <param name="validatorType">The validator type (name) the produced the issue.</param>
         /// <param name="code">The issue code.</param>
         void TrackValidationIssue(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType, ValidationIssueCode code);
@@ -103,6 +124,9 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <summary>
         /// A counter metric emitted when a client-mastered validation issue is emitted.
         /// </summary>
+        /// <param name="packageId">Id of the package for which issue is reported.</param>
+        /// <param name="normalizedVersion">Normalized version of the package for which issue is reported.</param>
+        /// <param name="validationTrackingId">Validation set tracking ID in scope of which validator had run.</param>
         /// <param name="validatorType">The validator type (name) the produced the issue.</param>
         /// <param name="clientCode">The client code.</param>
         void TrackClientValidationIssue(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType, string clientCode);
@@ -128,6 +152,8 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <summary>
         /// A metric to track the messages sent from Orchestrator to Validators and enqueued by validators. Ideally the messages should not duplicate.
         /// </summary>
+        /// <param name="packageId">Id of the package for which message is sent.</param>
+        /// <param name="normalizedVersion">Normalized version of the package for which message is sent.</param>
         /// <param name="validatorName">The validator name the message was sent to.</param>
         /// <param name="validationId">The validationId.</param>
         void TrackSymbolsMessageEnqueued(string packageId, string normalizedVersion, string validatorName, Guid validationId);

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -15,7 +15,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// The duration from when the package was created to when the first validation set was created. This metric
         /// is not emitted for revalidation requests.
         /// </summary>
-        void TrackDurationToValidationSetCreation(TimeSpan duration);
+        void TrackDurationToValidationSetCreation(string packageId, string normalizedVersion, Guid validationTrackingId, TimeSpan duration);
 
         /// <summary>
         /// Track how long a package's backup takes.
@@ -30,7 +30,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// </summary>
         /// <param name="fromStatus">The status that the package moved from.</param>
         /// <param name="toStatus">The status that the package moved to.</param>
-        void TrackPackageStatusChange(PackageStatus fromStatus, PackageStatus toStatus);
+        void TrackPackageStatusChange(string packageId, string normalizedVersion, Guid validationTrackingId, PackageStatus fromStatus, PackageStatus toStatus);
 
         /// <summary>
         /// The total duration of all validators. This is the time that the validation set is first created until all of
@@ -38,7 +38,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// </summary>
         /// <param name="duration">The duration.</param>
         /// <param name="isSuccess">Whether or not all of the validations succeeded.</param>
-        void TrackTotalValidationDuration(TimeSpan duration, bool isSuccess);
+        void TrackTotalValidationDuration(string packageId, string normalizedVersion, Guid validationTrackingId, TimeSpan duration, bool isSuccess);
 
         /// <summary>
         /// A counter metric emitted when a notification is sent because a validation set takes too long.
@@ -55,7 +55,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// configuration.
         /// </summary>
         /// <param name="validatorType">The validator type (name).</param>
-        void TrackValidatorTimeout(string validatorType);
+        void TrackValidatorTimeout(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType);
 
         /// <summary>
         /// The total duration of a single validator. This is the time from when the validation is first started until
@@ -64,24 +64,24 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <param name="duration">The duration.</param>
         /// <param name="validatorType">The validator type (name).</param>
         /// <param name="isSuccess">Whether or not the validation succeeded.</param>
-        void TrackValidatorDuration(TimeSpan duration, string validatorType, bool isSuccess);
+        void TrackValidatorDuration(string packageId, string normalizedVersion, Guid validationTrackingId, TimeSpan duration, string validatorType, bool isSuccess);
 
         /// <summary>
         /// A counter metric emitted when a validator is started.
         /// </summary>
         /// <param name="validatorType">The validator type (name).</param>
-        void TrackValidatorStarted(string validatorType);
+        void TrackValidatorStarted(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType);
 
         /// <summary>
         /// The duration to start the package signing validator. This includes both the enqueue and DB commit time.
         /// </summary>
-        IDisposable TrackDurationToStartPackageSigningValidator();
+        IDisposable TrackDurationToStartPackageSigningValidator(string packageId, string normalizedVersion);
 
         /// <summary>
         /// The duration to start the package certificates validator. This includes all enqueue times and the DB commit
         /// time.
         /// </summary>
-        IDisposable TrackDurationToStartPackageCertificatesValidator();
+        IDisposable TrackDurationToStartPackageCertificatesValidator(string packageId, string normalizedVersion);
 
         /// <summary>
         /// A counter metric emmitted when a validator reaches a terminal state and potentially persists validation
@@ -91,21 +91,21 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <param name="count">The number of issues.</param>
         /// <param name="validatorType">The validator type (name) that returned the issue list.</param>
         /// <param name="isSuccess">Whether or not the validation succeeded.</param>
-        void TrackValidationIssueCount(int count, string validatorType, bool isSuccess);
+        void TrackValidationIssueCount(string packageId, string normalizedVersion, Guid validationTrackingId, int count, string validatorType, bool isSuccess);
 
         /// <summary>
         /// A counter metric emitted when a validation issue is created.
         /// </summary>
         /// <param name="validatorType">The validator type (name) the produced the issue.</param>
         /// <param name="code">The issue code.</param>
-        void TrackValidationIssue(string validatorType, ValidationIssueCode code);
+        void TrackValidationIssue(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType, ValidationIssueCode code);
 
         /// <summary>
         /// A counter metric emitted when a client-mastered validation issue is emitted.
         /// </summary>
         /// <param name="validatorType">The validator type (name) the produced the issue.</param>
         /// <param name="clientCode">The client code.</param>
-        void TrackClientValidationIssue(string validatorType, string clientCode);
+        void TrackClientValidationIssue(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType, string clientCode);
 
         /// <summary>
         /// A counter metric emitted when the orchestrator is requested to validate a package,
@@ -123,14 +123,14 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <summary>
         /// A metric to of how long it took to hash a package.
         /// </summary>
-        IDisposable TrackDurationToHashPackage(string packageId, string normalizedVersion, long packageSize, string hashAlgorithm, string streamType);
+        IDisposable TrackDurationToHashPackage(string packageId, string normalizedVersion, Guid validationTrackingId, long packageSize, string hashAlgorithm, string streamType);
 
         /// <summary>
         /// A metric to track the messages sent from Orchestrator to Validators and enqueued by validators. Ideally the messages should not duplicate.
         /// </summary>
         /// <param name="validatorName">The validator name the message was sent to.</param>
         /// <param name="validationId">The validationId.</param>
-        void TrackSymbolsMessageEnqueued(string validatorName, Guid validationId);
+        void TrackSymbolsMessageEnqueued(string packageId, string normalizedVersion, string validatorName, Guid validationId);
 
         /// <summary>
         /// A metric to track duration of the license file extraction.

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -69,6 +69,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         public IDisposable TrackDurationToHashPackage(
             string packageId,
             string normalizedVersion,
+            Guid validationTrackingId,
             long packageSize,
             string hashAlgorithm,
             string streamType)
@@ -79,17 +80,24 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                 {
                     { PackageId, packageId },
                     { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { PackageSize, packageSize.ToString() },
                     { HashAlgorithm, hashAlgorithm },
                     { StreamType, streamType },
                 });
         }
 
-        public void TrackDurationToValidationSetCreation(TimeSpan duration)
+        public void TrackDurationToValidationSetCreation(string packageId, string normalizedVersion, Guid validationTrackingId, TimeSpan duration)
         {
             _telemetryClient.TrackMetric(
                 DurationToValidationSetCreationSeconds,
-                duration.TotalSeconds);
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
+                });
         }
 
         public IDisposable TrackDurationToBackupPackage(PackageValidationSet validationSet)
@@ -104,25 +112,31 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                 });
         }
 
-        public void TrackPackageStatusChange(PackageStatus fromStatus, PackageStatus toStatus)
+        public void TrackPackageStatusChange(string packageId, string normalizedVersion, Guid validationTrackingId, PackageStatus fromStatus, PackageStatus toStatus)
         {
             _telemetryClient.TrackMetric(
                 PackageStatusChange,
                 1,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { FromStatus, fromStatus.ToString() },
                     { ToStatus, toStatus.ToString() },
                 });
         }
 
-        public void TrackTotalValidationDuration(TimeSpan duration, bool isSuccess)
+        public void TrackTotalValidationDuration(string packageId, string normalizedVersion, Guid validationTrackingId, TimeSpan duration, bool isSuccess)
         {
             _telemetryClient.TrackMetric(
                 TotalValidationDurationSeconds,
                 duration.TotalSeconds,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { IsSuccess, isSuccess.ToString() },
                 });
         }
@@ -149,71 +163,89 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                         { ValidationTrackingId, validationTrackingId.ToString() },
                     });
 
-        public void TrackValidationIssue(string validatorType, ValidationIssueCode code)
+        public void TrackValidationIssue(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType, ValidationIssueCode code)
         {
             _telemetryClient.TrackMetric(
                 ValidationIssue,
                 1,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { ValidatorType, validatorType },
                     { IssueCode, code.ToString() },
                 });
         }
 
-        public void TrackValidationIssueCount(int count, string validatorType, bool isSuccess)
+        public void TrackValidationIssueCount(string packageId, string normalizedVersion, Guid validationTrackingId, int count, string validatorType, bool isSuccess)
         {
             _telemetryClient.TrackMetric(
                 ValidationIssueCount,
                 count,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { ValidatorType, validatorType },
                     { IsSuccess, isSuccess.ToString() },
                 });
         }
 
-        public void TrackValidatorTimeout(string validatorType)
+        public void TrackValidatorTimeout(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType)
         {
             _telemetryClient.TrackMetric(
                 ValidatorTimeout,
                 1,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { ValidatorType, validatorType },
                 });
         }
 
-        public void TrackValidatorDuration(TimeSpan duration, string validatorType, bool isSuccess)
+        public void TrackValidatorDuration(string packageId, string normalizedVersion, Guid validationTrackingId, TimeSpan duration, string validatorType, bool isSuccess)
         {
             _telemetryClient.TrackMetric(
                 ValidatorDurationSeconds,
                 duration.TotalSeconds,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { ValidatorType, validatorType },
                     { IsSuccess, isSuccess.ToString() },
                 });
         }
 
-        public void TrackValidatorStarted(string validatorType)
+        public void TrackValidatorStarted(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType)
         {
             _telemetryClient.TrackMetric(
                 ValidatorStarted,
                 1,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { ValidatorType, validatorType },
                 });
         }
 
-        public void TrackClientValidationIssue(string validatorType, string clientCode)
+        public void TrackClientValidationIssue(string packageId, string normalizedVersion, Guid validationTrackingId, string validatorType, string clientCode)
         {
             _telemetryClient.TrackMetric(
                 ClientValidationIssue,
                 1,
                 new Dictionary<string, string>
                 {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId.ToString() },
                     { ValidatorType, validatorType },
                     { ClientCode, clientCode },
                 });
@@ -241,11 +273,23 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                         { ValidationTrackingId, validationTrackingId },
                     });
 
-        public IDisposable TrackDurationToStartPackageSigningValidator()
-            => _telemetryClient.TrackDuration(DurationToStartPackageSigningValidatorSeconds);
+        public IDisposable TrackDurationToStartPackageSigningValidator(string packageId, string normalizedVersion)
+            => _telemetryClient.TrackDuration(
+                DurationToStartPackageSigningValidatorSeconds,
+                new Dictionary<string, string>
+                {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                });
 
-        public IDisposable TrackDurationToStartPackageCertificatesValidator()
-            => _telemetryClient.TrackDuration(DurationToStartPackageCertificatesValidatorSeconds);
+        public IDisposable TrackDurationToStartPackageCertificatesValidator(string packageId, string normalizedVersion)
+            => _telemetryClient.TrackDuration(
+                DurationToStartPackageCertificatesValidatorSeconds,
+                new Dictionary<string, string>
+                {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                });
 
         public void TrackMessageDeliveryLag<TMessage>(TimeSpan deliveryLag)
             => _telemetryClient.TrackMetric(
@@ -290,15 +334,17 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                     { MessageType, typeof(TMessage).Name }
                 });
 
-        public void TrackSymbolsMessageEnqueued(string validatorName, Guid validationId)
-           => _telemetryClient.TrackMetric(
-               SymbolsMessageEnqueued,
-               1,
-               new Dictionary<string, string>
-               {
-                   { ValidatorType, validatorName },
-                   { ValidationId, validationId.ToString()}
-               });
+        public void TrackSymbolsMessageEnqueued(string packageId, string normalizedVersion, string validatorName, Guid validationId)
+            => _telemetryClient.TrackMetric(
+                SymbolsMessageEnqueued,
+                1,
+                new Dictionary<string, string>
+                {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidatorType, validatorName },
+                    { ValidationId, validationId.ToString()}
+                });
 
         public IDisposable TrackDurationToExtractLicenseFile(string packageId, string normalizedVersion, string validationTrackingId)
             => _telemetryClient.TrackDuration(ExtractLicenseFileDuration,

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
@@ -158,6 +158,9 @@ namespace NuGet.Services.Validation.Orchestrator
         private void TrackTotalValidationDuration(PackageValidationSet validationSet, bool isSuccess)
         {
             _telemetryService.TrackTotalValidationDuration(
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion,
+                validationSet.ValidationTrackingId,
                 DateTime.UtcNow - validationSet.Created,
                 isSuccess);
         }
@@ -250,7 +253,7 @@ namespace NuGet.Services.Validation.Orchestrator
                         validationSet.PackageNormalizedVersion,
                         duration);
 
-                    _telemetryService.TrackValidatorTimeout(validation.Type);
+                    _telemetryService.TrackValidatorTimeout(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, validation.Type);
                 }
             }
 

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
@@ -272,6 +272,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     using (_telemetryService.TrackDurationToHashPackage(
                         validationSet.PackageId,
                         validationSet.PackageNormalizedVersion,
+                        validationSet.ValidationTrackingId,
                         packageStream.Length,
                         CoreConstants.Sha512HashAlgorithmId,
                         packageStream.GetType().FullName))

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
@@ -238,7 +238,7 @@ namespace NuGet.Services.Validation.Orchestrator
                             await validator.CleanUpAsync(validationRequest);
                         }
 
-                        _telemetryService.TrackValidatorStarted(packageValidation.Type);
+                        _telemetryService.TrackValidatorStarted(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, packageValidation.Type);
 
                         if (validationResult.Status == ValidationStatus.Succeeded)
                         {

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
@@ -123,7 +123,7 @@ namespace NuGet.Services.Validation.Orchestrator
             // case.
             if (await _validationStorageService.GetValidationSetCountAsync(validatingEntity) == 1)
             {
-                _telemetryService.TrackDurationToValidationSetCreation(validationSet.Created - validatingEntity.Created);
+                _telemetryService.TrackDurationToValidationSetCreation(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, validationSet.Created - validatingEntity.Created);
             }
 
             return persistedValidationSet;

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationStorageService.cs
@@ -177,26 +177,34 @@ namespace NuGet.Services.Validation.Orchestrator
                 validatorDuration = packageValidation.ValidationStatusTimestamp - packageValidation.Started.Value;
             }
 
+            var validationSet = packageValidation.PackageValidationSet;
+
             _telemetryService.TrackValidatorDuration(
-               validatorDuration,
-               packageValidation.Type,
-               isSuccess);
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion,
+                validationSet.ValidationTrackingId,
+                validatorDuration,
+                packageValidation.Type,
+                isSuccess);
 
             var issues = (packageValidation.PackageValidationIssues ?? Enumerable.Empty<PackageValidationIssue>()).ToList();
             _telemetryService.TrackValidationIssueCount(
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion,
+                validationSet.ValidationTrackingId,
                 issues.Count,
                 packageValidation.Type,
                 isSuccess);
 
             foreach (var issue in issues)
             {
-                _telemetryService.TrackValidationIssue(packageValidation.Type, issue.IssueCode);
+                _telemetryService.TrackValidationIssue(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, packageValidation.Type, issue.IssueCode);
 
                 var deserializedIssue = ValidationIssue.Deserialize(issue.IssueCode, issue.Data);
                 if (issue.IssueCode == ValidationIssueCode.ClientSigningVerificationFailure
                     && deserializedIssue is ClientSigningVerificationFailure typedIssue)
                 {
-                    _telemetryService.TrackClientValidationIssue(packageValidation.Type, typedIssue.ClientCode);
+                    _telemetryService.TrackClientValidationIssue(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, packageValidation.Type, typedIssue.ClientCode);
                 }
             }
         }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureProcessorFacts.cs
@@ -144,7 +144,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     .Verify(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
 
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageSigningValidator(),
+                    x => x.TrackDurationToStartPackageSigningValidator(It.IsAny<string>(), It.IsAny<string>()),
                     Times.Never);
             }
 
@@ -206,7 +206,7 @@ namespace NuGet.Services.Validation.PackageSigning
                         Times.Once);
 
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageSigningValidator(),
+                    x => x.TrackDurationToStartPackageSigningValidator(It.IsAny<string>(), It.IsAny<string>()),
                     Times.Once);
 
                 Assert.True(verificationQueuedBeforeStatePersisted);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ProcessSignature/PackageSignatureValidatorFacts.cs
@@ -194,7 +194,7 @@ namespace NuGet.Services.Validation.PackageSigning
                     .Verify(x => x.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
 
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageSigningValidator(),
+                    x => x.TrackDurationToStartPackageSigningValidator(It.IsAny<string>(), It.IsAny<string>()),
                     Times.Never);
             }
 
@@ -260,7 +260,7 @@ namespace NuGet.Services.Validation.PackageSigning
                         Times.Once);
 
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageSigningValidator(),
+                    x => x.TrackDurationToStartPackageSigningValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Once);
 
                 Assert.True(verificationQueuedBeforeStatePersisted);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageSigning/ValidateCertificate/PackageCertificatesValidatorFacts.cs
@@ -633,7 +633,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Never);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Never);
 
                 Assert.Equal(status, actual.Status);
@@ -670,7 +670,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
@@ -716,7 +716,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
@@ -799,7 +799,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);
@@ -880,7 +880,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Exactly(2));
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
@@ -964,7 +964,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Once);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
@@ -1046,7 +1046,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Failed, actual.Status);
@@ -1212,7 +1212,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Exactly(expectedCertificateValidations));
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Once);
 
                 Assert.Equal(ValidationStatus.Incomplete, actual.Status);
@@ -1281,7 +1281,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Failed, actual.Status);
@@ -1375,7 +1375,7 @@ namespace NuGet.Services.Validation.PackageSigning
                 _certificateVerifier.Verify(v => v.EnqueueVerificationAsync(It.IsAny<IValidationRequest>(), It.IsAny<EndCertificate>()), Times.Never);
                 _validationContext.Verify(c => c.SaveChangesAsync(), Times.Once);
                 _telemetryService.Verify(
-                    x => x.TrackDurationToStartPackageCertificatesValidator(),
+                    x => x.TrackDurationToStartPackageCertificatesValidator(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion),
                     Times.Never);
 
                 Assert.Equal(ValidationStatus.Succeeded, actual.Status);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
@@ -75,16 +75,16 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 if (fromStatus != toStatus)
                 {
                     TelemetryServiceMock.Verify(
-                        x => x.TrackPackageStatusChange(fromStatus, toStatus),
+                        x => x.TrackPackageStatusChange(ValidationSet.PackageId, ValidationSet.PackageNormalizedVersion, ValidationSet.ValidationTrackingId, fromStatus, toStatus),
                         Times.Once);
                     TelemetryServiceMock.Verify(
-                        x => x.TrackPackageStatusChange(It.IsAny<PackageStatus>(), It.IsAny<PackageStatus>()),
+                        x => x.TrackPackageStatusChange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<PackageStatus>(), It.IsAny<PackageStatus>()),
                         Times.Once);
                 }
                 else
                 {
                     TelemetryServiceMock.Verify(
-                        x => x.TrackPackageStatusChange(It.IsAny<PackageStatus>(), It.IsAny<PackageStatus>()),
+                        x => x.TrackPackageStatusChange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<PackageStatus>(), It.IsAny<PackageStatus>()),
                         Times.Never);
                 }
             }
@@ -561,7 +561,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     x => x.UpdateStatusAsync(It.IsAny<Package>(), It.IsAny<PackageStatus>(), It.IsAny<bool>()),
                     Times.Once);
                 TelemetryServiceMock.Verify(
-                    x => x.TrackPackageStatusChange(PackageStatus.Validating, PackageStatus.FailedValidation),
+                    x => x.TrackPackageStatusChange(ValidationSet.PackageId, ValidationSet.PackageNormalizedVersion, ValidationSet.ValidationTrackingId, PackageStatus.Validating, PackageStatus.FailedValidation),
                     Times.Once);
                 PackageFileServiceMock.Verify(
                     x => x.DeletePackageForValidationSetAsync(ValidationSet),

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolValidatorFacts.cs
@@ -132,7 +132,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests.Symbol
                     .Verify(x => x.TryAddValidatorStatusAsync(It.IsAny<ValidationRequest>(), It.IsAny<ValidatorStatus>(), It.IsAny<ValidationStatus>()), Times.Never);
 
                 _telemetryService.Verify(
-                    x => x.TrackSymbolsMessageEnqueued(It.IsAny<string>(), It.IsAny<Guid>()),
+                    x => x.TrackSymbolsMessageEnqueued(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>()),
                     Times.Never);
             }
 
@@ -194,7 +194,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests.Symbol
                         Times.Once);
 
                 _telemetryService.Verify(
-                    x => x.TrackSymbolsMessageEnqueued( ValidatorName.SymbolsValidator, _validationRequest.Object.ValidationId),
+                    x => x.TrackSymbolsMessageEnqueued(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion, ValidatorName.SymbolsValidator, _validationRequest.Object.ValidationId),
                     Times.Once);
 
                 Assert.True(verificationQueuedBeforeStatePersisted);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolsIngesterFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolsIngesterFacts.cs
@@ -104,7 +104,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests.Symbol
                     .Verify(x => x.AddSymbolsServerRequestAsync(It.IsAny<SymbolsServerRequest>()), Times.Never);
 
                 _telemetryService.Verify(
-                    x => x.TrackSymbolsMessageEnqueued(It.IsAny<string>(), It.IsAny<Guid>()),
+                    x => x.TrackSymbolsMessageEnqueued(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>()),
                     Times.Never);
             }
 
@@ -158,7 +158,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests.Symbol
                         Times.Once);
 
                 _telemetryService.Verify(
-                    x => x.TrackSymbolsMessageEnqueued( ValidatorName.SymbolsIngester, _validationRequest.Object.ValidationId),
+                    x => x.TrackSymbolsMessageEnqueued(_validationRequest.Object.PackageId, _validationRequest.Object.PackageVersion, ValidatorName.SymbolsIngester, _validationRequest.Object.ValidationId),
                     Times.Once);
 
                 Assert.True(verificationQueuedBeforeStatePersisted);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/TelemetryServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/TelemetryServiceFacts.cs
@@ -35,6 +35,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string PackageId = "a";
             const string NormalizedVersion = "b";
             const long PackageSize = 3;
+            Guid validationTrackingId = new Guid();
             const string HashAlgorithm = "c";
             const string StreamType = "d";
 
@@ -54,6 +55,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     {
                         { "PackageId", PackageId },
                         { "NormalizedVersion", NormalizedVersion },
+                        { "ValidationTrackingId", validationTrackingId.ToString() },
                         { "PackageSize", PackageSize.ToString() },
                         { "HashAlgorithm", HashAlgorithm },
                         { "StreamType", StreamType }
@@ -63,6 +65,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             using (_telemetryService.TrackDurationToHashPackage(
                 PackageId,
                 NormalizedVersion,
+                validationTrackingId,
                 PackageSize,
                 HashAlgorithm,
                 StreamType))

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -81,7 +81,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             await processor.ProcessValidationOutcomeAsync(ValidationSet, PackageValidatingEntity, ProcessorStats);
 
             TelemetryServiceMock
-                .Verify(t => t.TrackValidatorTimeout("IncompleteButTimedOut"));
+                .Verify(t => t.TrackValidatorTimeout(ValidationSet.PackageId, ValidationSet.PackageNormalizedVersion, ValidationSet.ValidationTrackingId, "IncompleteButTimedOut"));
             ValidationEnqueuerMock
                 .Verify(ve => ve.StartValidationAsync(It.IsAny<PackageValidationMessageData>(), It.IsAny<DateTimeOffset>()), Times.Once);
             PackageFileServiceMock
@@ -324,8 +324,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             TimeSpan duration = default(TimeSpan);
             TelemetryServiceMock
-                .Setup(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()))
-                .Callback<TimeSpan, bool>((t, _) => duration = t);
+                .Setup(ts => ts.TrackTotalValidationDuration(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>(), It.IsAny<bool>()))
+                .Callback<string, string, Guid, TimeSpan, bool>((_1, _2, _3, t, _4) => duration = t);
 
             ProcessorStats.AnyRequiredValidationSucceeded = true;
             ProcessorStats.AnyValidationSucceeded = true;
@@ -356,7 +356,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 x => x.DeletePackageForValidationSetAsync(ValidationSet),
                 Times.Once);
             TelemetryServiceMock
-                .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
+                .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
             Assert.InRange(duration, before - ValidationSet.Created, after - ValidationSet.Created);
         }
 
@@ -375,14 +375,14 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             if (expectedCompletionTracking)
             {
                 TelemetryServiceMock
-                    .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), true), Times.Once());
+                    .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>(), true), Times.Once());
                 TelemetryServiceMock
-                    .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
+                    .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
             }
             else
             {
                 TelemetryServiceMock
-                    .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Never());
+                    .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Never());
             }
         }
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
@@ -327,6 +327,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     x => x.TrackDurationToHashPackage(
                         _package.PackageRegistration.Id,
                         _package.NormalizedVersion,
+                        _validationSet.ValidationTrackingId,
                         stream.Length,
                         CoreConstants.Sha512HashAlgorithmId,
                         "System.IO.MemoryStream"))
@@ -373,6 +374,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     x => x.TrackDurationToHashPackage(
                         _package.PackageRegistration.Id,
                         _package.NormalizedVersion,
+                        _validationSet.ValidationTrackingId,
                         stream.Length,
                         CoreConstants.Sha512HashAlgorithmId,
                         "System.IO.MemoryStream"))

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
@@ -85,16 +85,16 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationStorageMock.Verify(
                     vs => vs.MarkValidationStartedAsync(It.IsAny<PackageValidation>(), It.IsAny<ValidationResult>()), Times.Once);
                 TelemetryServiceMock.Verify(
-                    ts => ts.TrackValidatorStarted(validationName), Times.Once);
+                    ts => ts.TrackValidatorStarted(ValidationSet.PackageId, ValidationSet.PackageNormalizedVersion, ValidationSet.ValidationTrackingId, validationName), Times.Once);
                 TelemetryServiceMock.Verify(
-                    ts => ts.TrackValidatorStarted(It.IsAny<string>()), Times.Once);
+                    ts => ts.TrackValidatorStarted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>()), Times.Once);
             }
             else
             {
                 ValidationStorageMock.Verify(
                     vs => vs.MarkValidationStartedAsync(It.IsAny<PackageValidation>(), It.IsAny<ValidationResult>()), Times.Never);
                 TelemetryServiceMock.Verify(
-                    ts => ts.TrackValidatorStarted(It.IsAny<string>()), Times.Never);
+                    ts => ts.TrackValidatorStarted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
             }
 
             if (expectCleanup)

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
@@ -55,7 +55,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 x => x.BackupPackageFileFromValidationSetPackageAsync(It.IsAny<PackageValidationSet>()),
                 Times.Never);
             TelemetryServiceMock.Verify(
-                x => x.TrackDurationToValidationSetCreation(It.IsAny<TimeSpan>()),
+                x => x.TrackDurationToValidationSetCreation(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>()),
                 Times.Never);
         }
 
@@ -377,7 +377,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 x => x.CopyValidationPackageForValidationSetAsync(returnedSet),
                 Times.Once);
             TelemetryServiceMock.Verify(
-                x => x.TrackDurationToValidationSetCreation(createdSet.Created - Package.Created),
+                x => x.TrackDurationToValidationSetCreation(createdSet.PackageId, createdSet.PackageNormalizedVersion, createdSet.ValidationTrackingId, createdSet.Created - Package.Created),
                 Times.Once);
         }
 
@@ -466,7 +466,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 x => x.CopyValidationPackageForValidationSetAsync(returnedSet),
                 Times.Once);
             TelemetryServiceMock.Verify(
-                x => x.TrackDurationToValidationSetCreation(createdSet.Created - Package.Created),
+                x => x.TrackDurationToValidationSetCreation(createdSet.PackageId, createdSet.PackageNormalizedVersion, createdSet.ValidationTrackingId, createdSet.Created - Package.Created),
                 Times.Once);
         }
 
@@ -519,7 +519,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 .Verify(vs => vs.CreateValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Once);
 
             TelemetryServiceMock.Verify(
-                x => x.TrackDurationToValidationSetCreation(It.IsAny<TimeSpan>()),
+                x => x.TrackDurationToValidationSetCreation(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>()),
                 Times.Never);
         }
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationStorageServiceFacts.cs
@@ -357,8 +357,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 // Arrange
                 TimeSpan duration = default(TimeSpan);
                 _telemetryService
-                    .Setup(x => x.TrackValidatorDuration(It.IsAny<TimeSpan>(), It.IsAny<string>(), It.IsAny<bool>()))
-                    .Callback<TimeSpan, string, bool>((d, _, __) => duration = d);
+                    .Setup(x => x.TrackValidatorDuration(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<TimeSpan>(), It.IsAny<string>(), It.IsAny<bool>()))
+                    .Callback<string, string, Guid, TimeSpan, string, bool>((_1, _2, _3, d, _, __) => duration = d);
 
                 var validationResult = new ValidationResult(
                     toStatus,
@@ -375,17 +375,18 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 var after = DateTime.UtcNow;
 
                 // Assert
+                var validationSet = _packageValidation.PackageValidationSet;
                 _telemetryService.Verify(
-                    x => x.TrackValidatorDuration(It.IsAny<TimeSpan>(), _validatorType, isSuccess),
+                    x => x.TrackValidatorDuration(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, It.IsAny<TimeSpan>(), _validatorType, isSuccess),
                     Times.Once);
                 Assert.InRange(duration, before - _packageValidation.Started.Value, after - _packageValidation.Started.Value);
 
-                _telemetryService.Verify(x => x.TrackValidationIssueCount(3, _validatorType, isSuccess), Times.Once);
-                _telemetryService.Verify(x => x.TrackValidationIssue(_validatorType, ValidationIssueCode.PackageIsSigned));
-                _telemetryService.Verify(x => x.TrackValidationIssue(_validatorType, ValidationIssueCode.ClientSigningVerificationFailure));
-                _telemetryService.Verify(x => x.TrackValidationIssue(_validatorType, ValidationIssueCode.ClientSigningVerificationFailure));
-                _telemetryService.Verify(x => x.TrackClientValidationIssue(_validatorType, "NU3000"), Times.Once);
-                _telemetryService.Verify(x => x.TrackClientValidationIssue(_validatorType, "NU3001"), Times.Once);
+                _telemetryService.Verify(x => x.TrackValidationIssueCount(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, 3, _validatorType, isSuccess), Times.Once);
+                _telemetryService.Verify(x => x.TrackValidationIssue(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, _validatorType, ValidationIssueCode.PackageIsSigned));
+                _telemetryService.Verify(x => x.TrackValidationIssue(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, _validatorType, ValidationIssueCode.ClientSigningVerificationFailure));
+                _telemetryService.Verify(x => x.TrackValidationIssue(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, _validatorType, ValidationIssueCode.ClientSigningVerificationFailure));
+                _telemetryService.Verify(x => x.TrackClientValidationIssue(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, _validatorType, "NU3000"), Times.Once);
+                _telemetryService.Verify(x => x.TrackClientValidationIssue(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, _validatorType, "NU3001"), Times.Once);
             }
 
             [Fact]
@@ -400,8 +401,9 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 await ExecuteAsync(validationResult);
 
                 // Assert
+                var validationSet = _packageValidation.PackageValidationSet;
                 _telemetryService.Verify(
-                    x => x.TrackValidatorDuration(TimeSpan.Zero, _validatorType, false),
+                    x => x.TrackValidatorDuration(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId, TimeSpan.Zero, _validatorType, false),
                     Times.Once);
             }
 


### PR DESCRIPTION
Package id/version with every track call in Orchestrator, validation set ID where available.

Logging package ID, version and validation set ID with metrics enables richer capabilities for getting data from AI metrics.