### PR TITLE
Add 60 second blob lease per package ID/version to orchestrator

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.Leases;
 using NuGet.Services.Entities;
 using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
@@ -15,11 +17,15 @@ namespace NuGet.Services.Validation.Orchestrator
     public abstract class BaseValidationMessageHandler<TEntity>
         : IMessageHandler<PackageValidationMessageData> where TEntity : class, IEntity
     {
+        private static readonly TimeSpan LeaseTime = TimeSpan.FromMinutes(1);
+
         private readonly ValidationConfiguration _configs;
         private readonly IEntityService<TEntity> _entityService;
         private readonly IValidationSetProvider<TEntity> _validationSetProvider;
         private readonly IValidationSetProcessor _validationSetProcessor;
         private readonly IValidationOutcomeProcessor<TEntity> _validationOutcomeProcessor;
+        private readonly ILeaseService _leaseService;
+        private readonly IPackageValidationEnqueuer _validationEnqueuer;
         private readonly IFeatureFlagService _featureFlagService;
         private readonly ITelemetryService _telemetryService;
         private readonly ILogger _logger;
@@ -30,6 +36,8 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidationSetProvider<TEntity> validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
             IValidationOutcomeProcessor<TEntity> validationOutcomeProcessor,
+            ILeaseService leaseService,
+            IPackageValidationEnqueuer validationEnqueuer,
             IFeatureFlagService featureFlagService,
             ITelemetryService telemetryService,
             ILogger logger)
@@ -58,6 +66,8 @@ namespace NuGet.Services.Validation.Orchestrator
             _validationSetProvider = validationSetProvider ?? throw new ArgumentNullException(nameof(validationSetProvider));
             _validationSetProcessor = validationSetProcessor ?? throw new ArgumentNullException(nameof(validationSetProcessor));
             _validationOutcomeProcessor = validationOutcomeProcessor ?? throw new ArgumentNullException(nameof(validationOutcomeProcessor));
+            _leaseService = leaseService ?? throw new ArgumentNullException(nameof(leaseService));
+            _validationEnqueuer = validationEnqueuer ?? throw new ArgumentNullException(nameof(leaseService));
             _featureFlagService = featureFlagService ?? throw new ArgumentNullException(nameof(featureFlagService));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -149,7 +159,28 @@ namespace NuGet.Services.Validation.Orchestrator
                 validationSet.PackageKey,
                 validationSet.ValidationTrackingId))
             {
-                await ProcessValidationSetAsync(entity, validationSet, scheduleNextCheck: false);
+                var lease = await TryAcquireLeaseAsync(validationSet.PackageId, validationSet.PackageNormalizedVersion);
+                if (lease.State == LeaseContextState.Unavailable)
+                {
+                    // If the lease is unavailable, we can drop this message. This part of the handler is processing a
+                    // queue-back message. We don't need to retry these since there is the main retry loop also occurring in
+                    // parallel.
+                    _logger.LogInformation(
+                        "The lease {ResourceName} is unavailable. Dropping check validator message for validation set " +
+                        "{ValidationSetId}.",
+                        lease.ResourceName,
+                        validationSet.ValidationTrackingId);
+                    return true;
+                }
+                
+                try
+                {
+                    await ProcessValidationSetAsync(entity, validationSet, scheduleNextCheck: false);
+                }
+                finally
+                {
+                    await TryReleaseLeaseAsync(lease);
+                }
             }
 
             return true;
@@ -223,25 +254,116 @@ namespace NuGet.Services.Validation.Orchestrator
                     return true;
                 }
 
-                var validationSet = await _validationSetProvider.TryGetOrCreateValidationSetAsync(message, entity);
-
-                if (validationSet == null)
+                var lease = await TryAcquireLeaseAsync(message.PackageId, message.PackageNormalizedVersion);
+                if (lease.State == LeaseContextState.Unavailable)
                 {
                     _logger.LogInformation(
-                        "The validation request for {ValidatingType} {PackageId} {PackageVersion} {Key} " +
-                        "{ValidationSetId} is a duplicate. Discarding the message.",
-                        ValidatingType,
+                        "The lease {ResourceName} is unavailable. Retrying this message in {LeaseTime}.",
+                        lease.ResourceName,
+                        LeaseTime);
+                    var messageData = PackageValidationMessageData.NewProcessValidationSet(
                         message.PackageId,
                         message.PackageNormalizedVersion,
-                        entity.Key,
-                        message.ValidationTrackingId);
+                        message.ValidationTrackingId,
+                        message.ValidatingType,
+                        message.EntityKey);
+                    var postponeUntil = DateTimeOffset.UtcNow + LeaseTime;
+                    await _validationEnqueuer.SendMessageAsync(messageData, postponeUntil);
                     return true;
                 }
 
