### PR TITLE
Add retries to queries run by ImportAzureCdnStatistics

### DIFF
--- a/src/NuGet.Jobs.Common/Extensions/DapperExtensions.cs
+++ b/src/NuGet.Jobs.Common/Extensions/DapperExtensions.cs
@@ -26,7 +26,8 @@ namespace System.Data.SqlClient
                     param, 
                     transaction, 
                     (int?)commandTimeout?.TotalSeconds, 
-                    commandType));
+                    commandType),
+                maxRetries);
         }
 
         public static Task<T> ExecuteScalarWithRetryAsync<T>(
@@ -44,7 +45,8 @@ namespace System.Data.SqlClient
                     param, 
                     transaction, 
                     (int?)commandTimeout?.TotalSeconds, 
-                    commandType));
+                    commandType),
+                maxRetries);
         }
     }
 }

--- a/src/NuGet.Jobs.Common/Extensions/DapperExtensions.cs
+++ b/src/NuGet.Jobs.Common/Extensions/DapperExtensions.cs
@@ -4,108 +4,47 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dapper;
+using NuGet.Jobs;
 
 // ReSharper disable once CheckNamespace
 namespace System.Data.SqlClient
 {
     public static class DapperExtensions
     {
-        public static async Task<IEnumerable<T>> QueryWithRetryAsync<T>(
+        public static Task<IEnumerable<T>> QueryWithRetryAsync<T>(
             this SqlConnection connection,
             string sql,
             object param = null,
             IDbTransaction transaction = null,
             TimeSpan? commandTimeout = null,
             CommandType? commandType = null,
-            int maxRetries = 10,
-            Action onRetry = null)
+            int maxRetries = SqlRetryUtility.DefaultMaxRetries)
         {
-            for (int attempt = 0; attempt < maxRetries; attempt++)
-            {
-                try
-                {
-                    return await connection.QueryAsync<T>(sql, param, transaction, (int?)commandTimeout?.TotalSeconds, commandType);
-                }
-                catch (SqlException ex)
-                {
-                    switch (ex.Number)
-                    {
-                        case -2:   // Client Timeout
-                        case 701:  // Out of Memory
-                        case 1204: // Lock Issue
-                        case 1205: // >>> Deadlock Victim
-                        case 1222: // Lock Request Timeout
-                        case 8645: // Timeout waiting for memory resource
-                        case 8651: // Low memory condition
-                            // Ignore
-                            if (attempt < (maxRetries - 1))
-                            {
-                                if (onRetry != null)
-                                {
-                                    onRetry();
-                                }
-                            }
-                            else
-                            {
-                                throw;
-                            }
-                            break;
-                        default:
-                            throw;
-                    }
-                }
-            }
-
-            throw new Exception("Unknown error! Should have thrown the final timeout!");
+            return SqlRetryUtility.RetryReadOnlySql(
+                () => connection.QueryAsync<T>(
+                    sql, 
+                    param, 
+                    transaction, 
+                    (int?)commandTimeout?.TotalSeconds, 
+                    commandType));
         }
 
-        public static async Task<T> ExecuteScalarWithRetryAsync<T>(
+        public static Task<T> ExecuteScalarWithRetryAsync<T>(
             this SqlConnection connection,
             string sql,
             object param = null,
             IDbTransaction transaction = null,
             TimeSpan? commandTimeout = null,
             CommandType? commandType = null,
-            int maxRetries = 10,
-            Action onRetry = null)
+            int maxRetries = SqlRetryUtility.DefaultMaxRetries)
         {
-            for (int attempt = 0; attempt < maxRetries; attempt++)
-            {
-                try
-                {
-                    return await connection.ExecuteScalarAsync<T>(sql, param, transaction, (int?)commandTimeout?.TotalSeconds, commandType);
-                }
-                catch (SqlException ex)
-                {
-                    switch (ex.Number)
-                    {
-                        case -2:   // Client Timeout
-                        case 701:  // Out of Memory
-                        case 1204: // Lock Issue
-                        case 1205: // >>> Deadlock Victim
-                        case 1222: // Lock Request Timeout
-                        case 8645: // Timeout waiting for memory resource
-                        case 8651: // Low memory condition
-                            // Ignore
-                            if (attempt < (maxRetries - 1))
-                            {
-                                if (onRetry != null)
-                                {
-                                    onRetry();
-                                }
-                            }
-                            else
-                            {
-                                throw;
-                            }
-                            break;
-                        default:
-                            throw;
-                    }
-                }
-            }
-
-            throw new Exception("Unknown error! Should have thrown the final timeout!");
+            return SqlRetryUtility.RetryReadOnlySql(
+                () => connection.ExecuteScalarAsync<T>(
+                    sql, 
+                    param, 
+                    transaction, 
+                    (int?)commandTimeout?.TotalSeconds, 
+                    commandType));
         }
     }
 }

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -69,6 +69,7 @@
     <Compile Include="JobRunner.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.*.cs" />
