### PR TITLE
Mark validation sets as completed and no-op based off this

### DIFF
--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -100,7 +100,7 @@
       <Version>9.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -38,7 +38,7 @@ namespace NuGet.Jobs
         /// </summary>
         /// <param name="job">Job to run</param>
         /// <param name="commandLineArgs">Args contains args to the job runner like (dbg, once and so on) and for the job itself</param>
-        /// <returns></returns>
+        /// <returns>The exit code, where 0 indicates success and non-zero indicates an error.</returns>
         public static async Task<int> Run(JobBase job, string[] commandLineArgs)
         {
             return await Run(job, commandLineArgs, runContinuously: null);
@@ -52,7 +52,7 @@ namespace NuGet.Jobs
         /// </summary>
         /// <param name="job">Job to run</param>
         /// <param name="commandLineArgs">Args contains args to the job runner like (dbg, once and so on) and for the job itself</param>
-        /// <returns></returns>
+        /// <returns>The exit code, where 0 indicates success and non-zero indicates an error.</returns>
         public static async Task<int> RunOnce(JobBase job, string[] commandLineArgs)
         {
             return await Run(job, commandLineArgs, runContinuously: false);

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -106,16 +106,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -118,7 +118,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
@@ -116,7 +116,20 @@ namespace NuGet.Services.Validation.Orchestrator
 
                 if (validationSet == null)
                 {
-                    _logger.LogInformation("The validation request for {PackageId} {PackageNormalizedVersion} validation set {ValidationSetId} is a duplicate. Discarding.",
+                    _logger.LogInformation(
+                        "The validation request for {PackageId} {PackageNormalizedVersion} validation set " +
+                        "{ValidationSetId} is a duplicate. Discarding the message.",
+                        message.PackageId,
+                        message.PackageNormalizedVersion,
+                        message.ValidationTrackingId);
+                    return true;
+                }
+
+                if (validationSet.ValidationSetStatus == ValidationSetStatus.Completed)
+                {
+                    _logger.LogInformation(
+                        "The validation set {PackageId} {PackageNormalizedVersion} {ValidationSetId} is already " +
+                        "completed. Discarding the message.",
                         message.PackageId,
                         message.PackageNormalizedVersion,
                         message.ValidationTrackingId);

--- a/src/NuGet.Services.Validation.Orchestrator/Services/PackageMessageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Services/PackageMessageService.cs
@@ -40,7 +40,11 @@ namespace NuGet.Services.Validation.Orchestrator
                                     packageSupportUrl,
                                     _serviceConfiguration.EmailConfiguration.EmailSettingsUrl,
                                     Array.Empty<string>());
-        
+
+            _logger.LogInformation(
+                "The publish email will be sent for the package {PackageId} {PackageVersion}",
+                package.Id,
+                package.NormalizedVersion);
             await _messageService.SendMessageAsync(packageAddedMessage);
         }
 
@@ -61,6 +65,12 @@ namespace NuGet.Services.Validation.Orchestrator
                                    _serviceConfiguration.EmailConfiguration.AnnouncementsUrl,
                                    _serviceConfiguration.EmailConfiguration.TwitterUrl);
 
+            _logger.LogInformation(
+                "The validation failed email will be sent for the package {PackageId} {PackageVersion} and " +
+                "{ValidationSetId}",
+                package.Id,
+                package.NormalizedVersion,
+                validationSet.ValidationTrackingId);
             await _messageService.SendMessageAsync(packageValidationFailedMessage);
         }
 
@@ -73,6 +83,10 @@ namespace NuGet.Services.Validation.Orchestrator
                                    package,
                                    _serviceConfiguration.GalleryPackageUrl(package.PackageRegistration.Id, package.NormalizedVersion));
 
+            _logger.LogInformation(
+                "The validating too long email will be sent for the package {PackageId} {PackageVersion}",
+                package.Id,
+                package.NormalizedVersion);
             await _messageService.SendMessageAsync(packageValidationTakingTooLongMessage);
         }
     }

--- a/src/NuGet.Services.Validation.Orchestrator/Services/SymbolsMessageService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Services/SymbolsMessageService.cs
@@ -44,9 +44,10 @@ namespace NuGet.Services.Validation.Orchestrator
                                     _serviceConfiguration.EmailConfiguration.EmailSettingsUrl,
                                     Array.Empty<string>());
 
-            _logger.LogInformation("The publish email will be sent for the symbol {SymbolId} {SymbolVersion}",
-                   symbolPackage.Id,
-                   symbolPackage.Version);
+            _logger.LogInformation(
+                "The publish email will be sent for the symbol {SymbolId} {SymbolVersion}",
+                symbolPackage.Id,
+                symbolPackage.Version);
             await _messageService.SendMessageAsync(symbolPackageAddedMessage);
         }
 
@@ -70,10 +71,12 @@ namespace NuGet.Services.Validation.Orchestrator
                                    _serviceConfiguration.EmailConfiguration.AnnouncementsUrl,
                                    _serviceConfiguration.EmailConfiguration.TwitterUrl);
 
