### PR TITLE
Auto-register the ApplicationInsightsApplicationIdProvider

### DIFF
--- a/src/NuGet.Jobs.Common/JobRunner.cs
+++ b/src/NuGet.Jobs.Common/JobRunner.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Logging;
 
@@ -188,6 +189,9 @@ namespace NuGet.Jobs
             var instanceName = JobConfigurationManager.TryGetArgument(jobArgsDictionary, JobArgumentNames.InstanceName) ?? jobName;
             applicationInsightsConfiguration.TelemetryConfiguration.TelemetryInitializers.Add(
                 new JobPropertiesTelemetryInitializer(jobName, instanceName, job.GlobalTelemetryDimensions));
+
+            applicationInsightsConfiguration.TelemetryConfiguration
+                .ApplicationIdProvider = new ApplicationInsightsApplicationIdProvider();
 
             job.SetApplicationInsightsConfiguration(applicationInsightsConfiguration);
 


### PR DESCRIPTION
The `ApplicationInsightsApplicationIdProvider` ensures proper telemetry correlation. I noticed some jobs didn't have this registered, so registering it by default in the `JobRunner` will fix this for all jobs and allows us to remove this registration in code elsewhere.