### PR TITLE
[Hotfix]Stats dependencies

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
+++ b/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
@@ -94,8 +94,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>2.2.0</Version>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
+      <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>

--- a/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
+++ b/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
@@ -97,6 +97,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>1.1.2</Version>
     </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
+    </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
     </PackageReference>

--- a/tests/Tests.Stats.AzureCdnLogs.Common/Tests.Stats.AzureCdnLogs.Common.csproj
+++ b/tests/Tests.Stats.AzureCdnLogs.Common/Tests.Stats.AzureCdnLogs.Common.csproj
@@ -42,7 +42,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Revert a change that broken runtime introduced by security fixes.
Use a fix that works around the runtime issue.