### PR TITLE
Add AppInsights heartbeat support to JobRunner

### DIFF
--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -91,7 +91,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -93,6 +93,7 @@ namespace NuGet.Jobs
 
         // Application Insights
         public const string InstrumentationKey = "InstrumentationKey";
+        public const string HeartbeatIntervalSeconds = "HeartbeatIntervalSeconds";
 
         // Arguments specific to validation tasks
         public const string RunValidationTasks = "RunValidationTasks";

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -212,6 +212,9 @@ namespace NuGet.Jobs
 
             int exitCode = 0;
 
+            // This tells Application Insights that, even though a heartbeat is reported, 
+            // the state of the application is unhealthy when the exitcode is different from zero.
+            // The heartbeat metadata is enriched with the job loop exit code.
             ApplicationInsights.HeartbeatManager?.AddHeartbeatProperty(
                 HeartbeatProperty_JobLoopExitCode,
                 exitCode.ToString(),

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -19,7 +19,8 @@ namespace NuGet.Jobs
         public static IServiceContainer ServiceContainer;
 
         private static ILogger _logger;
-        
+
+        private const string HeartbeatProperty_JobLoopExitCode = "JobLoopExitCode";
         private const string JobSucceeded = "Job Succeeded";
         private const string JobUninitialized = "Job Failed to Initialize";
         private const string JobFailed = "Job Failed to Run";
@@ -89,10 +90,20 @@ namespace NuGet.Jobs
                 // Setup logging
                 if (!ApplicationInsights.Initialized)
                 {
-                    string instrumentationKey = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstrumentationKey);
+                    var instrumentationKey = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstrumentationKey);
+                    var heartbeatIntervalSeconds = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.HeartbeatIntervalSeconds);
                     if (!string.IsNullOrWhiteSpace(instrumentationKey))
                     {
-                        ApplicationInsights.Initialize(instrumentationKey);
+                        if (heartbeatIntervalSeconds.HasValue)
+                        {
+                            ApplicationInsights.Initialize(
+                                instrumentationKey,
+                                TimeSpan.FromSeconds(heartbeatIntervalSeconds.Value));
+                        }
+                        else
+                        {
+                            ApplicationInsights.Initialize(instrumentationKey);
+                        }
                     }
                 }
 
@@ -127,7 +138,7 @@ namespace NuGet.Jobs
                     {
                         _logger.LogInformation("SleepDuration is not provided or is not a valid integer. Unit is milliSeconds. Assuming default of 5000 ms...");
                     }
-                    
+
                     sleepDuration = 5000;
                 }
                 else if (!runContinuously.Value)
@@ -182,8 +193,8 @@ namespace NuGet.Jobs
 
         private static string PrettyPrintTime(double milliSeconds)
         {
-            var seconds = (milliSeconds/1000.0);
-            var minutes = (milliSeconds/60000.0);
+            var seconds = (milliSeconds / 1000.0);
+            var minutes = (milliSeconds / 60000.0);
             return
                 $"'{milliSeconds:F3}' ms (or '{seconds:F3}' seconds or '{minutes:F3}' mins)";
         }
@@ -199,7 +210,13 @@ namespace NuGet.Jobs
             var stopWatch = new Stopwatch();
             Stopwatch timeSinceInitialization = null;
 
-            int exitCode;
+            int exitCode = 0;
+
+            ApplicationInsights.HeartbeatManager?.AddHeartbeatProperty(
+                HeartbeatProperty_JobLoopExitCode,
+                exitCode.ToString(),
+                isHealthy: exitCode == 0);
+
             while (true)
             {
                 _logger.LogInformation("Running {RunType}", (runContinuously ? " continuously..." : " once..."));
@@ -234,6 +251,11 @@ namespace NuGet.Jobs
                     _logger.LogInformation("Job run ended...");
                     stopWatch.Stop();
                     _logger.LogInformation("Job run took {RunDuration}", PrettyPrintTime(stopWatch.ElapsedMilliseconds));
+
+                    ApplicationInsights.HeartbeatManager?.SetHeartbeatProperty(
+                        HeartbeatProperty_JobLoopExitCode,
+                        exitCode.ToString(),
+                        isHealthy: exitCode == 0);
                 }
 
                 if (!runContinuously)
@@ -245,7 +267,7 @@ namespace NuGet.Jobs
 
                 // Wait for <sleepDuration> milliSeconds and run the job again
                 _logger.LogInformation("Will sleep for {SleepDuration} before the next Job run", PrettyPrintTime(sleepDuration));
-                
+
                 await Task.Delay(sleepDuration);
             }
 

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -107,19 +107,19 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -118,7 +118,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -110,7 +110,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -161,7 +161,7 @@
       <Version>2.55.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
       <Version>2.55.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -158,13 +158,13 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
       <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -107,16 +107,16 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-dev-3038285</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -64,7 +64,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.55.0</Version>
+      <Version>2.56.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>


### PR DESCRIPTION
This PR consumes ServerCommon v2.56.0 packages which depend on AppInsights v2.10 and adds heartbeat support to AppInsights initialization logic.