### PR TITLE
Bump up NuGetGallery.Core version and clean up dependencies

### DIFF
--- a/sign.thirdparty.targets
+++ b/sign.thirdparty.targets
@@ -12,10 +12,12 @@
             <ThirdPartyBinaries Include="Dapper.StrongName.dll" />
             <ThirdPartyBinaries Include="Elmah.dll" />
             <ThirdPartyBinaries Include="ICSharpCode.SharpZipLib.dll" />
+            <ThirdPartyBinaries Include="LibGit2Sharp.dll" />
             <ThirdPartyBinaries Include="Markdig.dll" />
             <ThirdPartyBinaries Include="MarkdownSharp.dll" />
             <ThirdPartyBinaries Include="Newtonsoft.Json.dll" />
             <ThirdPartyBinaries Include="Newtonsoft.Json.Schema.dll" />
+            <ThirdPartyBinaries Include="Octokit.dll" />
             <ThirdPartyBinaries Include="Owin.dll" />
             <ThirdPartyBinaries Include="Serilog.dll" />
             <ThirdPartyBinaries Include="Serilog.Enrichers.Environment.dll" />

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -91,7 +91,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -107,19 +107,19 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
@@ -47,6 +47,7 @@ namespace NuGet.Jobs.GitHubIndexer
                         $"{repo.Owner.Login}/{repo.Name}",
                         repo.HtmlUrl,
                         repo.StargazersCount,
+                        repo.Description ?? "No description.",
                         Array.Empty<string>())).ToList(),
                 ghTime.ToLocalTime(),
                 DateTimeOffset.FromUnixTimeSeconds(ghResetTime).ToLocalTime());

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -40,7 +40,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -70,7 +70,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Octokit">
+    <PackageReference Include="NuGet.StrongName.Octokit">
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -74,7 +74,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-2768844</Version>
+      <Version>4.4.5-dev-2842864</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -118,7 +118,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -108,7 +108,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -66,7 +66,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-2768844</Version>
+      <Version>4.4.5-dev-2842864</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Stats.CreateAzureCdnWarehouseReports.csproj
@@ -77,9 +77,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.1.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Data.Services.Client">
       <Version>5.8.4</Version>
     </PackageReference>

--- a/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
+++ b/src/Stats.ImportAzureCdnStatistics/Stats.ImportAzureCdnStatistics.csproj
@@ -105,9 +105,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.1.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Data.Services.Client">
       <Version>5.8.4</Version>
     </PackageReference>

--- a/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
+++ b/src/Stats.RollUpDownloadFacts/Stats.RollUpDownloadFacts.csproj
@@ -64,9 +64,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.1.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Data.Services.Client">
       <Version>5.8.4</Version>
     </PackageReference>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -157,13 +157,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/StatusAggregator/app.config
+++ b/src/StatusAggregator/app.config
@@ -6,10 +6,6 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0"/>
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -113,7 +113,7 @@
       <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-2768844</Version>
+      <Version>4.4.5-dev-2842864</Version>
     </PackageReference>
     <PackageReference Include="Serilog">
       <Version>2.5.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -86,9 +86,6 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection">
       <Version>4.2.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights">
-      <Version>2.2.0</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>1.1.1</Version>
     </PackageReference>
@@ -104,16 +101,16 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-dev-2768844</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.50.0</Version>
+      <Version>2.52.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearcherFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearcherFacts.cs
@@ -61,7 +61,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                 int maxStars = (totalCount + _configuration.MinStars);
                 for (int i = 0; i < totalCount; i++)
                 {
-                    items.Add(new RepositoryInformation("owner/Hello" + i, "dummyUrl", maxStars - i, Array.Empty<string>()));
+                    items.Add(new RepositoryInformation("owner/Hello" + i, "dummyUrl", maxStars - i, "Some random description", Array.Empty<string>()));
                 }
 
                 // Create a mock GitHub Search API that serves those results

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
@@ -39,7 +39,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR is needed for the GitHubIndexer job to run  properly. It basically bumps up the NuGetGallery.Core version to a newer build and fixes the build warnings.

P.S: StatusAggregator job was tested with [build #2856235](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2856235) and [release #387481](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=387481)