### PR TITLE
GitHubIndexer should crash if processing a single repository takes too long

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
@@ -26,6 +26,11 @@ namespace NuGet.Jobs.GitHubIndexer
         public int MaxDegreeOfParallelism { get; set; } = 32;
 
         /// <summary>
+        /// If a repo takes longer to index than this timeout, we will crash the process and attempt again later.
+        /// </summary>
+        public int RepoIndexingTimeoutMinutes { get; set; } = 150;
+
+        /// <summary>
         /// The connection string to be used for a <see cref="NuGetGallery.CloudBlobClientWrapper"/> instance.
         /// </summary>
         public string StorageConnectionString { get; set; }

--- a/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace NuGet.Jobs.GitHubIndexer
 {
     public class GitHubIndexerConfiguration
@@ -28,7 +30,7 @@ namespace NuGet.Jobs.GitHubIndexer
         /// <summary>
         /// If a repo takes longer to index than this timeout, we will crash the process and attempt again later.
         /// </summary>
-        public int RepoIndexingTimeoutMinutes { get; set; } = 150;
+        public TimeSpan RepoIndexingTimeout { get; set; } = TimeSpan.FromMinutes(150);
 
         /// <summary>
         /// The connection string to be used for a <see cref="NuGetGallery.CloudBlobClientWrapper"/> instance.

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -206,33 +206,36 @@ namespace NuGet.Jobs.GitHubIndexer
         {
             try
             {
-                using (var sem = new SemaphoreSlim(1))
+                using (var sem = new SemaphoreSlim(0, 1))
                 {
-                    while (items.TryTake(out var item))
+                    using (var delayCancellationTokenSource = new CancellationTokenSource())
+                    using (var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(parentCancellationTokenSource.Token, delayCancellationTokenSource.Token))
                     {
-                        using (var delayCancellationTokenSource = new CancellationTokenSource(RepoIndexingTimeout))
-                        using (var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(parentCancellationTokenSource.Token, delayCancellationTokenSource.Token))
+                        while (items.TryTake(out var item))
                         {
+                            var thread = new Thread(() =>
+                            {
+                                work(item);
+                                try
+                                {
+                                    sem.Release();
+                                }
+                                catch (ObjectDisposedException)
+                                {
+                                    // The semaphore may be disposed if the task cancelled early.
+                                }
+                            })
+                            {
+                                IsBackground = true // This is important as it allows the process to exit while this thread is running
+                            };
+
+                            thread.Start();
+
+                            // Wait for the thread to complete processing the repository.
+                            // If it takes longer than the timeout to complete, cancel the task.
+                            delayCancellationTokenSource.CancelAfter(RepoIndexingTimeout);
                             await sem.WaitAsync(cancellationTokenSource.Token);
                         }
-
-                        var thread = new Thread(() =>
-                        {
-                            work(item);
-                            try
-                            {
-                                sem.Release();
-                            }
-                            catch (ObjectDisposedException)
-                            {
-                                // The semaphore may be disposed if the Task cancelled early.
-                            }
-                        })
-                        {
-                            IsBackground = true // This is important as it allows the process to exit while this thread is running
-                        };
-
-                        thread.Start();
                     }
                 }
             }

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -125,10 +125,10 @@ namespace NuGet.Jobs.GitHubIndexer
 
         private RepositoryInformation ProcessSingleRepo(WritableRepositoryInformation repo)
         {
-            if (_repoCache.TryGetCachedVersion(repo, out var cachedVersion))
+            /*if (_repoCache.TryGetCachedVersion(repo, out var cachedVersion))
             {
                 return cachedVersion;
-            }
+            }*/
 
             using (_telemetry.TrackIndexRepositoryDuration(repo.Id))
             using (_logger.BeginScope("Starting indexing for repo {Name}", repo.Id))

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -58,7 +58,7 @@ namespace NuGet.Jobs.GitHubIndexer
             }
 
             _maxDegreeOfParallelism = configuration.Value.MaxDegreeOfParallelism;
-            _repoIndexingTimeout = TimeSpan.FromMinutes(configuration.Value.RepoIndexingTimeoutMinutes);
+            _repoIndexingTimeout = configuration.Value.RepoIndexingTimeout;
             _cloudClient = cloudClient ?? throw new ArgumentNullException(nameof(cloudClient));
             _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
         }

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -21,7 +21,7 @@ namespace NuGet.Jobs.GitHubIndexer
         private const string BlobStorageContainerName = "content";
         private const string GitHubUsageFileName = "GitHubUsage.v1.json";
         public const int MaxBlobSizeBytes = 1 << 20; // 1 MB = 2^20
-        private static TimeSpan RepoIndexingTimeout = TimeSpan.FromMinutes(90);
+        private static TimeSpan RepoIndexingTimeout = TimeSpan.FromMinutes(150);
 
         public static readonly string RepositoriesDirectory = Path.Combine(WorkingDirectory, "repos");
         public static readonly string CacheDirectory = Path.Combine(WorkingDirectory, "cache");

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -184,7 +184,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                     repo,
                     repoFiles,
                     telemetry,
-                    // This should not be called since there is no dependencies
+                    // This should not be called because the task will be cancelled before it writes.
                     onDisposeHandler: (string serializedValue) => Assert.True(false),
                     shouldTimeOut: true);
 

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -49,8 +49,14 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
             RepositoryInformation mockVal;
             mockRepoCache
                 .Setup(x => x.TryGetCachedVersion(It.IsAny<WritableRepositoryInformation>(), out mockVal))
-                // Wait at least one millisecond so that the timeout can take affect.
-                .Callback(() => Thread.Sleep(1))
+                .Callback(() => {
+                    if (shouldTimeOut)
+                    {
+                        // A minute should be long enough to cancel the task.
+                        // If the task isn't canceled, the test runtime will only be minorly affected.
+                        Thread.Sleep(60 * 1000);
+                    }
+                })
                 .Returns(false); // Simulate no cache
             mockRepoCache
                 .Setup(x => x.Persist(It.IsAny<RepositoryInformation>()));

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -184,7 +184,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                     repo,
                     repoFiles,
                     telemetry,
-                    // This should not be called because the task will be cancelled before it writes.
+                    // This should not be called because the process will be cancelled before it writes.
                     onDisposeHandler: (string serializedValue) => Assert.True(false),
                     shouldTimeOut: true);
 

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -33,7 +33,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
             var config = new GitHubIndexerConfiguration();
             if (shouldTimeOut)
             {
-                config.RepoIndexingTimeoutMinutes = 0;
+                config.RepoIndexingTimeout = TimeSpan.Zero;
             }
 
             mockConfig

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/ReposIndexerFacts.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -48,6 +49,8 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
             RepositoryInformation mockVal;
             mockRepoCache
                 .Setup(x => x.TryGetCachedVersion(It.IsAny<WritableRepositoryInformation>(), out mockVal))
+                // Wait at least one millisecond so that the timeout can take affect.
+                .Callback(() => Thread.Sleep(1))
                 .Returns(false); // Simulate no cache
             mockRepoCache
                 .Setup(x => x.Persist(It.IsAny<RepositoryInformation>()));


### PR DESCRIPTION
https://github.com/nuget/engineering/issues/2720

It appears that LibGit2Sharp, the synchronous library we are using, occasionally hangs when indexing a repository.

This change makes it so that if a single repository takes longer than 150 minutes to process (which seemed like a reasonable threshold given the metrics we report about indexing time), we crash the process and try again.

Note that we are using threads here because LibGit2Sharp is synchronous, and we want to avoid having synchronous threads occupy the same threadpool as the async code. I did not notice any perf impacts with the changes here.