### PR TITLE
[GitHub Indexer] Track total run duration

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/ITelemetryService.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ITelemetryService.cs
@@ -8,6 +8,13 @@ namespace NuGet.Jobs.GitHubIndexer
     public interface ITelemetryService
     {
         /// <summary>
+        /// Track the duration to run the GitHub Indexer job.
+        /// </summary>
+        /// <param name="duration">The time taken to run the GitHub indexer job.</param>
+        /// <param name="completed">If <see langword="false"/>, the job terminated unexpectedly.</param>
+        void TrackRunDuration(TimeSpan duration, bool completed);
+
+        /// <summary>
         /// Track the duration to find GitHub repositories to index.
         /// </summary>
         IDisposable TrackDiscoverRepositoriesDuration();

--- a/src/NuGet.Jobs.GitHubIndexer/TelemetryService.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/TelemetryService.cs
@@ -10,6 +10,7 @@ namespace NuGet.Jobs.GitHubIndexer
     public class TelemetryService : ITelemetryService
     {
         private const string Prefix = "GitHubIndexer.";
+        private const string RunDuration = Prefix + "RunDurationSeconds";
         private const string DiscoverRepositoriesDuration = Prefix + "DiscoverRepositoriesDurationSeconds";
         private const string IndexRepositoryDuration = Prefix + "IndexRepositoryDurationSeconds";
         private const string ListFilesDuration = Prefix + "ListFilesDurationSeconds";
@@ -17,6 +18,7 @@ namespace NuGet.Jobs.GitHubIndexer
         private const string UploadGitHubUsageBlobDuration = Prefix + "UploadGitHubUsageBlobDurationSeconds";
         private const string EmptyGitHubUsageBlob = Prefix + "EmptyGitHubUsageBlob";
 
+        private const string Completed = "Completed";
         private const string RepositoryName = "RepositoryName";
 
         private readonly ITelemetryClient _telemetryClient;
@@ -24,6 +26,17 @@ namespace NuGet.Jobs.GitHubIndexer
         public TelemetryService(ITelemetryClient telemetryClient)
         {
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public void TrackRunDuration(TimeSpan duration, bool completed)
+        {
+            _telemetryClient.TrackMetric(
+                RunDuration,
+                duration.TotalSeconds,
+                new Dictionary<string, string>
+                {
+                    { Completed, completed.ToString() }
+                });
         }
 
         public IDisposable TrackDiscoverRepositoriesDuration()


### PR DESCRIPTION
It is difficult to determine the GitHub Indexer job duration. This change adds a metric to make this clear. I recommend enabling `Hide whitespace changes` to review this pull request.

Addresses https://github.com/NuGet/NuGetGallery/issues/7625

Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3141138
Test release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=477402