### PR TITLE
Upgrading ServerCommon dependencies to v2.66.0

### DIFF
--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -92,7 +92,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -104,16 +104,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -119,7 +119,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -108,7 +108,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -159,13 +159,13 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -112,16 +112,16 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
       <Version>4.4.5-dev-3213233</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.65.0</Version>
+      <Version>2.66.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>


### PR DESCRIPTION
Aligning to the latest version (which will also facilitate transitive upgrades downstream).

[Changelog of ServerCommon v2.66.0](https://github.com/NuGet/ServerCommon/releases/tag/v2.66.0)