### PR TITLE
Disabling validation cleanup on validation success

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfiguration.cs
@@ -49,5 +49,10 @@ namespace NuGet.Services.Validation.Orchestrator
         /// The threshold until a validation set is no longer processed.
         /// </summary>
         public TimeSpan TimeoutValidationSetAfter { get; set; }
+
+        /// <summary>
+        /// The duration for which SAS tokens are generated for package URLs passed down to validators.
+        /// </summary>
+        public TimeSpan NupkgUrlValidityPeriod { get; set; } = TimeSpan.FromDays(7);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
@@ -133,10 +133,10 @@ namespace NuGet.Services.Validation.Orchestrator
                 {
                     await ScheduleCheckIfNotTimedOut(validationSet, validatingEntity, tooLongNotificationAllowed: false);
                 }
-                else
-                {
-                    await _packageFileService.DeletePackageForValidationSetAsync(validationSet);
-                }
+
+                // TODO: implement delayed cleanup that would allow internal services
+                // to access original packages for some time after package become available:
+                // https://github.com/NuGet/Engineering/issues/2506
             }
             else
             {

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
@@ -154,11 +154,11 @@ namespace NuGet.Services.Validation.Orchestrator
                 using (_logger.BeginScope("Not started {ValidationType} Key {ValidationId}", packageValidation.Type, packageValidation.Key))
                 {
                     _logger.LogInformation("Processing not started validation {ValidationType} for {PackageId} {PackageVersion}, validation set {ValidationSetId}, {ValidationId}",
-                    packageValidation.Type,
-                    validationSet.PackageId,
-                    validationSet.PackageNormalizedVersion,
-                    validationSet.ValidationTrackingId,
-                    packageValidation.Key);
+                        packageValidation.Type,
+                        validationSet.PackageId,
+                        validationSet.PackageNormalizedVersion,
+                        validationSet.ValidationTrackingId,
+                        packageValidation.Key);
                     var validationConfiguration = GetValidationConfiguration(packageValidation.Type);
                     if (validationConfiguration == null)
                     {
@@ -283,7 +283,7 @@ namespace NuGet.Services.Validation.Orchestrator
         {
             var nupkgUrl = await _packageFileService.GetPackageForValidationSetReadUriAsync(
                 packageValidationSet,
-                DateTimeOffset.UtcNow.Add(_validationConfiguration.TimeoutValidationSetAfter));
+                DateTimeOffset.UtcNow.Add(_validationConfiguration.NupkgUrlValidityPeriod));
 
             var validationRequest = new ValidationRequest(
                 validationId: packageValidation.Key,

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -450,9 +450,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     Times.Never);
             }
 
-            PackageFileServiceMock.Verify(
-                x => x.DeletePackageForValidationSetAsync(ValidationSet),
-                Times.Never);
             TelemetryServiceMock
                 .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
             Assert.InRange(duration, before - ValidationSet.Created, after - ValidationSet.Created);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -29,10 +29,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             PackageStateProcessorMock.Verify(
                 x => x.SetStatusAsync(PackageValidatingEntity, ValidationSet, expectedPackageStatus),
                 Times.Once);
-            PackageFileServiceMock.Verify(
-                x => x.DeletePackageForValidationSetAsync(ValidationSet),
-                Times.Once);
-
             Assert.Equal(ValidationSetStatus.Completed, ValidationSet.ValidationSetStatus);
         }
 
@@ -303,10 +299,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 x => x.SetStatusAsync(PackageValidatingEntity, ValidationSet, PackageStatus.Available),
                 Times.Once);
 
-            PackageFileServiceMock.Verify(
-                x => x.DeletePackageForValidationSetAsync(ValidationSet),
-                Times.Once);
-
             MessageServiceMock
                 .Verify(ms => ms.SendPublishedMessageAsync(Package), Times.Once());
             MessageServiceMock
@@ -336,7 +328,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     nameof(IValidationStorageService.UpdateValidationSetAsync),
                     nameof(IMessageService<Package>.SendPublishedMessageAsync),
                     nameof(ITelemetryService.TrackTotalValidationDuration),
