### PR TITLE
[Hot Fix] GitHub Indexer exception

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
@@ -34,10 +34,10 @@ namespace NuGet.Jobs.GitHubIndexer
                 throw new InvalidDataException("Date is missing, has a wrong format or is not in GMT timezone");
             }
 
-            if (!apiResponse.HttpResponse.Headers.TryGetValue("X-RateLimit-Reset", out var ghStrResetLimit)
+            if (!apiResponse.HttpResponse.Headers.TryGetValue("X-Ratelimit-Reset", out var ghStrResetLimit)
                 || !long.TryParse(ghStrResetLimit, out var ghResetTime))
             {
-                throw new InvalidDataException("X-RateLimit-Reset is required to compute the throttling time.");
+                throw new InvalidDataException("X-Ratelimit-Reset is required to compute the throttling time.");
             }
 
             return new GitHubSearchApiResponse(


### PR DESCRIPTION
It looks that GitHub changes the header to the lower case, which leads to the exception:

<img src="https://user-images.githubusercontent.com/41028779/78099619-5023c980-7397-11ea-9e8c-cd3f5d5647a6.png" width="2000">
<img src="https://user-images.githubusercontent.com/41028779/78099948-477fc300-7398-11ea-8714-422ceadddd4d.png" width="500">

Verify locally so the exception will not be thrown.