### PR TITLE
Update ApplicationInsights configuration

### DIFF
--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -92,7 +92,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -92,7 +92,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Jobs.Configuration;
 using NuGet.Services.KeyVault;
+using NuGet.Services.Logging;
 using NuGet.Services.Sql;
 
 namespace NuGet.Jobs
@@ -36,6 +37,8 @@ namespace NuGet.Jobs
         protected ILoggerFactory LoggerFactory { get; private set; }
 
         protected ILogger Logger { get; private set; }
+
+        protected ApplicationInsightsConfiguration ApplicationInsightsConfiguration { get; private set; }
 
         private Dictionary<string, ICoreSqlConnectionFactory> SqlConnectionFactories { get; }
 
@@ -224,6 +227,11 @@ namespace NuGet.Jobs
             }
 
             return GetSqlConnectionFactory(connectionStringArgName).OpenAsync();
+        }
+
+        internal void SetApplicationInsightsConfiguration(ApplicationInsightsConfiguration applicationInsightsConfiguration)
+        {
+            ApplicationInsightsConfiguration = applicationInsightsConfiguration ?? throw new ArgumentNullException(nameof(applicationInsightsConfiguration));
         }
     }
 }

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -155,6 +155,7 @@ namespace NuGet.Jobs
 
             Trace.Close();
             _applicationInsightsConfiguration.TelemetryConfiguration.TelemetryChannel.Flush();
+            _applicationInsightsConfiguration.Dispose();
 
             return exitCode;
         }

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -19,6 +19,7 @@ namespace NuGet.Jobs
         public static IServiceContainer ServiceContainer;
 
         private static ILogger _logger;
+        private static ApplicationInsightsConfiguration _applicationInsightsConfiguration;
 
         private const string HeartbeatProperty_JobLoopExitCode = "JobLoopExitCode";
         private const string JobSucceeded = "Job Succeeded";
@@ -82,30 +83,8 @@ namespace NuGet.Jobs
                     loggerFactory.CreateLogger(typeof(JobConfigurationManager)),
                     commandLineArgs);
 
-                // Determine job and instance name, for logging.
-                var jobName = job.GetType().Assembly.GetName().Name;
-                var instanceName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstanceName) ?? jobName;
-                TelemetryConfiguration.Active.TelemetryInitializers.Add(new JobNameTelemetryInitializer(jobName, instanceName));
-
                 // Setup logging
-                if (!ApplicationInsights.Initialized)
-                {
-                    var instrumentationKey = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstrumentationKey);
-                    var heartbeatIntervalSeconds = JobConfigurationManager.TryGetIntArgument(jobArgsDictionary, JobArgumentNames.HeartbeatIntervalSeconds);
-                    if (!string.IsNullOrWhiteSpace(instrumentationKey))
-                    {
-                        if (heartbeatIntervalSeconds.HasValue)
-                        {
-                            ApplicationInsights.Initialize(
-                                instrumentationKey,
-                                TimeSpan.FromSeconds(heartbeatIntervalSeconds.Value));
-                        }
-                        else
-                        {
-                            ApplicationInsights.Initialize(instrumentationKey);
-                        }
-                    }
-                }
+                _applicationInsightsConfiguration = ConfigureApplicationInsights(job, jobArgsDictionary);
 
                 // Configure our logging again with Application Insights initialized.
                 loggerFactory = ConfigureLogging(job);
@@ -175,9 +154,43 @@ namespace NuGet.Jobs
             }
 
             Trace.Close();
-            TelemetryConfiguration.Active.TelemetryChannel.Flush();
+            _applicationInsightsConfiguration.TelemetryConfiguration.TelemetryChannel.Flush();
 
             return exitCode;