-                await ProcessValidationSetAsync(entity, validationSet, scheduleNextCheck: true);
+                try
+                {
+                    var validationSet = await _validationSetProvider.TryGetOrCreateValidationSetAsync(message, entity);
+
+                    if (validationSet == null)
+                    {
+                        _logger.LogInformation(
+                            "The validation request for {ValidatingType} {PackageId} {PackageVersion} {Key} " +
+                            "{ValidationSetId} is a duplicate. Discarding the message.",
+                            ValidatingType,
+                            message.PackageId,
+                            message.PackageNormalizedVersion,
+                            entity.Key,
+                            message.ValidationTrackingId);
+                        return true;
+                    }
+
+                    await ProcessValidationSetAsync(entity, validationSet, scheduleNextCheck: true);
+                }
+                finally
+                {
+                    await TryReleaseLeaseAsync(lease);
+                }
             }
 
             return true;
+        }
+
+        private async Task<LeaseContext> TryAcquireLeaseAsync(string id, string normalizedVersion)
+        {
+            if (!_featureFlagService.IsOrchestratorLeaseEnabled())
+            {
+                return new LeaseContext(LeaseContextState.Skipped, resourceName: null, leaseId: null);
+            }
+
+            var resourceName = $"{ValidatingType}/{id.ToLowerInvariant()}/{normalizedVersion.ToLowerInvariant()}";
+
+            _logger.LogInformation(
+                "Attempting to acquire lease {ResourceName} for {LeaseTime}.",
+                resourceName,
+                LeaseTime);
+
+            var result = await _leaseService.TryAcquireAsync(resourceName, LeaseTime, CancellationToken.None);
+            if (result.IsSuccess)
+            {
+                _logger.LogInformation(
+                    "The lease {ResourceName} is has been acquired with lease ID {LeaseId}.",
+                    resourceName,
+                    result.LeaseId);
+            }
+
+            return new LeaseContext(
+                result.IsSuccess ? LeaseContextState.Acquired : LeaseContextState.Unavailable,
+                resourceName,
+                result.LeaseId);
+        }
+
+        private async Task TryReleaseLeaseAsync(LeaseContext lease)
+        {
+            if (lease.State != LeaseContextState.Acquired)
+            {
+                return;
+            }
+
+            try
+            {
+                var gracefulRelease = await _leaseService.ReleaseAsync(lease.ResourceName, lease.LeaseId, CancellationToken.None);
+                if (!gracefulRelease)
+                {
+                    _logger.LogWarning(
+                        "The lease {ResourceName} was not released gracefully with lease ID {LeaseId}. " +
+                        "This typically indicates another thread has obtained the lease.",
+                        lease.ResourceName,
+                        lease.LeaseId);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "The lease {ResourceName} with lease ID {LeaseId} has been released gracefully.",
+                        lease.ResourceName,
+                        lease.LeaseId);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    0,
+                    ex,
+                    "Releasing the lease {ResourceName} with lease ID {LeaseId} failed.",
+                    lease.ResourceName,
+                    lease.LeaseId);
+            }
         }
 
         private async Task ProcessValidationSetAsync(
@@ -269,6 +391,38 @@ namespace NuGet.Services.Validation.Orchestrator
                 entity,
                 processorStats,
                 scheduleNextCheck);
+        }
+
+        private class LeaseContext
+        {
+            public LeaseContext(LeaseContextState state, string resourceName, string leaseId)
+            {
+                ResourceName = resourceName;
+                State = state;
+                LeaseId = leaseId;
+            }
+
+            public string ResourceName { get; }
+            public LeaseContextState State { get; }
+            public string LeaseId { get; }
+        }
+
+        private enum LeaseContextState
+        {
+            /// <summary>
+            /// The lease has been acquired.
+            /// </summary>
+            Acquired,
+
+            /// <summary>
+            /// The lease is unavailable suggesting that another thread is processing this same entity.
+            /// </summary>
+            Unavailable,
+
+            /// <summary>
+            /// The lease acquisition was skipped allowing parallel execution.
+            /// </summary>
+            Skipped,
         }
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageSigning/ProcessSignature/PackageSignatureValidator.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.Storage;
-using NuGet.Services.Validation.Orchestrator;
 using NuGet.Services.Validation.Orchestrator.PackageSigning.ScanAndSign;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 using NuGetGallery;

