### PR TITLE
Take snapshots of downloads.v1.json

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/DownloadCountReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/DownloadCountReport.cs
@@ -81,6 +81,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
                         _logger.LogInformation("Writing report to {ReportUri}", blob.Uri.AbsoluteUri);
                         blob.Properties.ContentType = "application/json";
                         await blob.UploadTextAsync(reportText);
+                        await blob.CreateSnapshotAsync();
                         _logger.LogInformation("Wrote report to {ReportUri}", blob.Uri.AbsoluteUri);
                     }
                     catch (Exception ex)


### PR DESCRIPTION
https://github.com/NuGet/Engineering/issues/2574

Statistics DB doesn't have the data for older than 6 weeks, so we've decided to start taking snapshots of `downloads.v1.json` to get around this.

[Azure does not restrict the number of snapshots of a file](https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob), so we should be able to keep daily download counts forever using this method.