+    <Compile Include="SqlRetryUtility.cs" />
     <Compile Include="StorageHelpers.cs" />
     <Compile Include="Strings.Designer.cs" />
   </ItemGroup>

--- a/src/NuGet.Jobs.Common/SqlRetryUtility.cs
+++ b/src/NuGet.Jobs.Common/SqlRetryUtility.cs
@@ -73,14 +73,9 @@ namespace NuGet.Jobs
                 {
                     return executeSql();
                 }
-                catch (SqlException ex)
+                catch (SqlException ex) when (attempt < maxRetries - 1 && retriableExceptionNumbers.Contains(ex.Number))
                 {
-                    if (attempt < maxRetries - 1 && retriableExceptionNumbers.Contains(ex.Number))
-                    {
-                        continue;
-                    }
-
-                    throw;
+                    continue;
                 }
             }
 

--- a/src/NuGet.Jobs.Common/SqlRetryUtility.cs
+++ b/src/NuGet.Jobs.Common/SqlRetryUtility.cs
@@ -19,6 +19,11 @@ namespace NuGet.Jobs
         /// <remarks>
         /// There are many more retriable SQL exception numbers, but these are ones we've encountered in the past.
         /// If we encounter more in the future, we should add them here as well.
+        /// 
+        /// Note that the current implementation does not do any special handling of the SQL connection used.
+        /// Some retriable SQL exceptions require reopening the connection, but none on the list currently.
+        /// The implementation will break if a <see cref="Func{Task}"/> is used that does not reopen the connection and an exception is thrown that requires reopening the connection.
+        /// Do not add any SQL exceptions of class 20 or higher to this list until the implementation is improved!
         /// </remarks>
         private static readonly IReadOnlyCollection<int> RetriableSqlExceptionNumbers = new[]
         {
@@ -42,6 +47,9 @@ namespace NuGet.Jobs
             -2, // Client timeout
         }).ToList();
 
+        /// <summary>
+        /// Runs <paramref name="executeSql"/> and retries it up to <paramref name="maxRetries"/> times if it fails due to a retriable error.
+        /// </summary>
         public static Task RetrySql(
             Func<Task> executeSql,
             int maxRetries = DefaultMaxRetries)
@@ -52,6 +60,9 @@ namespace NuGet.Jobs
                 maxRetries);
         }
 
+        /// <summary>
+        /// Runs <paramref name="executeSql"/> and retries it up to <paramref name="maxRetries"/> times if it fails due to a retriable error.
+        /// </summary>
         public static Task<T> RetryReadOnlySql<T>(
             Func<Task<T>> executeSql,
             int maxRetries = DefaultMaxRetries)

--- a/src/NuGet.Jobs.Common/SqlRetryUtility.cs
+++ b/src/NuGet.Jobs.Common/SqlRetryUtility.cs
@@ -81,7 +81,7 @@ namespace NuGet.Jobs
 
             // Ideally we should never get to this point, because if all iterations of the loop throw, we should rethrow the last exception encountered.
             // However, we need to have this throw here so this code will compile.
-            throw new OperationCanceledException("Failed to execute SQL call in retry loop.");
+            throw new InvalidOperationException("Failed to execute SQL call in retry loop.");
         }
     }
 }