+        }
+
+        private static ApplicationInsightsConfiguration ConfigureApplicationInsights(JobBase job, IDictionary<string, string> jobArgsDictionary)
+        {
+            ApplicationInsightsConfiguration applicationInsightsConfiguration;
+
+            var instrumentationKey = JobConfigurationManager.TryGetArgument(
+                jobArgsDictionary,
+                JobArgumentNames.InstrumentationKey);
+
+            var heartbeatIntervalSeconds = JobConfigurationManager.TryGetIntArgument(
+                jobArgsDictionary,
+                JobArgumentNames.HeartbeatIntervalSeconds);
+
+            if (heartbeatIntervalSeconds.HasValue)
+            {
+                applicationInsightsConfiguration = ApplicationInsights.Initialize(
+                    instrumentationKey,
+                    TimeSpan.FromSeconds(heartbeatIntervalSeconds.Value));
+            }
+            else
+            {
+                applicationInsightsConfiguration = ApplicationInsights.Initialize(instrumentationKey);
+            }
+
+            // Determine job and instance name, for logging.
+            var jobName = job.GetType().Assembly.GetName().Name;
+            var instanceName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstanceName) ?? jobName;
+            applicationInsightsConfiguration.TelemetryConfiguration.TelemetryInitializers.Add(
+                new JobNameTelemetryInitializer(jobName, instanceName));
+
+            job.SetApplicationInsightsConfiguration(applicationInsightsConfiguration);
+
+            return applicationInsightsConfiguration;
         }
 
         private static ILoggerFactory ConfigureLogging(JobBase job)
@@ -215,7 +228,7 @@ namespace NuGet.Jobs
             // This tells Application Insights that, even though a heartbeat is reported, 
             // the state of the application is unhealthy when the exitcode is different from zero.
             // The heartbeat metadata is enriched with the job loop exit code.
