### PR TITLE
[HOTFIX] Handle duplicate zip entries

### DIFF
--- a/src/Validation.Symbols.Core/IZipArchiveService.cs
+++ b/src/Validation.Symbols.Core/IZipArchiveService.cs
@@ -23,7 +23,7 @@ namespace NuGet.Jobs.Validation.Symbols.Core
         /// </summary>
         /// <param name="stream">The zip stream.</param>
         /// <param name="targetDirectory">The target diorectoryu where to extract.</param>
-        /// <param name="filterFileExtensions">A list of file extension to filter. Only files with extension in this list will be extracted.</param>
+        /// <param name="filterFileExtensions">A list of file extension to filter. Only files with extensions in this list will be extracted.</param>
         /// <param name="filterFileNames">A collection of full symbol file names to be used for filtering.
         /// For example if the <paramref name="stream"/> contains foo.dll and bar.dll 
         /// and the <paramref name="filterFileNames"/> contains only foo.pdb than only the foo.dll wil be extracted.</param>

--- a/tests/Validation.Symbols.Tests/ZipArchiveTests.cs
+++ b/tests/Validation.Symbols.Tests/ZipArchiveTests.cs
@@ -130,6 +130,25 @@ namespace Validation.Symbols.Tests
                     Assert.Contains(s, result);
                 }
             }
+
+            [Fact]
+            public void SkipsDuplicates()
+            {
+                // Arrange
+                var input = CreateTestZipEntries(new string[] { "foo.pdb", "foo.pdb" });
+                var expected = new string[] { "foo.pdb" };
+                var service = new TestZipArchiveService();
+
+                // Act
+                var result = service.Extract(input, "Dir1");
+
+                // Assert
+                Assert.Equal(expected.Length, result.Count());
+                foreach (string s in expected)
+                {
+                    Assert.Contains(s, result);
+                }
+            }
         }
 
         public static IReadOnlyCollection<ZipArchiveEntry> CreateTestZipEntries(string[] files)


### PR DESCRIPTION
Hotfix to unblock validation id [`8d20655f-ff6f-ea11-a94c-2818789e3229`](https://www.nuget.org/Admin/Validation/Search?q=8d20655f-ff6f-ea11-a94c-2818789e3229). The .nupkg has duplicate zip archive entries for a .dll. Attempting to extract the same file multiple times throws a `The file 'ABC' already exists` exception.

Addresses https://github.com/NuGet/NuGetGallery/issues/7921