### PR TITLE
Consume serilog updates (ServerCommon v2.63.0 release)

### DIFF
--- a/sign.thirdparty.props
+++ b/sign.thirdparty.props
@@ -22,7 +22,7 @@
     <ThirdPartyBinaries Include="Serilog.Enrichers.Process.dll" />
     <ThirdPartyBinaries Include="Serilog.Extensions.Logging.dll" />
     <ThirdPartyBinaries Include="Serilog.Sinks.ApplicationInsights.dll" />
-    <ThirdPartyBinaries Include="Serilog.Sinks.ColoredConsole.dll" />
+    <ThirdPartyBinaries Include="Serilog.Sinks.Console.dll" />
     <ThirdPartyBinaries Include="SerilogTraceListener.dll" />
     <ThirdPartyBinaries Include="UAParser.dll" />
   </ItemGroup>

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -92,7 +92,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -232,7 +232,7 @@ namespace NuGet.Jobs
             // This tells Application Insights that, even though a heartbeat is reported, 
             // the state of the application is unhealthy when the exitcode is different from zero.
             // The heartbeat metadata is enriched with the job loop exit code.
-            _applicationInsightsConfiguration.DiagnosticsTelemetryModule?.AddHeartbeatProperty(
+            _applicationInsightsConfiguration.DiagnosticsTelemetryModule?.AddOrSetHeartbeatProperty(
                 HeartbeatProperty_JobLoopExitCode,
                 exitCode.ToString(),
                 isHealthy: exitCode == 0);

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -105,16 +105,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -119,7 +119,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -108,7 +108,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -159,13 +159,13 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -112,16 +112,16 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-dev-3213233</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.61.0</Version>
+      <Version>2.63.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>


### PR DESCRIPTION
This consumes the Serilog updates included as part of ServerCommon release [v2.63.0](https://github.com/NuGet/ServerCommon/releases/tag/v2.63.0), and ensures `ILogger` traces are actually sent to AppInsights as `traces` and not `customEvents`.