-            ApplicationInsights.HeartbeatManager?.AddHeartbeatProperty(
+            _applicationInsightsConfiguration.DiagnosticsTelemetryModule?.AddHeartbeatProperty(
                 HeartbeatProperty_JobLoopExitCode,
                 exitCode.ToString(),
                 isHealthy: exitCode == 0);
@@ -255,7 +268,7 @@ namespace NuGet.Jobs
                     stopWatch.Stop();
                     _logger.LogInformation("Job run took {RunDuration}", PrettyPrintTime(stopWatch.ElapsedMilliseconds));
 
-                    ApplicationInsights.HeartbeatManager?.SetHeartbeatProperty(
+                    _applicationInsightsConfiguration.DiagnosticsTelemetryModule?.SetHeartbeatProperty(
                         HeartbeatProperty_JobLoopExitCode,
                         exitCode.ToString(),
                         isHealthy: exitCode == 0);

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -120,7 +120,7 @@ namespace NuGet.Jobs
             services.Configure<ServiceBusConfiguration>(configurationRoot.GetSection(ServiceBusConfigurationSectionName));
             services.Configure<ValidationStorageConfiguration>(configurationRoot.GetSection(ValidationStorageConfigurationSectionName));
 
-            services.AddSingleton(new TelemetryClient());
+            services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
 
             AddScopedSqlConnectionFactory<GalleryDbConfiguration>(services);

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -105,16 +105,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -105,16 +105,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -119,7 +119,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -119,7 +119,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -280,7 +280,7 @@ namespace NuGet.Services.Validation.Orchestrator
             services.AddTransient<ISubscriptionProcessorTelemetryService, TelemetryService>();
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
             services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
-            services.AddSingleton(new TelemetryClient());
+            services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
             services.AddTransient<IValidationOutcomeProcessor<Package>, ValidationOutcomeProcessor<Package>>();
             services.AddSingleton(p =>
             {

--- a/src/NuGetCDNRedirect/ErrorHandler/AiHandleErrorAttribute.cs
+++ b/src/NuGetCDNRedirect/ErrorHandler/AiHandleErrorAttribute.cs
@@ -1,1 +1,11 @@
-using System;using System.Web.Mvc;using Microsoft.ApplicationInsights;namespace NuGet.Services.CDNRedirect.ErrorHandler{    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]     public class AiHandleErrorAttribute : HandleErrorAttribute    {        public override void OnException(ExceptionContext filterContext)        {            if (filterContext != null && filterContext.HttpContext != null && filterContext.Exception != null)            {                //If customError is Off, then AI HTTPModule will report the exception                if (filterContext.HttpContext.IsCustomErrorEnabled)                {                       var ai = new TelemetryClient();                    ai.TrackException(filterContext.Exception);                }             }            base.OnException(filterContext);        }    }}
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;using System.Web.Mvc;using Microsoft.ApplicationInsights;using Microsoft.ApplicationInsights.Extensibility;
+
+namespace NuGet.Services.CDNRedirect.ErrorHandler{    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
+    public class AiHandleErrorAttribute : HandleErrorAttribute    {        public override void OnException(ExceptionContext filterContext)        {            if (filterContext != null && filterContext.HttpContext != null && filterContext.Exception != null)            {
+                //If customError is Off, then AI HTTPModule will report the exception
+                if (filterContext.HttpContext.IsCustomErrorEnabled)                {
+                    var ai = new TelemetryClient(TelemetryConfiguration.CreateDefault());                    ai.TrackException(filterContext.Exception);                }
+            }            base.OnException(filterContext);        }    }}

--- a/src/NuGetCDNRedirect/ErrorHandler/AiHandleErrorAttribute.cs
+++ b/src/NuGetCDNRedirect/ErrorHandler/AiHandleErrorAttribute.cs
@@ -1,11 +1,28 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;using System.Web.Mvc;using Microsoft.ApplicationInsights;using Microsoft.ApplicationInsights.Extensibility;
+using System;
+using System.Web.Mvc;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
 
-namespace NuGet.Services.CDNRedirect.ErrorHandler{    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
-    public class AiHandleErrorAttribute : HandleErrorAttribute    {        public override void OnException(ExceptionContext filterContext)        {            if (filterContext != null && filterContext.HttpContext != null && filterContext.Exception != null)            {
+namespace NuGet.Services.CDNRedirect.ErrorHandler
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
+    public class AiHandleErrorAttribute : HandleErrorAttribute
+    {
+        public override void OnException(ExceptionContext filterContext)
+        {
+            if (filterContext != null && filterContext.HttpContext != null && filterContext.Exception != null)
+            {
                 //If customError is Off, then AI HTTPModule will report the exception
-                if (filterContext.HttpContext.IsCustomErrorEnabled)                {
-                    var ai = new TelemetryClient(TelemetryConfiguration.CreateDefault());                    ai.TrackException(filterContext.Exception);                }
-            }            base.OnException(filterContext);        }    }}
+                if (filterContext.HttpContext.IsCustomErrorEnabled)
+                {
+                    var ai = new TelemetryClient(TelemetryConfiguration.CreateDefault());
+                    ai.TrackException(filterContext.Exception);
+                }
+            }
+            base.OnException(filterContext);
+        }
+    }
+}

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/PackageLagMonitor/Job.cs
+++ b/src/PackageLagMonitor/Job.cs
@@ -118,7 +118,7 @@ namespace NuGet.Jobs.Monitoring.PackageLag
             services.AddSingleton(p => new HttpClient(p.GetService<HttpClientHandler>()));
             services.AddSingleton<IHttpClientWrapper>(p => new HttpClientWrapper(p.GetService<HttpClient>()));
             services.AddTransient<IPackageLagTelemetryService, PackageLagTelemetryService>();
-            services.AddSingleton(new TelemetryClient());
+            services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
             services.AddTransient<IAzureManagementAPIWrapperConfiguration>(p => p.GetService<IOptionsSnapshot<AzureManagementAPIWrapperConfiguration>>().Value);
             services.AddTransient<PackageLagMonitorConfiguration>(p => p.GetService<IOptionsSnapshot<PackageLagMonitorConfiguration>>().Value);

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -108,7 +108,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -108,7 +108,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Stats.CreateAzureCdnWarehouseReports/ApplicationInsightsHelper.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/ApplicationInsightsHelper.cs
@@ -1,22 +1,29 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using NuGet.Services.Logging;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Stats.CreateAzureCdnWarehouseReports
 {
-    internal static class ApplicationInsightsHelper
+    internal sealed class ApplicationInsightsHelper
     {
-        public static void TrackReportProcessed(string reportName, string packageId = null)
+        private readonly TelemetryClient _telemetryClient;
+
+        public ApplicationInsightsHelper(TelemetryConfiguration telemetryConfiguration)
         {
-            if (!ApplicationInsights.Initialized)
+            if (telemetryConfiguration == null)
             {
-                return;
+                throw new ArgumentNullException(nameof(telemetryConfiguration));
             }
 
-            var telemetryClient = new TelemetryClient();
+            _telemetryClient = new TelemetryClient(telemetryConfiguration);
+        }
+
+        public void TrackReportProcessed(string reportName, string packageId = null)
+        {
             var telemetry = new MetricTelemetry(reportName, 1);
 
             if (!string.IsNullOrWhiteSpace(packageId))
@@ -24,18 +31,12 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 telemetry.Properties.Add("Package Id", packageId);
             }
 
-            telemetryClient.TrackMetric(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackMetric(telemetry);
+            _telemetryClient.Flush();
         }
 
-        public static void TrackMetric(string metricName, double value, string logFileName = null)
+        public void TrackMetric(string metricName, double value, string logFileName = null)
         {
-            if (!ApplicationInsights.Initialized)
-            {
-                return;
-            }
-
-            var telemetryClient = new TelemetryClient();
             var telemetry = new MetricTelemetry(metricName, value);
 
             if (!string.IsNullOrWhiteSpace(logFileName))
@@ -43,8 +44,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 telemetry.Properties.Add("LogFile", logFileName);
             }
 
-            telemetryClient.TrackMetric(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackMetric(telemetry);
+            _telemetryClient.Flush();
         }
     }
 }

--- a/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
@@ -32,6 +32,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
         private string[] _dataContainerNames;
         private int _sqlCommandTimeoutSeconds = DefaultSqlCommandTimeoutSeconds;
         private int _perPackageReportDegreeOfParallelism = DefaultPerPackageReportDegreeOfParallelism;
+        private ApplicationInsightsHelper _applicationInsightsHelper;
 
         private static readonly IDictionary<string, string> _storedProcedures = new Dictionary<string, string>
         {
@@ -83,6 +84,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
             }
 
             _dataContainerNames = containerNames;
+            _applicationInsightsHelper = new ApplicationInsightsHelper(ApplicationInsightsConfiguration.TelemetryConfiguration);
         }
 
         private bool ShouldGenerateReport(string reportName, string reportNameConfig)
@@ -107,8 +109,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
             stopwatch.Stop();
 
             var reportMetricName = reportName + " report";
-            ApplicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
-            ApplicationInsightsHelper.TrackReportProcessed(reportMetricName);
+            _applicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
+            _applicationInsightsHelper.TrackReportProcessed(reportMetricName);
         }
 
         public override async Task Run()
@@ -174,8 +176,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
                 stopwatch.Stop();
                 var reportMetricName = ReportNames.DownloadCount + ReportNames.Extension;
-                ApplicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
-                ApplicationInsightsHelper.TrackReportProcessed(reportMetricName);
+                _applicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
+                _applicationInsightsHelper.TrackReportProcessed(reportMetricName);
             }
 
             // build stats-totals.json
@@ -194,8 +196,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
                 stopwatch.Stop();
                 var reportMetricName = ReportNames.GalleryTotals + ReportNames.Extension;
-                ApplicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
-                ApplicationInsightsHelper.TrackReportProcessed(reportMetricName);
+                _applicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
+                _applicationInsightsHelper.TrackReportProcessed(reportMetricName);
             }
 
             // build tools.v1.json
@@ -214,8 +216,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
                 stopwatch.Stop();
                 var reportMetricName = ReportNames.DownloadsPerToolVersion + ReportNames.Extension;
-                ApplicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
-                ApplicationInsightsHelper.TrackReportProcessed(reportMetricName);
+                _applicationInsightsHelper.TrackMetric(reportMetricName + " Generation Time (ms)", stopwatch.ElapsedMilliseconds);
+                _applicationInsightsHelper.TrackReportProcessed(reportMetricName);
             }
         }
 
