### PR TITLE
Move to latest version of NuGetGallery.Core

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -92,7 +92,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-master-3419450</Version>
+      <Version>4.4.5-dev-3612899</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-master-3419450</Version>
+      <Version>4.4.5-dev-3612899</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -127,7 +127,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-master-3419450</Version>
+      <Version>4.4.5-dev-3612899</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This aligns ServerCommon versions so pre-2.74.0 is not in the graph at all.