### PR TITLE
Add a common handler for both package and symbol orchestrator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
@@ -1,0 +1,263 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NuGet.Services.Entities;
+using NuGet.Services.ServiceBus;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    public abstract class BaseValidationMessageHandler<T> : IMessageHandler<PackageValidationMessageData> where T : class, IEntity
+    {
+        private readonly ValidationConfiguration _configs;
+        private readonly IEntityService<T> _entityService;
+        private readonly IValidationSetProvider<T> _validationSetProvider;
+        private readonly IValidationSetProcessor _validationSetProcessor;
+        private readonly IValidationOutcomeProcessor<T> _validationOutcomeProcessor;
+        private readonly ITelemetryService _telemetryService;
+        private readonly ILogger _logger;
+
+        public BaseValidationMessageHandler(
+            IOptionsSnapshot<ValidationConfiguration> validationConfigsAccessor,
+            IEntityService<T> entityService,
+            IValidationSetProvider<T> validationSetProvider,
+            IValidationSetProcessor validationSetProcessor,
+            IValidationOutcomeProcessor<T> validationOutcomeProcessor,
+            ITelemetryService telemetryService,
+            ILogger logger)
+        {
+            if (validationConfigsAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(validationConfigsAccessor));
+            }
+
+            if (validationConfigsAccessor.Value == null)
+            {
+                throw new ArgumentException(
+                    $"The {nameof(IOptionsSnapshot<ValidationConfiguration>)}.{nameof(IOptionsSnapshot<ValidationConfiguration>.Value)} property cannot be null",
+                    nameof(validationConfigsAccessor));
+            }
+
+            if (validationConfigsAccessor.Value.MissingPackageRetryCount < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(validationConfigsAccessor),
+                    $"{nameof(ValidationConfiguration)}.{nameof(ValidationConfiguration.MissingPackageRetryCount)} must be at least 1");
+            }
+
+            _configs = validationConfigsAccessor.Value;
+            _entityService = entityService ?? throw new ArgumentNullException(nameof(entityService));
+            _validationSetProvider = validationSetProvider ?? throw new ArgumentNullException(nameof(validationSetProvider));
+            _validationSetProcessor = validationSetProcessor ?? throw new ArgumentNullException(nameof(validationSetProcessor));
+            _validationOutcomeProcessor = validationOutcomeProcessor ?? throw new ArgumentNullException(nameof(validationOutcomeProcessor));
+            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        protected abstract ValidatingType ValidatingType { get; }
+        protected abstract bool ShouldNoOpDueToDeletion { get; }
+
+        public async Task<bool> HandleAsync(PackageValidationMessageData message)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            switch (message.Type)
+            {
+                case PackageValidationMessageType.CheckValidator:
+                    return await CheckValidatorAsync(message.CheckValidator);
+                case PackageValidationMessageType.ProcessValidationSet:
+                    return await ProcessValidationSetAsync(message.ProcessValidationSet, message.DeliveryCount);
+                default:
+                    throw new NotSupportedException($"The package validation message type '{message.Type}' is not supported.");
+            }
+        }
+
+        private async Task<bool> CheckValidatorAsync(CheckValidatorData message)
+        {
+            PackageValidationSet validationSet;
+            IValidatingEntity<T> entity;
+            using (_logger.BeginScope(
+                "Finding validation set for {ValidatingType} validation ID {ValidationId}",
+                ValidatingType,
+                message.ValidationId))
+            {
+                validationSet = await _validationSetProvider.TryGetParentValidationSetAsync(message.ValidationId);
+                if (validationSet == null)
+                {
+                    _logger.LogError("Could not find validation set for {ValidationId}.", message.ValidationId);
+                    return false;
+                }
+
+                if (validationSet.ValidatingType != ValidatingType)
+                {
+                    _logger.LogError("Validation set {ValidationSetId} is not for a {TypeName}.", message.ValidationId, ValidatingType);
+                    return false;
+                }
+
+                entity = _entityService.FindPackageByKey(validationSet.PackageKey);
+                if (entity == null)
+                {
+                    _logger.LogError(
+                        "Could not find {ValidatingType} {PackageId} {PackageVersion} {Key} for validation set {ValidationSetId}.",
+                        ValidatingType,
+                        validationSet.PackageId,
+                        validationSet.PackageNormalizedVersion,
+                        validationSet.PackageKey,
+                        validationSet.ValidationTrackingId);
+                    return false;
+                }
+                
+                // Immediately halt validation of a soft deleted package.
+                if (ShouldNoOpDueToDeletion && entity.Status == PackageStatus.Deleted)
+                {
+                    _logger.LogWarning(
+                        "{ValidatingType} {PackageId} {PackageVersion} {Key} is soft deleted. Dropping message for " +
+                        "validation set {ValidationSetId}.",
+                        ValidatingType,
+                        validationSet.PackageId,
+                        validationSet.PackageNormalizedVersion,
+                        entity.Key,
+                        validationSet.ValidationTrackingId);
+                    return true;
+                }
+            }
+
+            using (_logger.BeginScope(
+                "Handling check validator message for {ValidatingType} {PackageId} {PackageVersion} {Key} " +
+                "validation set {ValidationSetId}",
+                ValidatingType,
+                validationSet.PackageId,
+                validationSet.PackageNormalizedVersion,
+                validationSet.PackageKey,
+                validationSet.ValidationTrackingId))
+            {
+                await ProcessValidationSetAsync(entity, validationSet, scheduleNextCheck: false);
+            }
+
+            return true;
+        }
+
+        private async Task<bool> ProcessValidationSetAsync(ProcessValidationSetData message, int deliveryCount)
+        {
+            using (_logger.BeginScope(
+                "Handling process validation set message for {ValidatingType} {PackageId} {PackageVersion} {Key} " +
+                "{ValidationSetId}",
+                ValidatingType,
+                message.PackageId,
+                message.PackageNormalizedVersion,
+                message.EntityKey,
+                message.ValidationTrackingId))
+            {
+                // When a message is sent from the Gallery with validation of a new entity, the EntityKey will be null
+                // because the message is sent to the service bus before the entity is persisted in the DB. However
+                // when a revalidation happens or when the message is re-sent by the orchestrator the message will
+                // contain the key. In this case the key is used to find the entity to validate.
+                var entity = message.EntityKey.HasValue
+                    ? _entityService.FindPackageByKey(message.EntityKey.Value)
+                    : _entityService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
+
+                if (entity == null)
+                {
+                    // no package in DB yet. Might have received message a bit early, need to retry later
+                    if (deliveryCount - 1 >= _configs.MissingPackageRetryCount)
+                    {
+                        _logger.LogWarning(
+                            "Could not find {ValidatingType} {PackageId} {PackageVersion} {Key} in DB after " +
+                            "{DeliveryCount} tries. Discarding the message.",
+                            ValidatingType,
+                            message.PackageId,
+                            message.PackageNormalizedVersion,
+                            message.EntityKey,
+                            deliveryCount);
+
+                        _telemetryService.TrackMissingPackageForValidationMessage(
+                            message.PackageId,
+                            message.PackageNormalizedVersion,
+                            message.ValidationTrackingId.ToString());
+
+                        return true;
+                    }
+                    else
+                    {
+                        _logger.LogInformation(
+                            "Could not find {ValidatingType} {PackageId} {PackageVersion} {Key} in DB. Retrying.",
+                            ValidatingType,
+                            message.PackageId,
+                            message.PackageNormalizedVersion,
+                            message.EntityKey);
+
+                        return false;
+                    }
+                }
+
+                // Immediately halt validation of a soft deleted package.
+                if (ShouldNoOpDueToDeletion && entity.Status == PackageStatus.Deleted)
+                {
+                    _logger.LogWarning(
+                        "{ValidatingType} {PackageId} {PackageNormalizedVersion} {Key} is soft deleted. Dropping " +
+                        "message for validation set {ValidationSetId}.",
+                        ValidatingType,
+                        message.PackageId,
+                        message.PackageNormalizedVersion,
+                        entity.Key,
+                        message.ValidationTrackingId);
+
+                    return true;
+                }
+
+                var validationSet = await _validationSetProvider.TryGetOrCreateValidationSetAsync(message, entity);
+
+                if (validationSet == null)
+                {
+                    _logger.LogInformation(
+                        "The validation request for {ValidatingType} {PackageId} {PackageVersion} {Key} " +
+                        "{ValidationSetId} is a duplicate. Discarding the message.",
+                        ValidatingType,
+                        message.PackageId,
+                        message.PackageNormalizedVersion,
+                        entity.Key,
+                        message.ValidationTrackingId);
+                    return true;
+                }
+
+                await ProcessValidationSetAsync(entity, validationSet, scheduleNextCheck: true);
+            }
+
+            return true;
+        }
+
+        private async Task ProcessValidationSetAsync(
+            IValidatingEntity<T> entity,
+            PackageValidationSet validationSet,
+            bool scheduleNextCheck)
+        {
+            if (validationSet.ValidationSetStatus == ValidationSetStatus.Completed)
+            {
+                _logger.LogInformation(
+                    "The validation set {ValidatingType} {PackageId} {PackageVersion} {Key} {ValidationSetId} is " +
+                    "already completed. Discarding the message.",
+                    ValidatingType,
+                    validationSet.PackageId,
+                    validationSet.PackageNormalizedVersion,
+                    validationSet.PackageKey,
+                    validationSet.ValidationTrackingId);
+                return;
+            }
+
+            var processorStats = await _validationSetProcessor.ProcessValidationsAsync(validationSet);
+
+            await _validationOutcomeProcessor.ProcessValidationOutcomeAsync(
+                validationSet,
+                entity,
+                processorStats,
+                scheduleNextCheck);
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
@@ -11,22 +11,23 @@ using NuGet.Services.Validation.Orchestrator.Telemetry;
 
 namespace NuGet.Services.Validation.Orchestrator
 {
-    public abstract class BaseValidationMessageHandler<T> : IMessageHandler<PackageValidationMessageData> where T : class, IEntity
+    public abstract class BaseValidationMessageHandler<TEntity>
+        : IMessageHandler<PackageValidationMessageData> where TEntity : class, IEntity
     {
         private readonly ValidationConfiguration _configs;
-        private readonly IEntityService<T> _entityService;
-        private readonly IValidationSetProvider<T> _validationSetProvider;
+        private readonly IEntityService<TEntity> _entityService;
+        private readonly IValidationSetProvider<TEntity> _validationSetProvider;
         private readonly IValidationSetProcessor _validationSetProcessor;
-        private readonly IValidationOutcomeProcessor<T> _validationOutcomeProcessor;
+        private readonly IValidationOutcomeProcessor<TEntity> _validationOutcomeProcessor;
         private readonly ITelemetryService _telemetryService;
         private readonly ILogger _logger;
 
         public BaseValidationMessageHandler(
             IOptionsSnapshot<ValidationConfiguration> validationConfigsAccessor,
-            IEntityService<T> entityService,
-            IValidationSetProvider<T> validationSetProvider,
+            IEntityService<TEntity> entityService,
+            IValidationSetProvider<TEntity> validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
-            IValidationOutcomeProcessor<T> validationOutcomeProcessor,
+            IValidationOutcomeProcessor<TEntity> validationOutcomeProcessor,
             ITelemetryService telemetryService,
             ILogger logger)
         {
@@ -82,7 +83,7 @@ namespace NuGet.Services.Validation.Orchestrator
         private async Task<bool> CheckValidatorAsync(CheckValidatorData message)
         {
             PackageValidationSet validationSet;
-            IValidatingEntity<T> entity;
+            IValidatingEntity<TEntity> entity;
             using (_logger.BeginScope(
                 "Finding validation set for {ValidatingType} validation ID {ValidationId}",
                 ValidatingType,
@@ -234,7 +235,7 @@ namespace NuGet.Services.Validation.Orchestrator
         }
 
         private async Task ProcessValidationSetAsync(
-            IValidatingEntity<T> entity,
+            IValidatingEntity<TEntity> entity,
             PackageValidationSet validationSet,
             bool scheduleNextCheck)
         {

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BaseValidationMessageHandler.cs" />
     <Compile Include="BaseValidator.cs" />
     <Compile Include="Configuration\ConfigurationValidator.cs" />
     <Compile Include="Configuration\FlatContainerConfiguration.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
@@ -1,227 +1,34 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Services.Entities;
-using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 
 namespace NuGet.Services.Validation.Orchestrator
 {
-    public class PackageValidationMessageHandler : IMessageHandler<PackageValidationMessageData>
+    public class PackageValidationMessageHandler : BaseValidationMessageHandler<Package>
     {
-        private readonly ValidationConfiguration _configs;
-        private readonly IEntityService<Package> _galleryPackageService;
-        private readonly IValidationSetProvider<Package> _validationSetProvider;
-        private readonly IValidationSetProcessor _validationSetProcessor;
-        private readonly IValidationOutcomeProcessor<Package> _validationOutcomeProcessor;
-        private readonly ITelemetryService _telemetryService;
-        private readonly ILogger<PackageValidationMessageHandler> _logger;
-
         public PackageValidationMessageHandler(
             IOptionsSnapshot<ValidationConfiguration> validationConfigsAccessor,
-            IEntityService<Package> galleryPackageService,
+            IEntityService<Package> entityService,
             IValidationSetProvider<Package> validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
             IValidationOutcomeProcessor<Package> validationOutcomeProcessor,
             ITelemetryService telemetryService,
-            ILogger<PackageValidationMessageHandler> logger)
+            ILogger<PackageValidationMessageHandler> logger) : base(
+                validationConfigsAccessor,
+                entityService,
+                validationSetProvider,
+                validationSetProcessor,
+                validationOutcomeProcessor,
+                telemetryService,
+                logger)
         {
-            if (validationConfigsAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(validationConfigsAccessor));
-            }
-
-            if (validationConfigsAccessor.Value == null)
-            {
-                throw new ArgumentException(
-                    $"The {nameof(IOptionsSnapshot<ValidationConfiguration>)}.{nameof(IOptionsSnapshot<ValidationConfiguration>.Value)} property cannot be null",
-                    nameof(validationConfigsAccessor));
-            }
-
-            if (validationConfigsAccessor.Value.MissingPackageRetryCount < 1)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(validationConfigsAccessor),
-                    $"{nameof(ValidationConfiguration)}.{nameof(ValidationConfiguration.MissingPackageRetryCount)} must be at least 1");
-            }
-
-            _configs = validationConfigsAccessor.Value;
-            _galleryPackageService = galleryPackageService ?? throw new ArgumentNullException(nameof(galleryPackageService));
-            _validationSetProvider = validationSetProvider ?? throw new ArgumentNullException(nameof(validationSetProvider));
-            _validationSetProcessor = validationSetProcessor ?? throw new ArgumentNullException(nameof(validationSetProcessor));
-            _validationOutcomeProcessor = validationOutcomeProcessor ?? throw new ArgumentNullException(nameof(validationOutcomeProcessor));
-            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<bool> HandleAsync(PackageValidationMessageData message)
-        {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            switch (message.Type)
-            {
-                case PackageValidationMessageType.CheckValidator:
-                    return await CheckValidatorAsync(message.CheckValidator);
-                case PackageValidationMessageType.ProcessValidationSet:
-                    return await ProcessValidationSetAsync(message.ProcessValidationSet, message.DeliveryCount);
-                default:
-                    throw new NotSupportedException($"The package validation message type '{message.Type}' is not supported.");
-            }
-        }
-
-        private async Task<bool> CheckValidatorAsync(CheckValidatorData message)
-        {
-            PackageValidationSet validationSet;
-            IValidatingEntity<Package> package;
-            using (_logger.BeginScope("Finding validation set and package for validation ID {ValidationId}", message.ValidationId))
-            {
-                validationSet = await _validationSetProvider.TryGetParentValidationSetAsync(message.ValidationId);
-                if (validationSet == null)
-                {
-                    _logger.LogError("Could not find validation set for {ValidationId}.", message.ValidationId);
-                    return false;
-                }
-
-                if (validationSet.ValidatingType != ValidatingType.Package)
-                {
-                    _logger.LogError("Validation set {ValidationSetId} is not for a package.", message.ValidationId);
-                    return false;
-                }
-
-                package = _galleryPackageService.FindPackageByKey(validationSet.PackageKey);
-                if (package == null)
-                {
-                    _logger.LogError(
-                        "Could not find package {PackageId} {PackageVersion} for validation set {ValidationSetId}.",
-                        validationSet.PackageId,
-                        validationSet.PackageNormalizedVersion,
-                        validationSet.ValidationTrackingId);
-                    return false;
-                }
-                
-                // Immediately halt validation of a soft deleted package.
-                if (package.Status == PackageStatus.Deleted)
-                {
-                    _logger.LogWarning(
-                        "Package {PackageId} {PackageNormalizedVersion} (package key {PackageKey}) is soft deleted. Dropping message for validation set {ValidationSetId}.",
-                        validationSet.PackageId,
-                        validationSet.PackageNormalizedVersion,
-                        package.Key,
-                        validationSet.ValidationTrackingId);
-
-                    return true;
-                }
-            }
-
-            using (_logger.BeginScope("Handling check validator message for {PackageId} {PackageVersion} validation set {ValidationSetId}",
-                validationSet.PackageId,
-                validationSet.PackageNormalizedVersion,
-                validationSet.ValidationTrackingId))
-            {
-                await ProcessValidationSetAsync(package, validationSet, scheduleNextCheck: false);
-            }
-
-            return true;
-        }
-
-        private async Task<bool> ProcessValidationSetAsync(ProcessValidationSetData message, int deliveryCount)
-        {
-            using (_logger.BeginScope("Handling message for {PackageId} {PackageVersion} validation set {ValidationSetId}",
-                message.PackageId,
-                message.PackageNormalizedVersion,
-                message.ValidationTrackingId))
-            {
-                var package = _galleryPackageService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
-
-                if (package == null)
-                {
-                    // no package in DB yet. Might have received message a bit early, need to retry later
-                    if (deliveryCount - 1 >= _configs.MissingPackageRetryCount)
-                    {
-                        _logger.LogWarning("Could not find package {PackageId} {PackageNormalizedVersion} in DB after {DeliveryCount} tries, dropping message",
-                            message.PackageId,
-                            message.PackageNormalizedVersion,
-                            deliveryCount);
-
-                        _telemetryService.TrackMissingPackageForValidationMessage(
-                            message.PackageId,
-                            message.PackageNormalizedVersion,
-                            message.ValidationTrackingId.ToString());
-
-                        return true;
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Could not find package {PackageId} {PackageNormalizedVersion} in DB, retrying",
-                            message.PackageId,
-                            message.PackageNormalizedVersion);
-
-                        return false;
-                    }
-                }
-
-                // Immediately halt validation of a soft deleted package.
-                if (package.Status == PackageStatus.Deleted)
-                {
-                    _logger.LogWarning(
-                        "Package {PackageId} {PackageNormalizedVersion} (package key {PackageKey}) is soft deleted. Dropping message for validation set {ValidationSetId}.",
-                        message.PackageId,
-                        message.PackageNormalizedVersion,
-                        package.Key,
-                        message.ValidationTrackingId);
-
-                    return true;
-                }
-
-                var validationSet = await _validationSetProvider.TryGetOrCreateValidationSetAsync(message, package);
-
-                if (validationSet == null)
-                {
-                    _logger.LogInformation(
-                        "The validation request for {PackageId} {PackageNormalizedVersion} validation set " +
-                        "{ValidationSetId} is a duplicate. Discarding the message.",
-                        message.PackageId,
-                        message.PackageNormalizedVersion,
-                        message.ValidationTrackingId);
-                    return true;
-                }
-
-                await ProcessValidationSetAsync(package, validationSet, scheduleNextCheck: true);
-            }
-
-            return true;
-        }
-
-        private async Task ProcessValidationSetAsync(
-            IValidatingEntity<Package> package,
-            PackageValidationSet validationSet,
-            bool scheduleNextCheck)
-        {
-            if (validationSet.ValidationSetStatus == ValidationSetStatus.Completed)
-            {
-                _logger.LogInformation(
-                    "The validation set {PackageId} {PackageNormalizedVersion} {ValidationSetId} is already " +
-                    "completed. Discarding the message.",
-                    validationSet.PackageId,
-                    validationSet.PackageNormalizedVersion,
-                    validationSet.ValidationTrackingId);
-                return;
-            }
-
-            var processorStats = await _validationSetProcessor.ProcessValidationsAsync(validationSet);
-
-            await _validationOutcomeProcessor.ProcessValidationOutcomeAsync(
-                validationSet,
-                package,
-                processorStats,
-                scheduleNextCheck);
-        }
+        protected override ValidatingType ValidatingType => ValidatingType.Package;
+        protected override bool ShouldNoOpDueToDeletion => true;
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Services.Entities;
-using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 
 namespace NuGet.Services.Validation.Orchestrator
@@ -14,198 +11,27 @@ namespace NuGet.Services.Validation.Orchestrator
     /// <summary>
     /// The message handler for Symbols.
     /// </summary>
-    public class SymbolValidationMessageHandler : IMessageHandler<PackageValidationMessageData>
+    public class SymbolValidationMessageHandler : BaseValidationMessageHandler<SymbolPackage>
     {
-        private readonly ValidationConfiguration _configs;
-        private readonly IEntityService<SymbolPackage> _gallerySymbolService;
-        private readonly IValidationSetProvider<SymbolPackage> _validationSetProvider;
-        private readonly IValidationSetProcessor _validationSetProcessor;
-        private readonly IValidationOutcomeProcessor<SymbolPackage> _validationOutcomeProcessor;
-        private readonly ITelemetryService _telemetryService;
-        private readonly ILogger<SymbolValidationMessageHandler> _logger;
-
         public SymbolValidationMessageHandler(
             IOptionsSnapshot<ValidationConfiguration> validationConfigsAccessor,
-            IEntityService<SymbolPackage> gallerySymbolService,
+            IEntityService<SymbolPackage> entityService,
             IValidationSetProvider<SymbolPackage> validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
             IValidationOutcomeProcessor<SymbolPackage> validationOutcomeProcessor,
             ITelemetryService telemetryService,
-            ILogger<SymbolValidationMessageHandler> logger)
+            ILogger<SymbolValidationMessageHandler> logger) : base(
+                validationConfigsAccessor,
+                entityService,
+                validationSetProvider,
+                validationSetProcessor,
+                validationOutcomeProcessor,
+                telemetryService,
+                logger)
         {
-            if (validationConfigsAccessor == null)
-            {
-                throw new ArgumentNullException(nameof(validationConfigsAccessor));
-            }
-
-            if (validationConfigsAccessor.Value == null)
-            {
-                throw new ArgumentException(
-                    $"The {nameof(IOptionsSnapshot<ValidationConfiguration>)}.{nameof(IOptionsSnapshot<ValidationConfiguration>.Value)} property cannot be null",
-                    nameof(validationConfigsAccessor));
-            }
-
-            if (validationConfigsAccessor.Value.MissingPackageRetryCount < 1)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(validationConfigsAccessor),
-                    $"{nameof(ValidationConfiguration)}.{nameof(ValidationConfiguration.MissingPackageRetryCount)} must be at least 1");
-            }
-
-            _configs = validationConfigsAccessor.Value;
-            _gallerySymbolService = gallerySymbolService ?? throw new ArgumentNullException(nameof(gallerySymbolService));
-            _validationSetProvider = validationSetProvider ?? throw new ArgumentNullException(nameof(validationSetProvider));
-            _validationSetProcessor = validationSetProcessor ?? throw new ArgumentNullException(nameof(validationSetProcessor));
-            _validationOutcomeProcessor = validationOutcomeProcessor ?? throw new ArgumentNullException(nameof(validationOutcomeProcessor));
-            _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<bool> HandleAsync(PackageValidationMessageData message)
-        {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            switch (message.Type)
-            {
-                case PackageValidationMessageType.CheckValidator:
-                    return await CheckValidatorAsync(message.CheckValidator);
-                case PackageValidationMessageType.ProcessValidationSet:
-                    return await ProcessValidationSetAsync(message.ProcessValidationSet, message.DeliveryCount);
-                default:
-                    throw new NotSupportedException($"The package validation message type '{message.Type}' is not supported.");
-            }
-        }
-
-        private async Task<bool> CheckValidatorAsync(CheckValidatorData message)
-        {
-            PackageValidationSet validationSet;
-            IValidatingEntity<SymbolPackage> symbolPackageEntity;
-            using (_logger.BeginScope("Finding validation set and symbol package for validation ID {ValidationId}", message.ValidationId))
-            {
-                validationSet = await _validationSetProvider.TryGetParentValidationSetAsync(message.ValidationId);
-                if (validationSet == null)
-                {
-                    _logger.LogError("Could not find validation set for {ValidationId}.", message.ValidationId);
-                    return false;
-                }
-
-                if (validationSet.ValidatingType != ValidatingType.SymbolPackage)
-                {
-                    _logger.LogError("Validation set {ValidationSetId} is not for a symbol package.", message.ValidationId);
-                    return false;
-                }
-
-                symbolPackageEntity = _gallerySymbolService.FindPackageByKey(validationSet.PackageKey);
-                if (symbolPackageEntity == null)
-                {
-                    _logger.LogError(
-                        "Could not find symbol package {PackageId} {PackageVersion} {Key} for validation set {ValidationSetId}.",
-                        validationSet.PackageId,
-                        validationSet.PackageNormalizedVersion,
-                        validationSet.PackageKey,
-                        validationSet.ValidationTrackingId);
-                    return false;
-                }
-            }
-
-            using (_logger.BeginScope("Handling check symbol validator message for {PackageId} {PackageVersion} {Key} validation set {ValidationSetId}",
-                validationSet.PackageId,
-                validationSet.PackageNormalizedVersion,
-                validationSet.PackageKey,
-                validationSet.ValidationTrackingId))
-            {
-                await ProcessValidationSetAsync(symbolPackageEntity, validationSet, scheduleNextCheck: false);
-            }
-
-            return true;
-        }
-
-        private async Task<bool> ProcessValidationSetAsync(ProcessValidationSetData message, int deliveryCount)
-        {
-            using (_logger.BeginScope("Handling symbol message for {PackageId} {PackageVersion} validation set {ValidationSetId}",
-                message.PackageId,
-                message.PackageNormalizedVersion,
-                message.ValidationTrackingId))
-            {
-                // When a message is sent from the Gallery with validation of a new entity, the EntityKey will be null because the message is sent to the service bus before the entity is persisted in the DB
-                // However when a revalidation happens or when the message is re-sent by the orchestrator the message will contain the key. In this case the key is used to find the entity to validate.
-                var symbolPackageEntity = message.EntityKey.HasValue
-                    ? _gallerySymbolService.FindPackageByKey(message.EntityKey.Value)
-                    : _gallerySymbolService.FindPackageByIdAndVersionStrict(message.PackageId, message.PackageNormalizedVersion);
-
-                if (symbolPackageEntity == null)
-                {
-                    // no package in DB yet. Might have received message a bit early, need to retry later
-                    if (deliveryCount - 1 >= _configs.MissingPackageRetryCount)
-                    {
-                        _logger.LogWarning("Could not find symbols for package {PackageId} {PackageNormalizedVersion} in DB after {DeliveryCount} tries, dropping message",
-                            message.PackageId,
-                            message.PackageNormalizedVersion,
-                            deliveryCount);
-
-                        _telemetryService.TrackMissingPackageForValidationMessage(
-                            message.PackageId,
-                            message.PackageNormalizedVersion,
-                            message.ValidationTrackingId.ToString());
-
-                        return true;
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Could not find symbols for package {PackageId} {PackageNormalizedVersion} {Key} in DB, retrying",
-                            message.PackageId,
-                            message.PackageNormalizedVersion,
-                            message.EntityKey.HasValue);
-
-                        return false;
-                    }
-                }
-
-                var validationSet = await _validationSetProvider.TryGetOrCreateValidationSetAsync(message, symbolPackageEntity);
-
-                if (validationSet == null)
-                {
-                    _logger.LogInformation(
-                        "The validation request for {PackageId} {PackageNormalizedVersion} validation set " +
-                        "{ValidationSetId} is a duplicate. Discarding the message.",
-                        message.PackageId,
-                        message.PackageNormalizedVersion,
-                        message.ValidationTrackingId);
-                    return true;
-                }
-
-                await ProcessValidationSetAsync(symbolPackageEntity, validationSet, scheduleNextCheck: true);
-            }
-
-            return true;
-        }
-
-        private async Task ProcessValidationSetAsync(
-            IValidatingEntity<SymbolPackage> symbolPackageEntity,
-            PackageValidationSet validationSet,
-            bool scheduleNextCheck)
-        {
-            if (validationSet.ValidationSetStatus == ValidationSetStatus.Completed)
-            {
-                _logger.LogInformation(
-                    "The validation set {PackageId} {PackageNormalizedVersion} {ValidationSetId} is already " +
-                    "completed. Discarding the message.",
-                    validationSet.PackageId,
-                    validationSet.PackageNormalizedVersion,
-                    validationSet.ValidationTrackingId);
-                return;
-            }
-
-            var processorStats = await _validationSetProcessor.ProcessValidationsAsync(validationSet);
-
-            await _validationOutcomeProcessor.ProcessValidationOutcomeAsync(
-                validationSet,
-                symbolPackageEntity,
-                processorStats,
-                scheduleNextCheck);
-        }
+        protected override ValidatingType ValidatingType => ValidatingType.SymbolPackage;
+        protected override bool ShouldNoOpDueToDeletion => false;
     }
 }


### PR DESCRIPTION
In response to https://github.com/NuGet/NuGet.Jobs/pull/779#discussion_r306474352.
Depends on https://github.com/NuGet/NuGet.Jobs/pull/779.
Related to https://github.com/NuGet/NuGetGallery/issues/7354.

To verify this, I would recommend checking out the first commit of this PR and comparing the base to the symbol and package handler _before_ I use the base class. I left the unit tests unmerged to avoid regressions.