@@ -264,7 +266,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
                     "recentpopularity/" + _recentPopularityDetailByPackageReportBaseName + packageId);
 
                 ProcessReport(LoggerFactory, destinationContainer, reportBuilder, reportDataCollector, reportGenerationTime, Tuple.Create("@PackageId", 128, dirtyPackageId.PackageId)).Wait();
-                ApplicationInsightsHelper.TrackReportProcessed(reportBuilder.ReportName + " report", packageId);
+                _applicationInsightsHelper.TrackReportProcessed(reportBuilder.ReportName + " report", packageId);
             });
 
             // once top 100 is processed, continue with the rest
@@ -296,7 +298,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
                         {
                             ProcessReport(LoggerFactory, destinationContainer, reportGenerator.Key, reportGenerator.Value,
                                 reportGenerationTime, Tuple.Create("@PackageId", 128, dirtyPackageId.PackageId)).Wait();
-                            ApplicationInsightsHelper.TrackReportProcessed(reportGenerator.Key.ReportName + " report",
+                            _applicationInsightsHelper.TrackReportProcessed(reportGenerator.Key.ReportName + " report",
                                 dirtyPackageId.PackageId.ToLowerInvariant());
                         }
                     });

--- a/src/Stats.ImportAzureCdnStatistics/ApplicationInsightsHelper.cs
+++ b/src/Stats.ImportAzureCdnStatistics/ApplicationInsightsHelper.cs
@@ -5,20 +5,26 @@ using System;
 using System.Data.SqlClient;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using NuGet.Services.Logging;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Stats.ImportAzureCdnStatistics
 {
-    internal static class ApplicationInsightsHelper
+    internal sealed class ApplicationInsightsHelper
     {
-        public static void TrackException(Exception exception, string logFileName = null, string message = null)
+        private readonly TelemetryClient _telemetryClient;
+
+        public ApplicationInsightsHelper(TelemetryConfiguration telemetryConfiguration)
         {
-            if (!ApplicationInsights.Initialized)
+            if (telemetryConfiguration == null)
             {
-                return;
+                throw new ArgumentNullException(nameof(telemetryConfiguration));
             }
 
-            var telemetryClient = new TelemetryClient();
+            _telemetryClient = new TelemetryClient(telemetryConfiguration);
+        }
+
+        public void TrackException(Exception exception, string logFileName = null, string message = null)
+        {
             var telemetry = new ExceptionTelemetry(exception);
 
             if (!string.IsNullOrWhiteSpace(logFileName))
@@ -31,18 +37,12 @@ namespace Stats.ImportAzureCdnStatistics
                 telemetry.Properties.Add("Message", message);
             }
 
-            telemetryClient.TrackException(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackException(telemetry);
+            _telemetryClient.Flush();
         }
 
-        public static void TrackSqlException(string eventName, SqlException sqlException, string logFileName, string dimension)
+        public void TrackSqlException(string eventName, SqlException sqlException, string logFileName, string dimension)
         {
-            if (!ApplicationInsights.Initialized)
-            {
-                return;
-            }
-
-            var telemetryClient = new TelemetryClient();
             var telemetry = new EventTelemetry(eventName);
             telemetry.Properties.Add("Dimension", dimension);
             if (!string.IsNullOrWhiteSpace(logFileName))
@@ -50,38 +50,26 @@ namespace Stats.ImportAzureCdnStatistics
                 telemetry.Properties.Add("LogFile", logFileName);
             }
 
-            telemetryClient.TrackEvent(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackEvent(telemetry);
+            _telemetryClient.Flush();
 
             TrackException(sqlException, logFileName);
         }
 
-        public static void TrackToolNotFound(string id, string version, string fileName, string logFileName)
+        public void TrackToolNotFound(string id, string version, string fileName, string logFileName)
         {
-            if (!ApplicationInsights.Initialized)
-            {
-                return;
-            }
-
-            var telemetryClient = new TelemetryClient();
             var telemetry = new EventTelemetry("ToolNotFound");
             telemetry.Properties.Add("ToolId", id);
             telemetry.Properties.Add("ToolVersion", version);
             telemetry.Properties.Add("FileName", fileName);
             telemetry.Properties.Add("LogFile", logFileName);
 
-            telemetryClient.TrackEvent(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackEvent(telemetry);
+            _telemetryClient.Flush();
         }
 
-        public static void TrackRetrieveDimensionDuration(string dimension, long value, string logFileName)
+        public void TrackRetrieveDimensionDuration(string dimension, long value, string logFileName)
         {
-            if (!ApplicationInsights.Initialized)
-            {
-                return;
-            }
-
-            var telemetryClient = new TelemetryClient();
             var telemetry = new MetricTelemetry("Retrieve Dimension duration (ms)", value);
             telemetry.Properties.Add("Dimension", dimension);
             if (!string.IsNullOrWhiteSpace(logFileName))
@@ -89,35 +77,23 @@ namespace Stats.ImportAzureCdnStatistics
                 telemetry.Properties.Add("LogFile", logFileName);
             }
 
-            telemetryClient.TrackMetric(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackMetric(telemetry);
+            _telemetryClient.Flush();
         }
 
-        public static void TrackPackageNotFound(string id, string version, string logFileName)
+        public void TrackPackageNotFound(string id, string version, string logFileName)
         {
-            if (!ApplicationInsights.Initialized)
-            {
-                return;
-            }
-
-            var telemetryClient = new TelemetryClient();
             var telemetry = new EventTelemetry("PackageNotFound");
             telemetry.Properties.Add("PackageId", id);
             telemetry.Properties.Add("PackageVersion", version);
             telemetry.Properties.Add("LogFile", logFileName);
 
-            telemetryClient.TrackEvent(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackEvent(telemetry);
+            _telemetryClient.Flush();
         }
 
-        public static void TrackMetric(string metricName, double value, string logFileName = null)
+        public void TrackMetric(string metricName, double value, string logFileName = null)
         {
-            if (!ApplicationInsights.Initialized)
-            {
-                return;
-            }
-
-            var telemetryClient = new TelemetryClient();
             var telemetry = new MetricTelemetry(metricName, value);
 
             if (!string.IsNullOrWhiteSpace(logFileName))
@@ -125,8 +101,8 @@ namespace Stats.ImportAzureCdnStatistics
                 telemetry.Properties.Add("LogFile", logFileName);
             }
 
-            telemetryClient.TrackMetric(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackMetric(telemetry);
+            _telemetryClient.Flush();
         }
     }
 }

--- a/src/Stats.RollUpDownloadFacts/ApplicationInsightsHelper.cs
+++ b/src/Stats.RollUpDownloadFacts/ApplicationInsightsHelper.cs
@@ -1,27 +1,34 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using NuGet.Services.Logging;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Stats.RollUpDownloadFacts
 {
-    internal static class ApplicationInsightsHelper
+    internal sealed class ApplicationInsightsHelper
     {
-        public static void TrackRollUpMetric(string metricName, double value, string packageDimensionId)
+        private readonly TelemetryClient _telemetryClient;
+
+        public ApplicationInsightsHelper(TelemetryConfiguration telemetryConfiguration)
         {
-            if (!ApplicationInsights.Initialized)
+            if (telemetryConfiguration == null)
             {
-                return;
+                throw new ArgumentNullException(nameof(telemetryConfiguration));
             }
 
-            var telemetryClient = new TelemetryClient();
+            _telemetryClient = new TelemetryClient(telemetryConfiguration);
+        }
+
+        public void TrackRollUpMetric(string metricName, double value, string packageDimensionId)
+        {
             var telemetry = new MetricTelemetry(metricName, value);
             telemetry.Properties.Add("PackageDimensionId", packageDimensionId);
 
-            telemetryClient.TrackMetric(telemetry);
-            telemetryClient.Flush();
+            _telemetryClient.TrackMetric(telemetry);
+            _telemetryClient.Flush();
         }
     }
 }

--- a/src/Stats.RollUpDownloadFacts/RollUpDownloadFactsJob.cs
+++ b/src/Stats.RollUpDownloadFacts/RollUpDownloadFactsJob.cs
@@ -24,6 +24,7 @@ namespace Stats.RollUpDownloadFacts
         private const int DefaultMinAgeInDays = 43;
 
         private RollUpDownloadFactsConfiguration _configuration;
+        private ApplicationInsightsHelper _applicationInsightsHelper;
         private int _minAgeInDays;
 
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
@@ -34,6 +35,7 @@ namespace Stats.RollUpDownloadFacts
 
             _minAgeInDays = _configuration.MinAgeInDays ?? DefaultMinAgeInDays;
             Logger.LogInformation("Min age in days: {MinAgeInDays}", _minAgeInDays);
+            _applicationInsightsHelper = new ApplicationInsightsHelper(ApplicationInsightsConfiguration.TelemetryConfiguration);
         }
 
         public override async Task Run()
@@ -72,7 +74,7 @@ namespace Stats.RollUpDownloadFacts
                 var value = double.Parse(parts.Last());
                 var packageDimensionId = parts.First().Replace(":", string.Empty);
 
-                ApplicationInsightsHelper.TrackRollUpMetric("Download Facts Deleted", value, packageDimensionId);
+                _applicationInsightsHelper.TrackRollUpMetric("Download Facts Deleted", value, packageDimensionId);
             }
         }
 

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -159,13 +159,13 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -159,13 +159,13 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -112,16 +112,16 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-dev-3213233</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -112,16 +112,16 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-dev-3213233</Version>

