### PR TITLE
Mogah filter by blobsize

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -20,6 +20,7 @@ namespace NuGet.Jobs.GitHubIndexer
         private const string WorkingDirectory = "work";
         private const string BlobStorageContainerName = "content";
         private const string GitHubUsageFileName = "GitHubUsage.v1.json";
+        public const int MaxBlobSize = 1 << 20; // 1 MB = 2^20
 
         public static readonly string RepositoriesDirectory = Path.Combine(WorkingDirectory, "repos");
         public static readonly string CacheDirectory = Path.Combine(WorkingDirectory, "cache");
@@ -127,8 +128,17 @@ namespace NuGet.Jobs.GitHubIndexer
                 var checkedOutFiles =
                     fetchedRepo.CheckoutFiles(
                         filePaths
-                        // TODO: Filter by blobSize too! (https://github.com/NuGet/NuGetGallery/issues/7339)
                         .Where(x => Filters.GetConfigFileType(x.Path) != Filters.ConfigFileType.None)
+                        .Where(x =>
+                        {
+                            var isValidBlob = x.BlobSize <= MaxBlobSize;
+                            if (!isValidBlob)
+                            {
+                                _logger.LogWarning("File is too big! {FilePath}", x.Path);
+                            }
+
+                            return isValidBlob;
+                        })
                         .Select(x => x.Path)
                         .ToList()); // List of config files that are on-disk
 

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -20,7 +20,7 @@ namespace NuGet.Jobs.GitHubIndexer
         private const string WorkingDirectory = "work";
         private const string BlobStorageContainerName = "content";
         private const string GitHubUsageFileName = "GitHubUsage.v1.json";
-        public const int MaxBlobSize = 1 << 20; // 1 MB = 2^20
+        public const int MaxBlobSizeBytes = 1 << 20; // 1 MB = 2^20
 
         public static readonly string RepositoriesDirectory = Path.Combine(WorkingDirectory, "repos");
         public static readonly string CacheDirectory = Path.Combine(WorkingDirectory, "cache");
@@ -131,10 +131,10 @@ namespace NuGet.Jobs.GitHubIndexer
                         .Where(x => Filters.GetConfigFileType(x.Path) != Filters.ConfigFileType.None)
                         .Where(x =>
                         {
-                            var isValidBlob = x.BlobSize <= MaxBlobSize;
+                            var isValidBlob = x.BlobSize <= MaxBlobSizeBytes;
                             if (!isValidBlob)
                             {
-                                _logger.LogWarning("File is too big! {FilePath}", x.Path);
+                                _logger.LogWarning("File is too big! {FilePath} {FileSizeBytes} bytes", x.Path, x.BlobSize);
                             }
 
                             return isValidBlob;

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -176,7 +176,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                 {
                     new GitFileInfo("file1.txt", 1),
                     new GitFileInfo("file2.txt", 1),
-                    new GitFileInfo(configFileNames[0], ReposIndexer.MaxBlobSize + 1),
+                    new GitFileInfo(configFileNames[0], ReposIndexer.MaxBlobSizeBytes + 1),
                     new GitFileInfo(configFileNames[1], 1),
                     new GitFileInfo(configFileNames[2], 1),
                     new GitFileInfo(configFileNames[3], 1)
@@ -190,7 +190,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                         Assert.True(idx != -1);
                         Assert.True(
                             repoFiles[repoFiles.FindIndex(f => string.Equals(f.Path, file.Path))]
-                                .BlobSize < ReposIndexer.MaxBlobSize);
+                                .BlobSize < ReposIndexer.MaxBlobSizeBytes);
                         return repoDependencies;
                     },
                     onDisposeHandler: (string serializedText) =>

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -113,7 +113,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                 };
 
                 var indexer = CreateIndexer(repo,
-                    repoFiles, 
+                    repoFiles,
                     // This should not be called since there is no dependencies
                     onDisposeHandler: (string serializedValue) => Assert.True(false));
                 await indexer.RunAsync();
@@ -142,6 +142,55 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                     {
                         // Make sure that the Indexer filters out the non-config files
                         Assert.True(Array.Exists(configFileNames, x => string.Equals(x, file.Path)));
+                        return repoDependencies;
+                    },
+                    onDisposeHandler: (string serializedText) =>
+                    {
+                        writeToBlobCalled = true;
+                        Assert.Equal(JsonConvert.SerializeObject(new RepositoryInformation[] { repo.ToRepositoryInformation() }), serializedText);
+                    });
+                await indexer.RunAsync();
+
+                var result = repo.ToRepositoryInformation();
+
+                // Make sure the dependencies got read correctly
+                Assert.Equal(repoDependencies.Length, result.Dependencies.Count);
+                Assert.Equal(repoDependencies, result.Dependencies);
+
+                // Make sure the repo information didn't get changed in the process
+                Assert.Equal(repo.Id, result.Id);
+                Assert.Equal(repo.Stars, result.Stars);
+                Assert.Equal(repo.Url, result.Url);
+
+                // Make sure the blob has been written
+                Assert.True(writeToBlobCalled);
+            }
+
+            [Fact]
+            public async Task OversizedBlobs()
+            {
+                var repo = new WritableRepositoryInformation("owner/test", url: "", stars: 100, description: "", mainBranch: "master");
+                var configFileNames = new string[] { "packages.config", "someProjFile.csproj", "someProjFile.props", "someProjFile.targets" };
+                var repoDependencies = new string[] { "dependency1", "dependency2", "dependency3", "dependency4" };
+                var repoFiles = new List<GitFileInfo>()
+                {
+                    new GitFileInfo("file1.txt", 1),
+                    new GitFileInfo("file2.txt", 1),
+                    new GitFileInfo(configFileNames[0], ReposIndexer.MaxBlobSize + 1),
+                    new GitFileInfo(configFileNames[1], 1),
+                    new GitFileInfo(configFileNames[2], 1),
+                    new GitFileInfo(configFileNames[3], 1)
+                };
+                var writeToBlobCalled = false;
+                var indexer = CreateIndexer(repo, repoFiles, configFileParser: (ICheckedOutFile file) =>
+                    {
+                        var idx = Array.FindIndex(configFileNames, x => string.Equals(x, file.Path));
+
+                        // Make sure that the Indexer filters out the non-config files
+                        Assert.True(idx != -1);
+                        Assert.True(
+                            repoFiles[repoFiles.FindIndex(f => string.Equals(f.Path, file.Path))]
+                                .BlobSize < ReposIndexer.MaxBlobSize);
                         return repoDependencies;
                     },
                     onDisposeHandler: (string serializedText) =>


### PR DESCRIPTION
This PR limits the indexed config files' size to 1 MB for the GitHubIndexer job

Addresses https://github.com/NuGet/NuGetGallery/issues/7339