### PR TITLE
Disable FtpWebRequest KeepAlive to avoid hang when FTP server is unavailable

### DIFF
--- a/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
+++ b/src/Stats.CollectAzureCdnLogs/Ftp/FtpRawLogClient.cs
@@ -205,6 +205,7 @@ namespace Stats.CollectAzureCdnLogs.Ftp
             var request = (FtpWebRequest)WebRequest.Create(uri);
             request.Credentials = new NetworkCredential(_username, _password);
             request.EnableSsl = true;
+            request.KeepAlive = false;
 
             return request;
         }


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/2794.

Same underlying issue as https://nuget.visualstudio.com/NuGetMicrosoft/_git/NuGetMonitoring/pullrequest/1170?_a=overview.