### PR TITLE
Upgrade NuGetGallery.Core dependency

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -92,7 +92,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-3213233</Version>
+      <Version>4.4.5-dev-3390606</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/RepoUtils.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-3213233</Version>
+      <Version>4.4.5-dev-3390606</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -117,19 +117,13 @@
     <PackageReference Include="NuGet.Services.Storage">
       <Version>2.66.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.Validation">
-      <Version>2.66.0</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Validation.Issues">
-      <Version>2.66.0</Version>
-    </PackageReference>
-    <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-3213233</Version>
-    </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NuGetGallery.Core">
+      <Version>4.4.5-dev-3390606</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -176,9 +176,9 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     .Verify(x => x.DeletePackageForValidationSetAsync(It.IsAny<PackageValidationSet>()), Times.Never);
             }
 
-            TelemetryServiceMock.ResetCalls();
-            MessageServiceMock.ResetCalls();
-            ValidationEnqueuerMock.ResetCalls();
+            TelemetryServiceMock.Invocations.Clear();
+            MessageServiceMock.Invocations.Clear();
+            ValidationEnqueuerMock.Invocations.Clear();
 
             // Process the outcome again - the "too long to validate" message should NOT be sent.
             await processor.ProcessValidationOutcomeAsync(ValidationSet, PackageValidatingEntity, ProcessorStats, ScheduleNextCheck);

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignaturePartsExtractorFacts.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignaturePartsExtractorFacts.cs
@@ -424,7 +424,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 var signature = await TestResources.LoadPrimarySignatureAsync(TestResources.SignedPackageLeaf1);
                 await _target.ExtractAsync(_packageKey, signature, _token);
                 AssignIds();
-                _validationEntitiesContext.ResetCalls();
+                _validationEntitiesContext.Invocations.Clear();
 
                 // Act
                 await _target.ExtractAsync(_packageKey, signature, _token);


### PR DESCRIPTION
Upgrading `NuGetGallery.Core` to this version also upgrades the transitive ServerCommon dependencies to v2.66.0, and thus aligns with the version of direct ServerCommon dependencies in the repo, which also reduces binding redirects downstream.

Fixed some xunit compiler warnings along the way.