### PR TITLE
[HOTFIX] Improve 'GetFilesAsync' performance and logging

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
@@ -106,18 +106,17 @@ namespace Stats.AzureCdnLogs.Common.Collect
                         "Found blob {BlobUrl}, determining lease status...",
                         blobItem.Uri);
 
-                    var cloudBlob = (CloudBlob)blobItem;
-
-                    if (cloudBlob.Properties.LeaseStatus != LeaseStatus.Unlocked)
+                    var blob = (CloudBlob)blobItem;
+                    if (blob.Properties.LeaseStatus != LeaseStatus.Unlocked)
                     {
                         _logger.LogInformation(
                             "Skipping blob {BlobUrl} as its lease status is not unlocked: {LeaseStatus}",
-                            cloudBlob.Uri,
-                            cloudBlob.Properties.LeaseStatus);
+                            blob.Uri,
+                            blob.Properties.LeaseStatus);
                         continue;
                     }
 
-                    result.Add(cloudBlob.Uri);
+                    result.Add(blob.Uri);
                 }
             }
             while (continuationToken != null);

--- a/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
@@ -95,7 +95,7 @@ namespace Stats.AzureCdnLogs.Common.Collect
 
                 foreach (var blobItem in resultsInternal.Results)
                 {
-                    if (result.Count > maxResults)
+                    if (result.Count >= maxResults)
                     {
                         break;
                     }


### PR DESCRIPTION
PROD China has a backlog of ~5K blobs to process, some as old as July 2019.

The `GetFilesAsync` method is called to find the next batch of 4 blobs and currently takes ~20 minutes. This aims to improve the performance by reducing the calls to `FetchAttributesAsync`. This also improves logging so that we can further improve performance.

Build: [LINK](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3458527)
DEV release: [LINK](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=577703)
DEV verification query: [LINK](https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Ffa8b3229-dc0f-4633-a285-ad597076921d%2FresourceGroups%2Fnuget-dev-statistics%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnuget-dev-statistics/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA0XNQQ6CQAyF4b2Jd2hY6UJuwMLAyhg2nKDMNDCGmZK2BDEeXiYxuv7fl2eCjvR4eAM9jZKHG%252FctRoIKjNUkpOHkFjWOTYiUNHDS8rs5Z7aOJPRXFRSdoWlZ8zSRs%252BtrEarHkLBu2jsPWkBWs%252FBjrxdccfvhHFg8CfQb2H6nhnEGT%252Bo%252BzY%252BErqcAAAA%253D/timespan/P1D)