--- a/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.Leases;
 using NuGet.Services.Entities;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 
@@ -17,6 +18,8 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidationSetProvider<Package> validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
             IValidationOutcomeProcessor<Package> validationOutcomeProcessor,
+            ILeaseService leaseService,
+            IPackageValidationEnqueuer validationEnqueuer,
             IFeatureFlagService featureFlagService,
             ITelemetryService telemetryService,
             ILogger<PackageValidationMessageHandler> logger) : base(
@@ -25,6 +28,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 validationSetProvider,
                 validationSetProcessor,
                 validationOutcomeProcessor,
+                leaseService,
+                validationEnqueuer,
                 featureFlagService,
                 telemetryService,
                 logger)

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.Leases;
 using NuGet.Services.Entities;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
 
@@ -20,6 +21,8 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidationSetProvider<SymbolPackage> validationSetProvider,
             IValidationSetProcessor validationSetProcessor,
             IValidationOutcomeProcessor<SymbolPackage> validationOutcomeProcessor,
+            ILeaseService leaseService,
+            IPackageValidationEnqueuer validationEnqueuer,
             IFeatureFlagService featureFlagService,
             ITelemetryService telemetryService,
             ILogger<SymbolValidationMessageHandler> logger) : base(
@@ -28,6 +31,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 validationSetProvider,
                 validationSetProcessor,
                 validationOutcomeProcessor,
+                leaseService,
+                validationEnqueuer,
                 featureFlagService,
                 telemetryService,
                 logger)

--- a/src/Validation.Common.Job/FeatureFlags/FeatureFlagService.cs
+++ b/src/Validation.Common.Job/FeatureFlags/FeatureFlagService.cs
@@ -21,5 +21,10 @@ namespace NuGet.Jobs.Validation
         {
             return _featureFlagClient.IsEnabled(ValidationPrefix + "QueueBack", defaultValue: false);
         }
+
+        public bool IsOrchestratorLeaseEnabled()
+        {
+            return _featureFlagClient.IsEnabled(ValidationPrefix + "OrchestratorLease", defaultValue: false);
+        }
     }
 }

--- a/src/Validation.Common.Job/FeatureFlags/IFeatureFlagService.cs
+++ b/src/Validation.Common.Job/FeatureFlags/IFeatureFlagService.cs
@@ -11,5 +11,12 @@ namespace NuGet.Jobs.Validation
         /// https://github.com/NuGet/NuGetGallery/issues/7185
         /// </summary>
         bool IsQueueBackEnabled();
+
+        /// <summary>
+        /// Determines whether orchestrator should try to acquire a lease specific to the entity it is processing.
+        /// The progress of this work is tracked here:
+        /// https://github.com/NuGet/NuGetGallery/issues/7629
+        /// </summary>
+        bool IsOrchestratorLeaseEnabled();
     }
 }

--- a/src/Validation.Common.Job/Leases/LeaseConfiguration.cs
+++ b/src/Validation.Common.Job/Leases/LeaseConfiguration.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Jobs.Validation.Leases
+{
+    public class LeaseConfiguration
+    {
+        public string ConnectionString { get; set; }
+        public string ContainerName { get; set; }
+        public string StoragePath { get; set; }
+    }
+}

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ICommonTelemetryService.cs" />
     <Compile Include="IPackageDownloader.cs" />
     <Compile Include="Leases\ILeaseService.cs" />
+    <Compile Include="Leases\LeaseConfiguration.cs" />
     <Compile Include="Leases\LeaseResult.cs" />
     <Compile Include="Leases\CloudBlobLeaseService.cs" />
     <Compile Include="LoggerDiagnosticsService.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/BaseValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/BaseValidationMessageHandlerFacts.cs
