### PR TITLE
Consolidate unit test infrastructure

### DIFF
--- a/tests/Monitoring.PackageLag.Tests/Monitoring.PackageLag.Tests.csproj
+++ b/tests/Monitoring.PackageLag.Tests/Monitoring.PackageLag.Tests.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Protocol.Catalog">
       <Version>0.5.0-CI-20180510-012541</Version>

--- a/tests/Monitoring.PackageLag.Tests/Monitoring.PackageLag.Tests.csproj
+++ b/tests/Monitoring.PackageLag.Tests/Monitoring.PackageLag.Tests.csproj
@@ -63,10 +63,10 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Monitoring.RebootSearchInstance.Tests/Monitoring.RebootSearchInstance.Tests.csproj
+++ b/tests/Monitoring.RebootSearchInstance.Tests/Monitoring.RebootSearchInstance.Tests.csproj
@@ -61,10 +61,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Monitoring.RebootSearchInstance.Tests/Monitoring.RebootSearchInstance.Tests.csproj
+++ b/tests/Monitoring.RebootSearchInstance.Tests/Monitoring.RebootSearchInstance.Tests.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Jobs.Common.Tests/NuGet.Jobs.Common.Tests.csproj
+++ b/tests/NuGet.Jobs.Common.Tests/NuGet.Jobs.Common.Tests.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Jobs.Common.Tests/NuGet.Jobs.Common.Tests.csproj
+++ b/tests/NuGet.Jobs.Common.Tests/NuGet.Jobs.Common.Tests.csproj
@@ -49,10 +49,10 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
@@ -53,10 +53,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.Revalidate.Tests/NuGet.Services.Revalidate.Tests.csproj
+++ b/tests/NuGet.Services.Revalidate.Tests/NuGet.Services.Revalidate.Tests.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Services.Revalidate.Tests/NuGet.Services.Revalidate.Tests.csproj
+++ b/tests/NuGet.Services.Revalidate.Tests/NuGet.Services.Revalidate.Tests.csproj
@@ -46,10 +46,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -80,7 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -83,10 +83,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/PackageStatusProcessorFacts.cs
@@ -149,7 +149,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 PackageServiceMock
                     .Setup(x => x.UpdateMetadataAsync(Package, It.IsAny<PackageStreamMetadata>(), false))
                     .Returns(Task.CompletedTask)
-                    .Callback<Package, PackageStreamMetadata, bool>((_, m, __) => actual = m);
+                    .Callback<Package, object, bool>((_, m, __) => actual = m as PackageStreamMetadata);
 
                 await Target.SetStatusAsync(PackageValidatingEntity, ValidationSet, PackageStatus.Available);
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
@@ -71,7 +71,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationStorageMock
                 .Setup(vs => vs.MarkValidationStartedAsync(validation, It.Is<ValidationResult>(r => r.Status == startStatus)))
                 .Returns(Task.FromResult(0))
-                .Callback<PackageValidation, ValidationResult>((pv, vr) => pv.ValidationStatus = vr.Status)
+                .Callback<PackageValidation, IValidationResult>((pv, vr) => pv.ValidationStatus = vr.Status)
                 .Verifiable();
 
             var processor = CreateProcessor();

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -106,23 +106,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Castle.Core">
-      <Version>4.3.0</Version>
-    </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>
     </PackageReference>
-    <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.4.0</Version>
-    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.core">
-      <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <Version>2.4.1</Version>

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -110,7 +110,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.3.0</Version>

--- a/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
+++ b/tests/StatusAggregator.Tests/StatusAggregator.Tests.csproj
@@ -119,13 +119,13 @@
       <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.0</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.core">
       <Version>2.4.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.0</Version>
+      <Version>2.4.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/TestUtil/TestUtil.csproj
+++ b/tests/TestUtil/TestUtil.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Tests.CredentialExpiration/Tests.CredentialExpiration.csproj
+++ b/tests/Tests.CredentialExpiration/Tests.CredentialExpiration.csproj
@@ -71,10 +71,12 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Tests.Gallery.Maintenance/Tests.Gallery.Maintenance.csproj
+++ b/tests/Tests.Gallery.Maintenance/Tests.Gallery.Maintenance.csproj
@@ -66,10 +66,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Tests.Search.GenerateAuxiliaryData/Tests.Search.GenerateAuxiliaryData.csproj
+++ b/tests/Tests.Search.GenerateAuxiliaryData/Tests.Search.GenerateAuxiliaryData.csproj
@@ -62,7 +62,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.8.2</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Tests.Search.GenerateAuxiliaryData/Tests.Search.GenerateAuxiliaryData.csproj
+++ b/tests/Tests.Search.GenerateAuxiliaryData/Tests.Search.GenerateAuxiliaryData.csproj
@@ -65,10 +65,12 @@
       <Version>4.8.2</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Tests.Stats.AggregateCdnDownloadsInGallery/Tests.Stats.AggregateCdnDownloadsInGallery.csproj