--- a/src/Validation.PackageSigning.ValidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/Job.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Autofac;
-using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,7 +43,6 @@ namespace Validation.PackageSigning.ValidateCertificate
             services.AddTransient<ICertificateValidationService, CertificateValidationService>();
             services.AddTransient<ITelemetryService, TelemetryService>();
             services.AddTransient<ISubscriptionProcessorTelemetryService, TelemetryService>();
-            services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)

--- a/src/Validation.PackageSigning.ValidateCertificate/Job.cs
+++ b/src/Validation.PackageSigning.ValidateCertificate/Job.cs
@@ -44,7 +44,7 @@ namespace Validation.PackageSigning.ValidateCertificate
             services.AddTransient<ICertificateValidationService, CertificateValidationService>();
             services.AddTransient<ITelemetryService, TelemetryService>();
             services.AddTransient<ISubscriptionProcessorTelemetryService, TelemetryService>();
-            services.AddSingleton(new TelemetryClient());
+            services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.59.0</Version>
+      <Version>2.60.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.58.0</Version>
+      <Version>2.59.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Symbols/Job.cs
+++ b/src/Validation.Symbols/Job.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Autofac;
-using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/src/Validation.Symbols/Job.cs
+++ b/src/Validation.Symbols/Job.cs
@@ -48,7 +48,7 @@ namespace Validation.Symbols
 
                 return new SymbolsFileService(packageStorageService, packageValidationStorageService, c.GetRequiredService<IFileDownloader>());
             });
