### PR TITLE
[StatusAggregator] Log the "endTime" rather than null

### DIFF
--- a/src/StatusAggregator/Update/IncidentUpdater.cs
+++ b/src/StatusAggregator/Update/IncidentUpdater.cs
@@ -41,8 +41,8 @@ namespace StatusAggregator.Update
 
                 if (endTime != null)
                 {
-                    _logger.LogInformation("Updated mitigation time of active incident to {MitigationTime}.", entity.EndTime);
                     entity.EndTime = endTime;
+                    _logger.LogInformation("Updated mitigation time of active incident to {MitigationTime}.", entity.EndTime);
                     await _table.ReplaceAsync(entity);
                 }
             }


### PR DESCRIPTION
I notice that we always log the mitigation time of the incident to be null.
A small change to log the exact "endTime" of the incident rather than null. 