### PR TITLE
Fix FXCop build failure in RepoUtils

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
@@ -110,8 +110,6 @@ namespace NuGet.Jobs.GitHubIndexer
                 using (var xmlReader = XmlReader.Create(streamReader, xmlSettings))
                 {
                     var projDocument = new XmlDocument();
-                    projDocument.XmlResolver = null;
-
                     projDocument.Load(xmlReader);
                     return GetAllPackageReferenceNodes(projDocument)
                         .Select(p => p.Attributes["Include"])

--- a/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
@@ -109,7 +109,7 @@ namespace NuGet.Jobs.GitHubIndexer
                 using (var streamReader = new StreamReader(fileStream))
                 using (var xmlReader = XmlReader.Create(streamReader, xmlSettings))
                 {
-                    var projDocument = new XmlDocument;
+                    var projDocument = new XmlDocument();
                     projDocument.XmlResolver = null;
 
                     projDocument.Load(xmlReader);

--- a/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
@@ -110,6 +110,8 @@ namespace NuGet.Jobs.GitHubIndexer
                 using (var xmlReader = XmlReader.Create(streamReader, xmlSettings))
                 {
                     var projDocument = new XmlDocument();
+                    projDocument.XmlResolver = null;
+
                     projDocument.Load(xmlReader);
                     return GetAllPackageReferenceNodes(projDocument)
                         .Select(p => p.Attributes["Include"])

--- a/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
@@ -102,7 +102,7 @@ namespace NuGet.Jobs.GitHubIndexer
             try
             {
                 using (var streamReader = new StreamReader(fileStream))
-                using (var xmlReader = XmlReader.Create(streamReader))
+                using (var xmlReader = XmlReader.Create(streamReader, new XmlReaderSettings { XmlResolver = null }))
                 {
                     var projDocument = new XmlDocument
                     {

--- a/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
@@ -101,13 +101,16 @@ namespace NuGet.Jobs.GitHubIndexer
         {
             try
             {
+                // Need to set XmlResolver to null for CA3053.
+                // FXCop does not understand initializer syntax, so we must directly set the property.
+                var xmlSettings = new XmlReaderSettings();
+                xmlSettings.XmlResolver = null;
+
                 using (var streamReader = new StreamReader(fileStream))
-                using (var xmlReader = XmlReader.Create(streamReader, new XmlReaderSettings { XmlResolver = null }))
+                using (var xmlReader = XmlReader.Create(streamReader, xmlSettings))
                 {
-                    var projDocument = new XmlDocument
-                    {
-                        XmlResolver = null
-                    };
+                    var projDocument = new XmlDocument;
+                    projDocument.XmlResolver = null;
 
                     projDocument.Load(xmlReader);
                     return GetAllPackageReferenceNodes(projDocument)


### PR DESCRIPTION
FXCop seems to not understand when the `XmlResolver` field is set with initializer syntax instead of the setting the property directly. This fixes the build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3060854