### PR TITLE
Consume latest master branch builds of nugetgallery.core

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -92,7 +92,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-3390606</Version>
+      <Version>4.4.5-master-3419450</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-3390606</Version>
+      <Version>4.4.5-master-3419450</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -123,7 +123,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-3390606</Version>
+      <Version>4.4.5-master-3419450</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Think it's good practice to consume the latest `master` branch release of `NuGetGallery.Core` before merging `dev` into `master`, as it gives a clear signal that we rely on a build that is considered stable.

Internal jobs will also consume this release to align.