### PR TITLE
Max lease time for blobs is 60 seconds

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
@@ -20,7 +20,11 @@ namespace Stats.AzureCdnLogs.Common.Collect
     public class AzureStatsLogSource : ILogSource
     {
         private const ushort GzipLeadBytes = 0x8b1f;
-        private const int CopyBlobLeaseTimeInSeconds = 120;
+
+        /// <summary>
+        ///  Maximum allowed lease time for Azure Blobs is 60 seconds.
+        /// </summary>
+        private const int CopyBlobLeaseTimeInSeconds = 60;
 
         private string _deadletterContainerName = "-deadletter";
         private string _archiveContainerName = "-archive";


### PR DESCRIPTION
Noticed an issue in `Stats.CollectAzureCdnLogs` after deploying private build of it to DEV:

Exception message;
```
System.ArgumentOutOfRangeException:
The argument 'leaseTime' is larger than maximum of '00:01:00'
Parameter name: leaseTime
Source: Stats.AzureCdnLogs.Common\Collect\AzureStatsLogSource.cs
Line: 198
```

Source:
https://docs.microsoft.com/en-us/rest/api/storageservices/lease-blob