### PR TITLE
StatusAggregator should support managed KeyVault certificates

### DIFF
--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -13,6 +13,7 @@ using Autofac.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Jobs;
 using NuGet.Services.Incidents;
@@ -352,15 +353,27 @@ namespace StatusAggregator
             serviceCollection.AddLogging();
         }
 
-        private static X509Certificate2 GetCertificateFromJson(string certJson)
+        private static X509Certificate2 GetCertificateFromJson(string certSecret)
         {
-            var certJObject = JObject.Parse(certJson);
+            // Certificates are persisted in two different ways in KeyVault.
+            // Try both before failing.
+            try
+            {
+                // Legacy KeyVault certificates are stored as JSON objects with Base64 data and a password.
+                var certJObject = JObject.Parse(certSecret);
 
-            var certData = certJObject["Data"].Value<string>();
-            var certPassword = certJObject["Password"].Value<string>();
+                var certData = certJObject["Data"].Value<string>();
+                var certPassword = certJObject["Password"].Value<string>();
 
-            var certBytes = Convert.FromBase64String(certData);
-            return new X509Certificate2(certBytes, certPassword);
+                var certBytes = Convert.FromBase64String(certData);
+                return new X509Certificate2(certBytes, certPassword);
+            }
+            catch (JsonReaderException)
+            {
+                // New KeyVault certificates are stored as Base64 strings and have no password.
+                var certBytes = Convert.FromBase64String(certSecret);
+                return new X509Certificate2(certBytes);
+            }
         }
     }
 }

--- a/src/StatusAggregator/Job.cs
+++ b/src/StatusAggregator/Job.cs
@@ -341,7 +341,7 @@ namespace StatusAggregator
                 BaseUri = 
                     new Uri(JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.StatusIncidentApiBaseUri)),
                 Certificate = 
-                    GetCertificateFromJson(JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.StatusIncidentApiCertificate))
+                    GetCertificateFromConfiguration(JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.StatusIncidentApiCertificate))
             };
 
             serviceCollection.AddSingleton(incidentApiConfiguration);
@@ -353,7 +353,7 @@ namespace StatusAggregator
             serviceCollection.AddLogging();
         }
 