-                    nameof(IValidationFileService.DeletePackageForValidationSetAsync),
                 },
                 operations.ToArray());
         }
@@ -359,7 +350,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     nameof(IStatusProcessor<Package>.SetStatusAsync),
                     nameof(IValidationStorageService.UpdateValidationSetAsync),
                     nameof(ITelemetryService.TrackTotalValidationDuration),
-                    nameof(IValidationFileService.DeletePackageForValidationSetAsync),
                 },
                 operations.ToArray());
         }
@@ -456,9 +446,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     Times.Never);
             }
 
-            PackageFileServiceMock.Verify(
-                x => x.DeletePackageForValidationSetAsync(ValidationSet),
-                Times.Once);
             TelemetryServiceMock
                 .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
             Assert.InRange(duration, before - ValidationSet.Created, after - ValidationSet.Created);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -300,8 +300,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 Times.Once);
 
             PackageFileServiceMock.Verify(
-               x => x.DeletePackageForValidationSetAsync(ValidationSet),
-               Times.Never);
+                x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                Times.Never);
 
             MessageServiceMock
                 .Verify(ms => ms.SendPublishedMessageAsync(Package), Times.Once());

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -299,6 +299,10 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 x => x.SetStatusAsync(PackageValidatingEntity, ValidationSet, PackageStatus.Available),
                 Times.Once);
 
+            PackageFileServiceMock.Verify(
+               x => x.DeletePackageForValidationSetAsync(ValidationSet),
+               Times.Never);
+
             MessageServiceMock
                 .Verify(ms => ms.SendPublishedMessageAsync(Package), Times.Once());
             MessageServiceMock
@@ -446,6 +450,9 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     Times.Never);
             }
 
+            PackageFileServiceMock.Verify(
+                x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                Times.Never);
             TelemetryServiceMock
                 .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
             Assert.InRange(duration, before - ValidationSet.Created, after - ValidationSet.Created);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -450,6 +450,19 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     Times.Never);
             }
 
+            if (validation != ValidationStatus.Failed)
+            {
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Never);
+            }
+            else
+            {
+                PackageFileServiceMock.Verify(
+                    x => x.DeletePackageForValidationSetAsync(ValidationSet),
+                    Times.Once);
+            }
+
             TelemetryServiceMock
                 .Verify(ts => ts.TrackTotalValidationDuration(It.IsAny<TimeSpan>(), It.IsAny<bool>()), Times.Once());
             Assert.InRange(duration, before - ValidationSet.Created, after - ValidationSet.Created);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
@@ -308,11 +308,11 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 .ReturnsAsync(ValidationResult.Incomplete);
 
             var processor = CreateProcessor();
-            var expectedEndOfAccessLower = DateTimeOffset.UtcNow.Add(Configuration.TimeoutValidationSetAfter);
+            var expectedEndOfAccessLower = DateTimeOffset.UtcNow.Add(Configuration.NupkgUrlValidityPeriod);
 
             await processor.ProcessValidationsAsync(ValidationSet);
 
-            var expectedEndOfAccessUpper = DateTimeOffset.UtcNow.Add(Configuration.TimeoutValidationSetAfter);
+            var expectedEndOfAccessUpper = DateTimeOffset.UtcNow.Add(Configuration.NupkgUrlValidityPeriod);
 
             validator
                 .Verify(v => v.GetResultAsync(It.IsAny<IValidationRequest>()), Times.AtLeastOnce());
@@ -402,6 +402,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 {
                 },
                 TimeoutValidationSetAfter = TimeSpan.FromDays(5),
+                NupkgUrlValidityPeriod = TimeSpan.FromDays(9),
             };
             ConfigurationAccessorMock
                 .SetupGet(ca => ca.Value)


### PR DESCRIPTION
Mitigates https://github.com/NuGet/Engineering/issues/2506 to buy us some time until proper solution is developed.

Removed validation container cleanup, introduced new configuration property specifying how long SAS tokens generated for downstream validators are valid.

There is an accompanying configuration update PR.