+++ b/tests/Tests.Stats.AggregateCdnDownloadsInGallery/Tests.Stats.AggregateCdnDownloadsInGallery.csproj
@@ -53,10 +53,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Tests.Stats.AzureCdnLogs.Common/Tests.Stats.AzureCdnLogs.Common.csproj
+++ b/tests/Tests.Stats.AzureCdnLogs.Common/Tests.Stats.AzureCdnLogs.Common.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Tests.Stats.AzureCdnLogs.Common/Tests.Stats.AzureCdnLogs.Common.csproj
+++ b/tests/Tests.Stats.AzureCdnLogs.Common/Tests.Stats.AzureCdnLogs.Common.csproj
@@ -57,10 +57,10 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
+++ b/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
@@ -48,10 +48,10 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
+++ b/tests/Tests.Stats.CDNLogsSanitizer/Tests.Stats.CDNLogsSanitizer.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Tests.Stats.CollectAzureCdnLogs/Tests.Stats.CollectAzureCdnLogs.csproj
+++ b/tests/Tests.Stats.CollectAzureCdnLogs/Tests.Stats.CollectAzureCdnLogs.csproj
@@ -73,10 +73,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Tests.Stats.CollectAzureCdnLogs/Tests.Stats.CollectAzureCdnLogs.csproj
+++ b/tests/Tests.Stats.CollectAzureCdnLogs/Tests.Stats.CollectAzureCdnLogs.csproj
@@ -70,7 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/Tests.Stats.CollectAzureChinaCDNLogs.csproj
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/Tests.Stats.CollectAzureChinaCDNLogs.csproj
@@ -74,7 +74,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/Tests.Stats.CollectAzureChinaCDNLogs.csproj
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/Tests.Stats.CollectAzureChinaCDNLogs.csproj
@@ -77,10 +77,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
@@ -91,7 +91,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.8.2</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/Tests.Stats.ImportAzureCdnStatistics.csproj
@@ -94,10 +94,12 @@
       <Version>4.8.2</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
+++ b/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
+++ b/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
@@ -60,10 +60,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -73,12 +73,6 @@
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>
     </PackageReference>
-    <PackageReference Include="Portable.BouncyCastle">
-      <Version>1.8.1.3</Version>
-    </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.4.0</Version>
-    </PackageReference>
     <PackageReference Include="Test.Utility">
       <Version>4.8.0-preview4.5289</Version>
     </PackageReference>

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -83,10 +83,12 @@
       <Version>4.8.0-preview4.5289</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.8.1.3</Version>

--- a/tests/Validation.PackageSigning.Helpers/Tests.ContextHelpers.csproj
+++ b/tests/Validation.PackageSigning.Helpers/Tests.ContextHelpers.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.8.1.3</Version>

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
@@ -56,9 +56,6 @@
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>
     </PackageReference>
-    <PackageReference Include="Portable.BouncyCastle">
-      <Version>1.8.1.3</Version>
-    </PackageReference>
     <PackageReference Include="SharpZipLib">
       <Version>1.1.0</Version>
     </PackageReference>

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/Validation.PackageSigning.ProcessSignature.Tests.csproj
@@ -63,10 +63,12 @@
       <Version>1.1.0</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.8.1.3</Version>

--- a/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
@@ -44,9 +44,6 @@
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>
     </PackageReference>
-    <PackageReference Include="Portable.BouncyCastle">
-      <Version>1.8.1.3</Version>
-    </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>
     </PackageReference>

--- a/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.RevalidateCertificate.Tests/Validation.PackageSigning.RevalidateCertificate.Tests.csproj
@@ -48,10 +48,12 @@
       <Version>1.8.1.3</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
@@ -68,10 +68,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
@@ -82,7 +82,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/Validation.PackageSigning.ValidateCertificate.Tests.csproj
@@ -85,10 +85,12 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Validation.Symbols.Core.Tests/Validation.Symbols.Core.Tests.csproj
+++ b/tests/Validation.Symbols.Core.Tests/Validation.Symbols.Core.Tests.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Validation.Symbols.Core.Tests/Validation.Symbols.Core.Tests.csproj
+++ b/tests/Validation.Symbols.Core.Tests/Validation.Symbols.Core.Tests.csproj
@@ -49,10 +49,10 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.0</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.0</Version>
+      <Version>2.4.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Validation.Symbols.Tests/Validation.Symbols.Tests.csproj
+++ b/tests/Validation.Symbols.Tests/Validation.Symbols.Tests.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Moq">
-      <Version>4.7.145</Version>
+      <Version>4.13.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/Validation.Symbols.Tests/Validation.Symbols.Tests.csproj
+++ b/tests/Validation.Symbols.Tests/Validation.Symbols.Tests.csproj
@@ -60,10 +60,10 @@
       <Version>4.7.145</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.4.0</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR:
* consolidates `xunit` to version `2.4.1`
* consolidates `xunit.runners.visualstudio` to version `2.4.1`
* consolidates `moq` to version `4.13.1` (and fixes some callback setups that were invalid after the upgrade)
* makes some transitive packages transitive again in the test projects