### PR TITLE
GitHubIndexer should do work in the Temp directory

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -17,11 +17,11 @@ namespace NuGet.Jobs.GitHubIndexer
 {
     public class ReposIndexer
     {
-        private static string WorkingDirectory = Path.Combine(Path.GetTempPath(), "NuGet.Jobs.GitHubIndexer");
         private const string BlobStorageContainerName = "content";
         private const string GitHubUsageFileName = "GitHubUsage.v1.json";
         public const int MaxBlobSizeBytes = 1 << 20; // 1 MB = 2^20
 
+        private static string WorkingDirectory = Path.Combine(Path.GetTempPath(), "NuGet.Jobs.GitHubIndexer");
         public static readonly string RepositoriesDirectory = Path.Combine(WorkingDirectory, "repos");
         public static readonly string CacheDirectory = Path.Combine(WorkingDirectory, "cache");
         private static readonly JsonSerializer Serializer = new JsonSerializer();

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -17,7 +17,7 @@ namespace NuGet.Jobs.GitHubIndexer
 {
     public class ReposIndexer
     {
-        private const string WorkingDirectory = "work";
+        private static string WorkingDirectory = Path.Combine(Path.GetTempPath(), "NuGet.Jobs.GitHubIndexer");
         private const string BlobStorageContainerName = "content";
         private const string GitHubUsageFileName = "GitHubUsage.v1.json";
         public const int MaxBlobSizeBytes = 1 << 20; // 1 MB = 2^20

--- a/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/ReposIndexer.cs
@@ -21,7 +21,7 @@ namespace NuGet.Jobs.GitHubIndexer
         private const string GitHubUsageFileName = "GitHubUsage.v1.json";
         public const int MaxBlobSizeBytes = 1 << 20; // 1 MB = 2^20
 
-        private static string WorkingDirectory = Path.Combine(Path.GetTempPath(), "NuGet.Jobs.GitHubIndexer");
+        private static readonly string WorkingDirectory = Path.Combine(Path.GetTempPath(), "NuGet.Jobs.GitHubIndexer");
         public static readonly string RepositoriesDirectory = Path.Combine(WorkingDirectory, "repos");
         public static readonly string CacheDirectory = Path.Combine(WorkingDirectory, "cache");
         private static readonly JsonSerializer Serializer = new JsonSerializer();


### PR DESCRIPTION
https://github.com/nuget/nugetgallery/issues/7575

With this change, `WorkingDirectory` becomes something like `C:\Users\<username>\AppData\Local\Temp\NuGet.Jobs.GitHubIndexer`, which is shared between all runs of the job as the same user, but also doesn't make any assumptions about the user's system. Because our jobs run as the system account, this will likely be `C:\Windows\System32\config\systemprofile\AppData\Local\Temp\NuGet.Jobs.GitHubIndexer`.