@@ -1,0 +1,299 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elmah.ContentSyndication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.ServiceBus.Messaging;
+using Moq;
+using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.Leases;
+using NuGet.Services.Entities;
+using NuGet.Services.Validation.Orchestrator.Telemetry;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Services.Validation.Orchestrator.Tests
+{
+    public class BaseValidationMessageHandlerFacts
+    {
+        public class HandleCheckValidatorAsync : CommonFacts
+        {
+            public HandleCheckValidatorAsync(ITestOutputHelper output) : base(output)
+            {
+                ValidationId = new Guid("1f25a05c-4bbb-4366-a0bf-d9acef69cca1");
+                Message = PackageValidationMessageData.NewCheckValidator(ValidationId);
+
+                ValidationSetProvider
+                    .Setup(x => x.TryGetParentValidationSetAsync(It.IsAny<Guid>()))
+                    .ReturnsAsync(() => ValidationSet);
+            }
+
+            public Guid ValidationId { get; }
+        }
+
+        public class HandleProcessValidationSetAsync : CommonFacts
+        {
+            public HandleProcessValidationSetAsync(ITestOutputHelper output) : base(output)
+            {
+                Message = PackageValidationMessageData.NewProcessValidationSet(
+                    ValidationSet.PackageId,
+                    ValidationSet.PackageNormalizedVersion,
+                    ValidationSet.ValidationTrackingId,
+                    ValidationSet.ValidatingType,
+                    ValidationSet.PackageKey);
+
+                ValidationSetProvider
+                    .Setup(x => x.TryGetOrCreateValidationSetAsync(
+                        It.IsAny<ProcessValidationSetData>(),
+                        It.IsAny<IValidatingEntity<TestEntity>>()))
+                    .ReturnsAsync(() => ValidationSet);
+            }
+        }
+
+        public abstract class CommonFacts : Facts
+        {
+            public CommonFacts(ITestOutputHelper output) : base(output)
+            {
+            }
+
+            public PackageValidationMessageData Message { get; set; }
+
+            [Fact]
+            public async Task DoesNotAcquireLeaseWhenFeatureFlagIsDisabled()
+            {
+                FeatureFlagService.Setup(x => x.IsOrchestratorLeaseEnabled()).Returns(false);
+
+                var success = await Target.HandleAsync(Message);
+
+                Assert.True(success);
+                VerifyAcquire(Times.Never);
+                ValidationSetProcessor.Verify(
+                    x => x.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()),
+                    Times.Once);
+                ValidationOutcomeProcessor.Verify(
+                    x => x.ProcessValidationOutcomeAsync(
+                        It.IsAny<PackageValidationSet>(),
+                        It.IsAny<IValidatingEntity<TestEntity>>(),
+                        It.IsAny<ValidationSetProcessorResult>(),
+                        It.IsAny<bool>()),
+                    Times.Once);
+                VerifyRelease(Times.Never);
+            }
+
+            [Fact]
+            public async Task ReleasesAcquiredLeaseOnException()
+            {
+                var exception = new InvalidOperationException("Fail!");
+                ValidationSetProcessor
+                    .Setup(x => x.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()))
+                    .Throws(exception);
+
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => Target.HandleAsync(Message));
+                Assert.Same(exception, actual);
+
+                VerifyAcquire(Times.Once);
+                ValidationSetProcessor.Verify(
+                    x => x.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()),
+                    Times.Once);
+                ValidationOutcomeProcessor.Verify(
+                    x => x.ProcessValidationOutcomeAsync(
+                        It.IsAny<PackageValidationSet>(),
+                        It.IsAny<IValidatingEntity<TestEntity>>(),
+                        It.IsAny<ValidationSetProcessorResult>(),
+                        It.IsAny<bool>()),
+                    Times.Never);
+                VerifyRelease(Times.Once);
+            }
+
+            [Fact]
+            public async Task ReleasesAcquiredLeaseOnSuccess()
+            {
+                var success = await Target.HandleAsync(Message);
+
+                Assert.True(success);
+                VerifyAcquire(Times.Once);
+                ValidationSetProcessor.Verify(
+                    x => x.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()),
+                    Times.Once);
+                ValidationOutcomeProcessor.Verify(
+                    x => x.ProcessValidationOutcomeAsync(
+                        It.IsAny<PackageValidationSet>(),
+                        It.IsAny<IValidatingEntity<TestEntity>>(),
+                        It.IsAny<ValidationSetProcessorResult>(),
+                        It.IsAny<bool>()),
+                    Times.Once);
+                VerifyRelease(Times.Once);
+            }
+
+            [Fact]
+            public async Task SwallowsReleaseException()
+            {
+                var processorException = new InvalidOperationException("Fail!");
+                ValidationSetProcessor
+                    .Setup(x => x.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()))
+                    .Throws(processorException);
+                var leaseException = new ArgumentException("Release fail!");
+                LeaseService
+                    .Setup(x => x.ReleaseAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Throws(leaseException);
+
+                var actual = await Assert.ThrowsAsync<InvalidOperationException>(() => Target.HandleAsync(Message));
+                Assert.Same(processorException, actual);
+
+                VerifyAcquire(Times.Once);
+                ValidationSetProcessor.Verify(
+                    x => x.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()),
+                    Times.Once);
+                ValidationOutcomeProcessor.Verify(
+                    x => x.ProcessValidationOutcomeAsync(
+                        It.IsAny<PackageValidationSet>(),
+                        It.IsAny<IValidatingEntity<TestEntity>>(),
+                        It.IsAny<ValidationSetProcessorResult>(),
+                        It.IsAny<bool>()),
+                    Times.Never);
+                VerifyRelease(Times.Once);
+            }
+        }
+
+        public abstract class Facts
+        {
+            public Facts(ITestOutputHelper output)
+            {
+                Options = new Mock<IOptionsSnapshot<ValidationConfiguration>>();
+                EntityService = new Mock<IEntityService<TestEntity>>();
+                ValidationSetProvider = new Mock<IValidationSetProvider<TestEntity>>();
+                ValidationSetProcessor = new Mock<IValidationSetProcessor>();
+                ValidationOutcomeProcessor = new Mock<IValidationOutcomeProcessor<TestEntity>>();
+                LeaseService = new Mock<ILeaseService>();
+                PackageValidationEnqueuer = new Mock<IPackageValidationEnqueuer>();
+                FeatureFlagService = new Mock<IFeatureFlagService>();
+                TelemetryService = new Mock<ITelemetryService>();
+                Logger = new LoggerFactory().AddXunit(output).CreateLogger<SymbolValidationMessageHandler>();
+
+                Config = new ValidationConfiguration
+                {
+                    MissingPackageRetryCount = 1,
+                };
+                ValidatingEntity = new Mock<IValidatingEntity<TestEntity>>();
+                ValidationSet = new PackageValidationSet
+                {
+                    PackageKey = 42,
+                    ValidationTrackingId = new Guid("dc2aa638-a23c-4791-a4ff-c3e07b1320a4"),
+                    PackageId = "NuGet.Versioning",
+                    PackageNormalizedVersion = "5.3.0-BETA",
+                    ValidatingType = ValidatingType.Package,
+                    ValidationSetStatus = ValidationSetStatus.InProgress,
+                };
+                LeaseResourceName = "Package/nuget.versioning/5.3.0-beta";
+                ValidationSetProcessorResult = new ValidationSetProcessorResult();
+                LeaseResult = LeaseResult.Success("lease-id");
+                
+                Options.Setup(x => x.Value).Returns(() => Config);
+                EntityService
+                    .Setup(x => x.FindPackageByKey(It.IsAny<int>()))
+                    .Returns(() => ValidatingEntity.Object);
+                ValidationSetProcessor
+                    .Setup(x => x.ProcessValidationsAsync(It.IsAny<PackageValidationSet>()))
+                    .ReturnsAsync(() => ValidationSetProcessorResult);
+                ValidatingEntity
+                    .Setup(x => x.Status)
+                    .Returns(PackageStatus.Validating);
+                LeaseService
+                    .Setup(x => x.TryAcquireAsync(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => LeaseResult);
+
+                FeatureFlagService.Setup(x => x.IsQueueBackEnabled()).Returns(true);
+                FeatureFlagService.Setup(x => x.IsOrchestratorLeaseEnabled()).Returns(true);
+
+                Target = new TestHandler(
+                    Options.Object,
+                    EntityService.Object,
+                    ValidationSetProvider.Object,
+                    ValidationSetProcessor.Object,
+                    ValidationOutcomeProcessor.Object,
+                    LeaseService.Object,
+                    PackageValidationEnqueuer.Object,
+                    FeatureFlagService.Object,
+                    TelemetryService.Object,
+                    Logger);
+            }
+
+            public Mock<IOptionsSnapshot<ValidationConfiguration>> Options { get; }
+            public Mock<IEntityService<TestEntity>> EntityService { get; }
+            public Mock<IValidationSetProvider<TestEntity>> ValidationSetProvider { get; }
+            public Mock<IValidationSetProcessor> ValidationSetProcessor { get; }
+            public Mock<IValidationOutcomeProcessor<TestEntity>> ValidationOutcomeProcessor { get; }
+            public Mock<ILeaseService> LeaseService { get; }
+            public Mock<IPackageValidationEnqueuer> PackageValidationEnqueuer { get; }
+            public Mock<IFeatureFlagService> FeatureFlagService { get; }
+            public Mock<ITelemetryService> TelemetryService { get; }
+            public ILogger<SymbolValidationMessageHandler> Logger { get; }
+            public ValidationConfiguration Config { get; }
+            public TestHandler Target { get; }
+            public Mock<IValidatingEntity<TestEntity>> ValidatingEntity { get; }
+            public PackageValidationSet ValidationSet { get; }
+            public string LeaseResourceName { get; }
+            public ValidationSetProcessorResult ValidationSetProcessorResult { get; }
+            public LeaseResult LeaseResult { get; set; }
+
+            public void VerifyAcquire(Func<Times> times)
+            {
+                LeaseService.Verify(
+                    x => x.TryAcquireAsync(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+                    times);
+                LeaseService.Verify(
+                    x => x.TryAcquireAsync(LeaseResourceName, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()),
+                    times);
+            }
+
+            public void VerifyRelease(Func<Times> times)
+            {
+                LeaseService.Verify(
+                    x => x.ReleaseAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    times);
+                LeaseService.Verify(
+                    x => x.ReleaseAsync(LeaseResourceName, LeaseResult.LeaseId, It.IsAny<CancellationToken>()),
+                    times);
+            }
+        }
+
+        public class TestHandler : BaseValidationMessageHandler<TestEntity>
+        {
+            public TestHandler(
+                IOptionsSnapshot<ValidationConfiguration> validationConfigsAccessor,
+                IEntityService<TestEntity> entityService,
+                IValidationSetProvider<TestEntity> validationSetProvider,
+                IValidationSetProcessor validationSetProcessor,
+                IValidationOutcomeProcessor<TestEntity> validationOutcomeProcessor,
+                ILeaseService leaseService,
+                IPackageValidationEnqueuer validationEnqueuer,
+                IFeatureFlagService featureFlagService,
+                ITelemetryService telemetryService,
+                ILogger logger) : base(
+                    validationConfigsAccessor,
+                    entityService,
+                    validationSetProvider,
+                    validationSetProcessor,
+                    validationOutcomeProcessor,
+                    leaseService,
+                    validationEnqueuer,
+                    featureFlagService,
+                    telemetryService,
+                    logger)
+            {
+            }
+
+            protected override ValidatingType ValidatingType => ValidatingType.Package;
+            protected override bool ShouldNoOpDueToDeletion => true;
+        }
+
+        public class TestEntity : IEntity
+        {
+            public int Key { get; set; }
+        }
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BaseValidationMessageHandlerFacts.cs" />
     <Compile Include="Configuration\ConfigurationValidatorFacts.cs" />
     <Compile Include="Configuration\CoreMessageServiceConfigurationFacts.cs" />
     <Compile Include="Configuration\TopologicalSortFacts.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.Leases;
 using NuGet.Services.Entities;
 using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
@@ -371,6 +372,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         protected Mock<IValidationSetProvider<SymbolPackage>> ValidationSetProviderMock { get; }
         protected Mock<IValidationSetProcessor> ValidationSetProcessorMock { get; }
         protected Mock<IValidationOutcomeProcessor<SymbolPackage>> ValidationOutcomeProcessorMock { get; }
+        protected Mock<ILeaseService> LeaseService { get; }
+        protected Mock<IPackageValidationEnqueuer> ValidationEnqueuer { get; }
         protected Mock<IFeatureFlagService> FeatureFlagService { get; }
         protected Mock<ITelemetryService> TelemetryServiceMock { get; }
         protected ILogger<SymbolValidationMessageHandler> Logger { get; }
@@ -382,10 +385,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationSetProviderMock = new Mock<IValidationSetProvider<SymbolPackage>>(mockBehavior);
             ValidationSetProcessorMock = new Mock<IValidationSetProcessor>(mockBehavior);
             ValidationOutcomeProcessorMock = new Mock<IValidationOutcomeProcessor<SymbolPackage>>(mockBehavior);
+            LeaseService = new Mock<ILeaseService>(mockBehavior);
+            ValidationEnqueuer = new Mock<IPackageValidationEnqueuer>(mockBehavior);
             FeatureFlagService = new Mock<IFeatureFlagService>(mockBehavior);
             TelemetryServiceMock = new Mock<ITelemetryService>(mockBehavior);
 
             FeatureFlagService.Setup(x => x.IsQueueBackEnabled()).Returns(true);
+            FeatureFlagService.Setup(x => x.IsOrchestratorLeaseEnabled()).Returns(false);
 
             // we generally don't care about how logger is called, so don't make a strict mock.
             Logger = new LoggerFactory().AddXunit(output).CreateLogger<SymbolValidationMessageHandler>();
@@ -403,6 +409,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSetProviderMock.Object,
                 ValidationSetProcessorMock.Object,
                 ValidationOutcomeProcessorMock.Object,
+                LeaseService.Object,
+                ValidationEnqueuer.Object,
                 FeatureFlagService.Object,
                 TelemetryServiceMock.Object,
                 Logger);

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Jobs.Validation;
+using NuGet.Jobs.Validation.Leases;
 using NuGet.Services.Entities;
 using NuGet.Services.ServiceBus;
 using NuGet.Services.Validation.Orchestrator.Telemetry;
@@ -451,6 +452,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         protected Mock<IValidationSetProvider<Package>> ValidationSetProviderMock { get; }
         protected Mock<IValidationSetProcessor> ValidationSetProcessorMock { get; }
         protected Mock<IValidationOutcomeProcessor<Package>> ValidationOutcomeProcessorMock { get; }
+        protected Mock<ILeaseService> LeaseService { get; }
+        protected Mock<IPackageValidationEnqueuer> ValidationEnqueuer { get; }
         protected Mock<IFeatureFlagService> FeatureFlagService { get; }
         protected Mock<ITelemetryService> TelemetryServiceMock { get; }
         protected ILogger<PackageValidationMessageHandler> Logger { get; }
@@ -464,10 +467,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationSetProviderMock = new Mock<IValidationSetProvider<Package>>(mockBehavior);
             ValidationSetProcessorMock = new Mock<IValidationSetProcessor>(mockBehavior);
             ValidationOutcomeProcessorMock = new Mock<IValidationOutcomeProcessor<Package>>(mockBehavior);
+            LeaseService = new Mock<ILeaseService>(mockBehavior);
+            ValidationEnqueuer = new Mock<IPackageValidationEnqueuer>(mockBehavior);
             FeatureFlagService = new Mock<IFeatureFlagService>(mockBehavior);
             TelemetryServiceMock = new Mock<ITelemetryService>(mockBehavior);
 
             FeatureFlagService.Setup(x => x.IsQueueBackEnabled()).Returns(true);
+            FeatureFlagService.Setup(x => x.IsOrchestratorLeaseEnabled()).Returns(false);
 
             // we generally don't care about how logger is called, so don't make a strict mock.
             Logger = new LoggerFactory().AddXunit(output).CreateLogger<PackageValidationMessageHandler>();
@@ -485,6 +491,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSetProviderMock.Object,
                 ValidationSetProcessorMock.Object,
                 ValidationOutcomeProcessorMock.Object,
+                LeaseService.Object,
+                ValidationEnqueuer.Object,
                 FeatureFlagService.Object,
                 TelemetryServiceMock.Object,
                 Logger);


### PR DESCRIPTION
Progress on https://github.com/NuGet/NuGetGallery/issues/7629.

Over the past 90 days, the message processing duration for the orchestrator were like this:

Percentile | Value
-- | --
50 | 0.6 seconds
95 | 2.7 seconds
99 | 8.0 seconds
99.9 | 27.3 seconds
99.99 | 45.0 seconds
99.999 | 91.2 seconds

1,391,413 messages were below 60 seconds. 56 were above 60 seconds.

If the lease expires we can potentially get the same concurrency that we have today.

With a queue spamming tool on DEV I was able to reproduce three issues:

1. Multiple concurrent validation sets around the same time
1. Multiple repo signed packages meaning all but one validation set succeed
1. Zero byte blob after handling processor output

With this lease all 3 issues were solved. They are still possible if the lease expires (60 seconds) but based on the data above this is exceedingly rare. If this case becomes a pain point we can introduce lease renewal.