-        private static X509Certificate2 GetCertificateFromJson(string certSecret)
+        private static X509Certificate2 GetCertificateFromConfiguration(string certSecret)
         {
             // Certificates are persisted in two different ways in KeyVault.
             // Try both before failing.

--- a/tests/StatusAggregator.Tests/JobTests.cs
+++ b/tests/StatusAggregator.Tests/JobTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace StatusAggregator.Tests
+{
+    public class JobTests
+    {
+        public class TheGetCertificateFromConfigurationMethod
+        {
+            /// <remarks>
+            /// This is a self-signed certificate that was created solely for the purpose of this test.
+            /// It has no password.
+            /// </remarks>
+            private const string _certificateBase64 =
+                "MIIDGDCCAgCgAwIBAgIQS97pQXcKf4NH38AoyLpy1DANBgkqhkiG9w0BAQsFADAfMR0wGwYDVQQDDBRz" +
+                "dGF0dXNhZ2dyZWdhdG9ydGVzdDAeFw0xOTA3MjYxNzU4MzVaFw0yMDA3MjYxODE4MzVaMB8xHTAbBgNV" +
+                "BAMMFHN0YXR1c2FnZ3JlZ2F0b3J0ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1jvc" +
+                "9y+24qAs9Wjihoa9xJfwewkGwZROMvL57DvIhWnNyLiUqRviRR8yMfc674EWC3pCYKPgGA2aKIVHZBcR" +
+                "0QIB4CPoB3IuiVGuKXI3c1R6vJV9QgfodoGT4liXCdA01jgqbWYBnrXICpSGjwm21rCmXEA6InI0py0p" +
+                "1k8Kq1phijONmQHpa58MANhE6SRb8/knv6kLNJwC9ZjSMzsdAvyrxBHRidX1hMduy8Y6lVnkC243fvEP" +
+                "bB3dICkbmSap1E9WSonR53pEt0HwJdCIzKX/HnG32VlWG2Jud9fNoACw/zgx7+yNmQrOD1b0SXQTfz0e" +
+                "/8NH/Su/Fv27eafb6QIDAQABo1AwTjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwIG" +
+                "CCsGAQUFBwMBMB0GA1UdDgQWBBQRctibnTaB9NgpH3wNvM3Y83KO5jANBgkqhkiG9w0BAQsFAAOCAQEA" +
+                "XkdXOpS1r68Vnl2ADOStc7ct6CZI3srcRUV8ryXJILg/jvj7x9AAGwASkkgfpvG2mz9sEs0DMOIRJ4/3" +
+                "6fdqR6ud/19xfHEHKfbAF+SNBKyutvJ0tmf+q9jd2GI7bYBbBhW7wrTYOpe2XcY8hix8q08jyrNC+Dja" +
+                "VSh6n+HxFYyA6oDfRg+6nXPsZYdgHjevYFah/cmWU7F0k+E3n2V2rUfBdXNrWxiu/jsUi4p8gpC6HAST" +
+                "jcLaO6IhsmJU3d5YRUduOeyqYq5yksjr+3jWphsESzC2w1V+H91V2WpXGWRLB3LU9BgBeC0CTRetrarx" +
+                "RwAe7G+JUatDppyP+8jKZA==";
+
+            private readonly ILogger _logger = NullLogger.Instance;
+
+            [Fact]
+            public void HandlesJsonCerts()
+            {
+                var password = "password";
+                var certWithPasswordBytes = 
+                    new X509Certificate2(Convert.FromBase64String(_certificateBase64))
+                    .Export(X509ContentType.Cert, password);
+
+                var certWithPasswordBase64 = Convert.ToBase64String(certWithPasswordBytes);
+                var data = new CertificateData
+                {
+                    Data = certWithPasswordBase64,
+                    Password = password
+                };
+
+                var cert = Job.GetCertificateFromConfiguration(JsonConvert.SerializeObject(data), _logger);
+
+                var base64 = Convert.ToBase64String(cert.RawData);
+                Assert.Equal(certWithPasswordBase64, base64);
+            }
+
+            [Fact]
+            public void HandlesBase64Certs()
+            {
+                var cert = Job.GetCertificateFromConfiguration(_certificateBase64, _logger);
+
+                var base64 = Convert.ToBase64String(cert.RawData);
+                Assert.Equal(_certificateBase64, base64);
+            }
+
+            private class CertificateData
+            {
+                public string Data { get; set; }
+                public string Password { get; set; }
+            }
+        }
+    }
+}

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Factory\IncidentFactoryTests.cs" />
     <Compile Include="Factory\IncidentGroupFactoryTests.cs" />
     <Compile Include="Factory\NuGetServiceComponentFactoryTests.cs" />
+    <Compile Include="JobTests.cs" />
     <Compile Include="Manual\AddStatusEventManualChangeHandlerTests.cs" />
     <Compile Include="Manual\AddStatusMessageManualChangeHandlerTests.cs" />
     <Compile Include="Manual\DeleteStatusEventManualChangeHandlerTests.cs" />
@@ -94,6 +95,10 @@
     <Compile Include="Update\StatusUpdaterTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
+      <Project>{4B4B1EFB-8F33-42E6-B79F-54E7F3293D31}</Project>
+      <Name>NuGet.Jobs.Common</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\StatusAggregator\StatusAggregator.csproj">
       <Project>{d357fdb5-bf19-41a5-82b0-14c8cec2a5eb}</Project>
       <Name>StatusAggregator</Name>


### PR DESCRIPTION
https://github.com/nuget/engineering/issues/2322

Previously, the ICM connector certificate was stored in KeyVault's now legacy certificate format:

```
{
    "Data": "someBase64String",
    "Password": "openSesame"
}
```

Now, because the new ICM connector certificate is managed by KeyVault, it is stored in KeyVault's new certificate format, which doesn't support passwords:

```
someBase64String
```

As a result, StatusAggregator needs to be updated to support this new format as well. I kept the backwards-compatibility just in case we need to switch back to an unmanaged certificate.