--- a/src/NuGet.Jobs.Common/SqlRetryUtility.cs
+++ b/src/NuGet.Jobs.Common/SqlRetryUtility.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs
+{
+    public static class SqlRetryUtility
+    {
+        public const int DefaultMaxRetries = 10;
+
+        /// <summary>
+        /// If a SQL query fails due to one of these exception numbers, it should always be retried.
+        /// </summary>
+        /// <remarks>
+        /// There are many more retriable SQL exception numbers, but these are ones we've encountered in the past.
+        /// If we encounter more in the future, we should add them here as well.
+        /// </remarks>
+        private static readonly IReadOnlyCollection<int> RetriableSqlExceptionNumbers = new[]
+        {
+            701, // Out of memory
+            1204, // Lock issue
+            1205, // Deadlock victim
+            1222, // Lock request timeout
+            8645, // Timeout waiting for memory resource
+            8651, // Low memory condition
+        };
+
+        /// <summary>
+        /// If a SQL query fails due to one of these exception numbers, it should always be retried if the query is read-only.
+        /// </summary>
+        /// <remarks>
+        /// The exception numbers on this list that are not on <see cref="RetriableSqlExceptionNumbers"/> do not explicitly state that the query did not complete.
+        /// Retrying them may cause duplicate write operations.
+        /// </remarks>
+        private static readonly IReadOnlyCollection<int> RetriableReadOnlySqlExceptionNumbers = RetriableSqlExceptionNumbers.Concat(new[]
+        {
+            -2, // Client timeout
+        }).ToList();
+
+        public static Task RetrySql(
+            Func<Task> executeSql,
+            int maxRetries = DefaultMaxRetries)
+        {
+            return RetrySqlInternal(
+                executeSql,
+                RetriableSqlExceptionNumbers,
+                maxRetries);
+        }
+
+        public static Task<T> RetryReadOnlySql<T>(
+            Func<Task<T>> executeSql,
+            int maxRetries = DefaultMaxRetries)
+        {
+            return RetrySqlInternal(
+                executeSql,
+                RetriableReadOnlySqlExceptionNumbers,
+                maxRetries);
+        }
+
+        private static T RetrySqlInternal<T>(
+            Func<T> executeSql,
+            IReadOnlyCollection<int> retriableExceptionNumbers,
+            int maxRetries)
+        {
+            for (int attempt = 0; attempt < maxRetries; attempt++)
+            {
+                try
+                {
+                    return executeSql();
+                }
+                catch (SqlException ex)
+                {
+                    if (attempt < maxRetries - 1 && retriableExceptionNumbers.Contains(ex.Number))
+                    {
+                        continue;
+                    }
+
+                    throw;
+                }
+            }
+
+            // Ideally we should never get to this point, because if all iterations of the loop throw, we should rethrow the last exception encountered.
+            // However, we need to have this throw here so this code will compile.
+            throw new OperationCanceledException("Failed to execute SQL call in retry loop.");
+        }
+    }
+}

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -381,13 +381,12 @@ namespace Stats.ImportAzureCdnStatistics
             Func<Task> executeSql,
             int maxRetries = 10)
         {
-            var success = false;
             for (int attempt = 0; attempt < maxRetries; attempt++)
             {
                 try
                 {
                     await executeSql();
-                    success = true;
+                    break;
                 }
                 catch (SqlException ex)
                 {
@@ -400,21 +399,16 @@ namespace Stats.ImportAzureCdnStatistics
                         case 1222: // Lock Request Timeout
                         case 8645: // Timeout waiting for memory resource
                         case 8651: // Low memory condition
-                            break;
+                            if (attempt < maxRetries - 1)
+                            {
+                                break;
+                            }
+
+                            throw;
                         default:
                             throw;
                     }
                 }
-
-                if (success)
-                {
-                    break;
-                }
-            }
-
-            if (!success)
-            {
-                throw new OperationCanceledException("Failed to execute non-query after many attempts!");
             }
         }
 


### PR DESCRIPTION
I saw a lot of deadlettered stats blobs due to retriable SQL exceptions while I was on-call last week.

Specifically, I saw a lot of
```
Transaction (Process ID 192) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.
```

I looked at the code and saw that we had no retry logic around it at all. I looked at our other SQL calls in `NuGet.Jobs` and noticed that we typically use [DapperExtensions](https://github.com/NuGet/NuGet.Jobs/blob/master/src/NuGet.Jobs.Common/Extensions/DapperExtensions.cs) to retry, but due to the nature of the SQL queries we are running here (bulk SQL copy and a structured parameter) it was not possible to use Dapper as well so I did some refactoring to allow us to share the retry logic between Dapper and non-Dapper queries.