-            services.AddSingleton(new TelemetryClient());
+            services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)

--- a/src/Validation.Symbols/Job.cs
+++ b/src/Validation.Symbols/Job.cs
@@ -48,7 +48,6 @@ namespace Validation.Symbols
 
                 return new SymbolsFileService(packageStorageService, packageValidationStorageService, c.GetRequiredService<IFileDownloader>());
             });
-            services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder)

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/LogFileProcessorFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/LogFileProcessorFacts.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Stats.AzureCdnLogs.Common;
@@ -30,6 +31,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
             private const string _logFileName = "PackageDownloads.log";
             private readonly ILoggerFactory _loggerFactory;
             private readonly ILeasedLogFile _leasedLogFile;
+            private readonly ApplicationInsightsHelper _applicationInsightsHelper;
 
             public WhenOnlyPackageStatisticsInLogFile(ITestOutputHelper testOutputHelper)
             {
@@ -38,6 +40,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 _loggerFactory = loggerFactory;
 
                 _leasedLogFile = GetLeasedLogFileMock(_logFileName);
+                _applicationInsightsHelper = new ApplicationInsightsHelper(TelemetryConfiguration.CreateDefault());
             }
 
             [Fact]
@@ -72,7 +75,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly: false);
@@ -117,7 +121,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly: true);
@@ -164,7 +169,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly);
@@ -203,6 +209,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
             private const string _logFileName = "ToolDownloads.log";
             private readonly ILoggerFactory _loggerFactory;
             private readonly ILeasedLogFile _leasedLogFile;
