### PR TITLE
[Queue-Back 1] Enable queue-back on signature processor and certificate validator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/ValidateCertificateEnqueuer.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ValidateCertificate/ValidateCertificateEnqueuer.cs
@@ -27,7 +27,12 @@ namespace NuGet.Services.Validation.PackageSigning.ValidateCertificate
 
         public async Task EnqueueVerificationAsync(IValidationRequest request, EndCertificate certificate)
         {
-            var message = new CertificateValidationMessage(certificate.Key, request.ValidationId);
+            var message = new CertificateValidationMessage(
+                certificate.Key,
+                request.ValidationId,
+                revalidateRevokedCertificate: false,
+                sendCheckValidator: true);
+
             var brokeredMessage = _serializer.Serialize(message);
 
             var visibleAt = DateTimeOffset.UtcNow + (_configuration.Value.MessageDelay ?? TimeSpan.Zero);

--- a/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessage.cs
+++ b/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessage.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using NuGet.Services.Validation;
 
 namespace NuGet.Jobs.Validation.PackageSigning.Messages
 {
@@ -10,11 +11,16 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
     /// </summary>
     public class CertificateValidationMessage
     {
-        public CertificateValidationMessage(long certificateKey, Guid validationId, bool revalidateRevokedCertificate = false)
+        public CertificateValidationMessage(
+            long certificateKey,
+            Guid validationId,
+            bool revalidateRevokedCertificate,
+            bool sendCheckValidator)
         {
             CertificateKey = certificateKey;
             ValidationId = validationId;
             RevalidateRevokedCertificate = revalidateRevokedCertificate;
+            SendCheckValidator = sendCheckValidator;
         }
 
         /// <summary>
@@ -35,5 +41,11 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
         /// by a NuGet Admin.
         /// </summary>
         public bool RevalidateRevokedCertificate { get; }
+
+        /// <summary>
+        /// Whether or not to send a <see cref="PackageValidationMessageData.CheckValidator"/> message at the end of
+        /// the validation.
+        /// </summary>
+        public bool SendCheckValidator { get; }
     }
 }

--- a/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessageSerializer.cs
+++ b/src/Validation.PackageSigning.Core/Messages/CertificateValidationMessageSerializer.cs
@@ -19,7 +19,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
             {
                 CertificateKey = message.CertificateKey,
                 ValidationId = message.ValidationId,
-                RevalidateRevokedCertificate = message.RevalidateRevokedCertificate
+                RevalidateRevokedCertificate = message.RevalidateRevokedCertificate,
+                SendCheckValidator = message.SendCheckValidator,
             });
         }
 
@@ -30,7 +31,8 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
             return new CertificateValidationMessage(
                 message.CertificateKey,
                 message.ValidationId,
-                message.RevalidateRevokedCertificate);
+                message.RevalidateRevokedCertificate,
+                message.SendCheckValidator);
         }
 
         [Schema(Name = CertificateValidationSchemaName, Version = 1)]
@@ -39,6 +41,7 @@ namespace NuGet.Jobs.Validation.PackageSigning.Messages
             public long CertificateKey { get; set; }
             public Guid ValidationId { get; set; }
             public bool RevalidateRevokedCertificate { get; set; }
+            public bool SendCheckValidator { get; set; }
         }
     }
 }

--- a/src/Validation.PackageSigning.RevalidateCertificate/ValidateCertificateEnqueuer.cs
+++ b/src/Validation.PackageSigning.RevalidateCertificate/ValidateCertificateEnqueuer.cs
@@ -24,7 +24,12 @@ namespace Validation.PackageSigning.RevalidateCertificate
 
         public async Task EnqueueValidationAsync(Guid validationId, EndCertificate certificate)
         {
-            var message = new CertificateValidationMessage(certificate.Key, validationId);
+            var message = new CertificateValidationMessage(
+                certificate.Key,
+                validationId,
+                revalidateRevokedCertificate: false,
+                sendCheckValidator: false);
+
             var brokeredMessage = _serializer.Serialize(message);
 
             await _topicClient.SendAsync(brokeredMessage);

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationServiceFacts.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateValidationServiceFacts.cs
@@ -38,7 +38,9 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
 
                 var message = new CertificateValidationMessage(
                     certificateKey: EndCertificateKey1,
-                    validationId: ValidationId2);
+                    validationId: ValidationId2,
+                    revalidateRevokedCertificate: false,
+                    sendCheckValidator: true);
 
                 // Act & Assert
                 var result = await _target.FindCertificateValidationAsync(message);
@@ -60,7 +62,9 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
 
                 var message = new CertificateValidationMessage(
                     certificateKey: EndCertificateKey2,
-                    validationId: ValidationId2);
+                    validationId: ValidationId2,
+                    revalidateRevokedCertificate: false,
+                    sendCheckValidator: true);
 
                 // Act & Assert
                 var result = await _target.FindCertificateValidationAsync(message);

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
@@ -55,6 +55,10 @@
     <Compile Include="Support\X509V3CertificateGeneratorExtensions2.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Validation.Common.Job\Validation.Common.Job.csproj">
+      <Project>{FA87D075-A934-4443-8D0B-5DB32640B6D7}</Project>
+      <Name>Validation.Common.Job</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Validation.PackageSigning.Core\Validation.PackageSigning.Core.csproj">
       <Project>{91c060da-736f-4da9-a57f-cb3ac0e6cb10}</Project>
       <Name>Validation.PackageSigning.Core</Name>


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/7482

I had to enhance the message for the certificate validator so that messages from the certificate revalidate job don't queue-back to the orchestrator.