### PR TITLE
Bringing in NuGetGallery.Core aligned with ServerCommon in NuGet.Jobs

### DIFF
--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -66,7 +66,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-master-39280</Version>
+      <Version>4.4.5-dev-2717380</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -116,7 +116,7 @@
       <Version>2.48.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-2571542</Version>
+      <Version>4.4.5-dev-2717380</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>

--- a/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
+++ b/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>1.0.0</Version>
+      <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.7.145</Version>


### PR DESCRIPTION
With this change, a version of NuGetGallery.Core is brought in that depends on ServerCommon 2.48.

Also one annoying "Package downgrade detected" warning was addressed by bumping `Microsoft.Extensions.Logging` 1.0.0 -> 1.1.2 for one of the test projects.