### PR TITLE
Update ServerCommon dependencies 2.68.0 for using managed identity with keyvault

### DIFF
--- a/src/CopyAzureContainer/CopyAzureContainerJob.cs
+++ b/src/CopyAzureContainer/CopyAzureContainerJob.cs
@@ -46,9 +46,10 @@ namespace CopyAzureContainer
                    + $"-{ArgumentNames.CopyAzureContainer_BackupDays} <backupDaysToKeepAsIntValue> "
                    + $"-{JobArgumentNames.InstrumentationKey} <intrumentationKey> "
                    + $"-{JobArgumentNames.VaultName} <keyvault name> "
-                   + $"-{JobArgumentNames.ClientId} <keyvault-client-id> "
-                   + $"-{JobArgumentNames.CertificateThumbprint} <keyvault-certificate-thumbprint> "
-                   + $"-{JobArgumentNames.ValidateCertificate} true|false";
+                   + $"-{JobArgumentNames.UseManagedIdentity} <true|false> "
+                   + $"-{JobArgumentNames.ClientId} <keyvault-client-id> Should not be set if UseManagedIdentity is true"
+                   + $"-{JobArgumentNames.CertificateThumbprint} <keyvault-certificate-thumbprint> Should not be set if UseManagedIdentity is true"
+                   + $"-{JobArgumentNames.ValidateCertificate} <true|false>";
         }
 
         public override async Task Run()

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -92,7 +92,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -103,6 +103,7 @@ namespace NuGet.Jobs
 
         // Key Vault
         public const string VaultName = "VaultName";
+        public const string UseManagedIdentity = "UseManagedIdentity";
         public const string ClientId = "ClientId";
         public const string CertificateThumbprint = "CertificateThumbprint";
         public const string ValidateCertificate = "ValidateCertificate";

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -104,16 +104,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.68.0-kv-managed-identities-3426238</Version>
+      <Version>2.68.0-kv-managed-identities-3433819</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.68.0-kv-managed-identities-3426238</Version>
+      <Version>2.68.0-kv-managed-identities-3433819</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.68.0-kv-managed-identities-3426238</Version>
+      <Version>2.68.0-kv-managed-identities-3433819</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.68.0-kv-managed-identities-3426238</Version>
+      <Version>2.68.0-kv-managed-identities-3433819</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -104,7 +104,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.66.0</Version>
+      <Version>2.68.0-kv-managed-identities-3426238</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
       <Version>2.66.0</Version>

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -104,16 +104,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.68.0-kv-managed-identities-3433819</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.68.0-kv-managed-identities-3433819</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.68.0-kv-managed-identities-3433819</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.68.0-kv-managed-identities-3433819</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -107,13 +107,13 @@
       <Version>2.68.0-kv-managed-identities-3426238</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.66.0</Version>
+      <Version>2.68.0-kv-managed-identities-3426238</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.66.0</Version>
+      <Version>2.68.0-kv-managed-identities-3426238</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.66.0</Version>
+      <Version>2.68.0-kv-managed-identities-3426238</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -119,7 +119,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/PackageLagMonitor/Monitoring.PackageLag.csproj
+++ b/src/PackageLagMonitor/Monitoring.PackageLag.csproj
@@ -108,7 +108,7 @@
       <Version>0.5.0-CI-20180510-012541</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.AzureManagement">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -159,13 +159,13 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -112,10 +112,10 @@
       <Version>5.0.0-preview1.5707</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.66.0</Version>
+      <Version>2.68.0</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/tests/StatusAggregator.Tests/Collector/ManualStatusChangeCollectorProcessorTests.cs
+++ b/tests/StatusAggregator.Tests/Collector/ManualStatusChangeCollectorProcessorTests.cs
@@ -90,7 +90,7 @@ namespace StatusAggregator.Tests.Collector
 
         public class TheFetchSinceMethodAtMinValue : TheFetchSinceMethod
         {
-            public override DateTime Cursor => DateTime.MinValue.ToUniversalTime();
+            public override DateTime Cursor => DateTime.MinValue;
 
             [Fact]
             public async Task DoesNotFilterByCursor()

--- a/tests/StatusAggregator.Tests/Collector/ManualStatusChangeCollectorProcessorTests.cs
+++ b/tests/StatusAggregator.Tests/Collector/ManualStatusChangeCollectorProcessorTests.cs
@@ -90,7 +90,7 @@ namespace StatusAggregator.Tests.Collector
 
         public class TheFetchSinceMethodAtMinValue : TheFetchSinceMethod
         {
-            public override DateTime Cursor => DateTime.MinValue;
+            public override DateTime Cursor => DateTime.MinValue.ToUniversalTime();
 
             [Fact]
             public async Task DoesNotFilterByCursor()


### PR DESCRIPTION
This change will still be backwards compatible, such that the jobs can continue to use certificate to access keyvault. It has additive config change to use managed identities.

Taking the dependencies on stable `2.68.0` version.

The stable build out of this branch will be used to be consumed in Services.metadata and other services(gallery, azure search etc).

/cc @joelverhagen 