### PR TITLE
Reduce expected exceptions at job startup

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
@@ -64,14 +64,12 @@ namespace NuGet.Jobs
         /// <returns>Returns the argument value as a string</returns>
         public static string TryGetArgument(IDictionary<string, string> jobArgsDictionary, string argName)
         {
-            try
-            {
-                return GetArgument(jobArgsDictionary, argName);
-            }
-            catch
+            if (!jobArgsDictionary.TryGetValue(argName, out var value) || string.IsNullOrEmpty(value))
             {
                 return null;
             }
+
+            return value;
         }
 
         /// <summary>


### PR DESCRIPTION
The `Db2AzureSearch` job throws 5 expected exceptions at startup, which cause the debugger to break repeatedly.

Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3501082
Test release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=594453