### PR TITLE
Ensure RollUpDownloadFacts always loses deadlock

### DIFF
--- a/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.RollUpDownloadFacts.sql
+++ b/src/Stats.Warehouse/Programmability/Stored Procedures/dbo.RollUpDownloadFacts.sql
@@ -5,6 +5,10 @@ AS
 BEGIN
 	SET NOCOUNT ON;
 
+	-- We want this query to always be the deadlock victim.
+	-- Rolling up existing download facts is not as important as inserting new statistics.
+	SET DEADLOCK_PRIORITY LOW;
+
 	IF @MinAgeInDays IS NOT NULL
 	BEGIN
 


### PR DESCRIPTION
Part of the fix for https://github.com/nuget/engineering/issues/2721

RollUpDownloadFacts will no longer be able to block write if it has low deadlock priority.

This change will coupled with a job frequency change that ensures that the job restarts itself quickly in case it loses a deadlock, so that it does not fall behind.