### PR TITLE
[GitHub Usage] Pack libgit2sharp's native assemblies

### DIFF
--- a/sign.thirdparty.targets
+++ b/sign.thirdparty.targets
@@ -12,7 +12,8 @@
             <ThirdPartyBinaries Include="Dapper.StrongName.dll" />
             <ThirdPartyBinaries Include="Elmah.dll" />
             <ThirdPartyBinaries Include="ICSharpCode.SharpZipLib.dll" />
-            <ThirdPartyBinaries Include="git2-572e4d8.dll" />
+            <ThirdPartyBinaries Include="lib\win32\x64\git2-572e4d8.dll" />
+            <ThirdPartyBinaries Include="lib\win32\x86\git2-572e4d8.dll" />
             <ThirdPartyBinaries Include="LibGit2Sharp.dll" />
             <ThirdPartyBinaries Include="Markdig.dll" />
             <ThirdPartyBinaries Include="MarkdownSharp.dll" />

--- a/sign.thirdparty.targets
+++ b/sign.thirdparty.targets
@@ -12,6 +12,7 @@
             <ThirdPartyBinaries Include="Dapper.StrongName.dll" />
             <ThirdPartyBinaries Include="Elmah.dll" />
             <ThirdPartyBinaries Include="ICSharpCode.SharpZipLib.dll" />
+            <ThirdPartyBinaries Include="git2-572e4d8.dll" />
             <ThirdPartyBinaries Include="LibGit2Sharp.dll" />
             <ThirdPartyBinaries Include="Markdig.dll" />
             <ThirdPartyBinaries Include="MarkdownSharp.dll" />

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.nuspec
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.nuspec
@@ -10,7 +10,7 @@
     <copyright>Copyright .NET Foundation</copyright>
   </metadata>
   <files>
-    <file src="bin\$configuration$\*.*" target="bin"/>
+    <file src="bin\$configuration$\**.*" target="bin"/>
     <file src="Scripts\*.ps1" />
     <file src="Scripts\nssm.exe" />
   </files>


### PR DESCRIPTION
libgit2sharp has native assemblies that are placed into the `lib/<rid>/` folders that should be packed into the package that is deployed onto our machine.

Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2898846