+            private readonly ApplicationInsightsHelper _applicationInsightsHelper;
 
             public WhenOnlyToolStatisticsInLogFile(ITestOutputHelper testOutputHelper)
             {
@@ -211,6 +218,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 _loggerFactory = loggerFactory;
 
                 _leasedLogFile = GetLeasedLogFileMock(_logFileName);
+                _applicationInsightsHelper = new ApplicationInsightsHelper(TelemetryConfiguration.CreateDefault());
             }
 
             [Fact]
@@ -242,7 +250,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly: false);
@@ -283,7 +292,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly: true);
@@ -330,7 +340,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly);
@@ -369,6 +380,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
             private const string _logFileName = "PackageAndToolDownloads.log";
             private readonly ILoggerFactory _loggerFactory;
             private readonly ILeasedLogFile _leasedLogFile;
+            private readonly ApplicationInsightsHelper _applicationInsightsHelper;
 
             public WhenPackageAndToolStatisticsInLogFile(ITestOutputHelper testOutputHelper)
             {
@@ -377,6 +389,7 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 _loggerFactory = loggerFactory;
 
                 _leasedLogFile = GetLeasedLogFileMock(_logFileName);
+                _applicationInsightsHelper = new ApplicationInsightsHelper(TelemetryConfiguration.CreateDefault());
             }
 
             [Fact]
@@ -417,7 +430,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly: false);
@@ -479,7 +493,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly: false);
@@ -541,7 +556,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly: false);
@@ -599,7 +615,8 @@ namespace Tests.Stats.ImportAzureCdnStatistics
                 var logFileProcessor = new LogFileProcessor(
                     statisticsBlobContainerUtilityMock.Object,
                     _loggerFactory,
-                    warehouseMock.Object);
+                    warehouseMock.Object,
+                    _applicationInsightsHelper);
 
                 // act
                 await logFileProcessor.ProcessLogFileAsync(_leasedLogFile, _packageStatisticsParser, aggregatesOnly);


### PR DESCRIPTION
* no longer use obsolete `new TelemetryClient()`
* no longer use obsolete `TelemetryConfiguration.Active`
* upgrade to `NuGet.Services.Logging v2.60.0`
* use updated `ApplicationInsights.Initialize` method