-            _logger.LogInformation("The validation failed  email will be sent for the symbol {SymbolId} {SymbolVersion} and ValidationSetKey {ValidationSetKey}",
-                   symbolPackage.Id,
-                   symbolPackage.Version,
-                   validationSet.Key);
+            _logger.LogInformation(
+                "The validation failed email will be sent for the symbol {SymbolId} {SymbolVersion} and " +
+                "{ValidationSetId}",
+                symbolPackage.Id,
+                symbolPackage.Version,
+                validationSet.ValidationTrackingId);
             await _messageService.SendMessageAsync(symbolPackageValidationFailedMessage);
         }
 
@@ -88,9 +91,10 @@ namespace NuGet.Services.Validation.Orchestrator
                                    symbolPackage,
                                    _serviceConfiguration.GalleryPackageUrl(symbolPackage.Package.PackageRegistration.Id, symbolPackage.Package.NormalizedVersion));
 
-            _logger.LogInformation("The validation failed  email will be sent for the symbol {SymbolId} {SymbolVersion}.",
-                   symbolPackage.Id,
-                   symbolPackage.Version);
+            _logger.LogInformation(
+                "The validating too long email will be sent for the symbol {SymbolId} {SymbolVersion}.",
+                symbolPackage.Id,
+                symbolPackage.Version);
             await _messageService.SendMessageAsync(symbolPackageValidationTakingTooLongMessage);
         }
     }

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -111,7 +111,20 @@ namespace NuGet.Services.Validation.Orchestrator
 
                 if (validationSet == null)
                 {
-                    _logger.LogInformation("The validation request for {PackageId} {PackageNormalizedVersion} validation set {ValidationSetId} is a duplicate. Discarding.",
+                    _logger.LogInformation(
+                        "The validation request for {PackageId} {PackageNormalizedVersion} validation set " +
+                        "{ValidationSetId} is a duplicate. Discarding the message.",
+                        message.PackageId,
+                        message.PackageNormalizedVersion,
+                        message.ValidationTrackingId);
+                    return true;
+                }
+
+                if (validationSet.ValidationSetStatus == ValidationSetStatus.Completed)
+                {
+                    _logger.LogInformation(
+                        "The validation set {PackageId} {PackageNormalizedVersion} {ValidationSetId} is already " +
+                        "completed. Discarding the message.",
                         message.PackageId,
                         message.PackageNormalizedVersion,
                         message.ValidationTrackingId);

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
@@ -149,7 +149,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 PackageValidations = new List<PackageValidation>(),
                 Updated = now,
                 ValidationTrackingId = message.ValidationTrackingId,
-                ValidatingType = message.ValidatingType
+                ValidatingType = message.ValidatingType,
+                ValidationSetStatus = ValidationSetStatus.InProgress,
             };
 
             var validationsToStart = _validationConfiguration

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -111,7 +111,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -157,13 +157,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.2.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -104,16 +104,16 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-dev-2717380</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.48.0</Version>
+      <Version>2.49.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
@@ -168,6 +168,27 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Fact]
+        public async Task SkipsCompletedValidationSets()
+        {
+            ValidationSet.ValidationSetStatus = ValidationSetStatus.Completed;
+
+            var handler = CreateHandler();
+            var output = await handler.HandleAsync(MessageData);
+
+            Assert.True(output, "The message should have been successfully processed.");
+
+            ValidationSetProcessorMock.Verify(
+                vop => vop.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()),
+                Times.Never);
+            ValidationOutcomeProcessorMock.Verify(
+                vop => vop.ProcessValidationOutcomeAsync(
+                    It.IsAny<PackageValidationSet>(),
+                    It.IsAny<IValidatingEntity<SymbolPackage>>(),
+                    It.IsAny<ValidationSetProcessorResult>()),
+                Times.Never);
+        }
+
+        [Fact]
         public async Task CallsProcessValidations()
         {
             var handler = CreateHandler();

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -191,6 +191,27 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Fact]
+        public async Task SkipsCompletedValidationSets()
+        {
+            ValidationSet.ValidationSetStatus = ValidationSetStatus.Completed;
+
+            var handler = CreateHandler();
+            var output = await handler.HandleAsync(MessageData);
+
+            Assert.True(output, "The message should have been successfully processed.");
+
+            ValidationSetProcessorMock.Verify(
+                vop => vop.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()),
+                Times.Never);
+            ValidationOutcomeProcessorMock.Verify(
+                vop => vop.ProcessValidationOutcomeAsync(
+                    It.IsAny<PackageValidationSet>(),
+                    It.IsAny<IValidatingEntity<Package>>(),
+                    It.IsAny<ValidationSetProcessorResult>()),
+                Times.Never);
+        }
+
+        [Fact]
         public async Task CallsProcessValidations()
         {
             var handler = CreateHandler();

--- a/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
+++ b/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
@@ -37,7 +37,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -45,9 +44,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>1.1.2</Version>
-    </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.7.145</Version>
     </PackageReference>


### PR DESCRIPTION
Depends on https://github.com/NuGet/ServerCommon/pull/296
Progress on https://github.com/NuGet/NuGetGallery/issues/7185

An important change in behavior here is that we mark the validation set as completed before sending the emails. In the happy path this means only one email will be send since all but one thread will successfully mark the validation set as completed. However if the enqueue to send the email message fails, then the email will never be sent. This already happens because the message sending is gated on the package being in the "Validating" or "Failed Validation" state, which will only happen once anyway.