### PR TITLE
[SDL] Perform online verification for X.509 certificates

### DIFF
--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -66,6 +66,13 @@ namespace NuGet.Jobs
                 Debugger.Launch();
             }
 
+            // Ensure that SSLv3 is disabled and that Tls v1.2 is enabled.
+            ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            // Ensure that certificate validation check for online revocations.
+            ServicePointManager.CheckCertificateRevocationList = true;
+
             // Configure logging before Application Insights is enabled.
             // This is done so, in case Application Insights fails to initialize, we still see output.
             var loggerFactory = ConfigureLogging(job);
@@ -149,10 +156,6 @@ namespace NuGet.Jobs
                         $"The job is designed to run once so the -{JobArgumentNames.ReinitializeAfterSeconds} " +
                         $"argument is ignored.");
                 }
-
-                // Ensure that SSLv3 is disabled and that Tls v1.2 is enabled.
-                ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
-                ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
                 // Run the job loop
                 exitCode = await JobLoop(job, runContinuously.Value, sleepDuration.Value, reinitializeAfterSeconds, jobArgsDictionary);

--- a/src/NuGetCDNRedirect/Global.asax.cs
+++ b/src/NuGetCDNRedirect/Global.asax.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.CDNRedirect
         protected void Application_Start()
         {
             // Ensure that SSLv3 is disabled and that TLS v1.2 is enabled.
-            ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;;
+            ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             // Ensure that certificate validation check for online revocations.

--- a/src/NuGetCDNRedirect/Global.asax.cs
+++ b/src/NuGetCDNRedirect/Global.asax.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Net;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -10,6 +11,13 @@ namespace NuGet.Services.CDNRedirect
     {
         protected void Application_Start()
         {
+            // Ensure that SSLv3 is disabled and that TLS v1.2 is enabled.
+            ServicePointManager.SecurityProtocol &= ~SecurityProtocolType.Ssl3;;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            // Ensure that certificate validation check for online revocations.
+            ServicePointManager.CheckCertificateRevocationList = true;
+
             AreaRegistration.RegisterAllAreas();
             FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
             RouteConfig.RegisterRoutes(RouteTable.Routes);


### PR DESCRIPTION
X.509 Certificate validations must now go online for revocation validation. All jobs that use secrets are affected.

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2991191
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=432596

Part of https://github.com/nuget/engineering/issues/2686