### PR TITLE
[GH Idx] Stop uploading empty blob when job crashes

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -89,6 +89,11 @@ namespace NuGet.Jobs.GitHubIndexer
             {
                 await WriteFinalBlobAsync(finalList);
             }
+            else
+            {
+                // TODO: Add telemetry for this (https://github.com/NuGet/NuGetGallery/issues/7359)
+                _logger.LogError("The final blob is empty!");
+            }
 
             // Delete the repos and cache directory
             Directory.Delete(RepositoriesDirectory, recursive: true);

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -85,7 +85,10 @@ namespace NuGet.Jobs.GitHubIndexer
                 .ThenBy(x => x.Id)
                 .ToList();
 
-            await WriteFinalBlobAsync(finalList);
+            if (finalList.Any())
+            {
+                await WriteFinalBlobAsync(finalList);
+            }
 
             // Delete the repos and cache directory
             Directory.Delete(RepositoriesDirectory, recursive: true);

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -112,7 +112,10 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                     new GitFileInfo(configFileNames[3], 1)
                 };
 
-                var indexer = CreateIndexer(repo, repoFiles, onDisposeHandler: null);
+                var indexer = CreateIndexer(repo,
+                    repoFiles, 
+                    // This should not be called since there is no dependencies
+                    onDisposeHandler: (string serializedValue) => Assert.True(false));
                 await indexer.RunAsync();
 
                 var result = repo.ToRepositoryInformation();


### PR DESCRIPTION
This PR prevents the GitHubIndexer job of uploading empty blobs to Azure Blob Storage. This case may happen when there is an exception that happens for all the repositories (like if a DLL is missing...)