### PR TITLE
[HOTFIX] Skip malformed log entries in mooncake log collection

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
@@ -136,34 +136,45 @@ namespace Stats.AzureCdnLogs.Common.Collect
       
         protected void ProcessLogStream(Stream sourceStream, Stream targetStream)
         {
+            var rawLineNumber = 0;
+            string rawLine = string.Empty;
+
             try
             {
                 using (var sourceStreamReader = new StreamReader(sourceStream))
                 using (var targetStreamWriter = new StreamWriter(targetStream))
                 {
                     targetStreamWriter.WriteLine(OutputLogLine.Header);
-                    var lineNumber = 0;
+
+                    var targetLineNumber = 0;
                     while (!sourceStreamReader.EndOfStream)
                     {
-                        var rawLogLine = TransformRawLogLine(sourceStreamReader.ReadLine());
-                        if (rawLogLine != null)
+                        rawLine = sourceStreamReader.ReadLine();
+                        rawLineNumber++;
+
+                        var transformedLine = TransformRawLogLine(rawLine);
+                        if (transformedLine != null)
                         {
-                            lineNumber++;
-                            var logLine = GetParsedModifiedLogEntry(lineNumber, rawLogLine.ToString());
+                            targetLineNumber++;
+                            var logLine = GetParsedModifiedLogEntry(targetLineNumber, transformedLine.ToString());
                             if (!string.IsNullOrEmpty(logLine))
                             {
                                 targetStreamWriter.Write(logLine);
                             }
                         }
                     };
-                    _logger.LogInformation("ProcessLogStream: Finished writting to the destination stream.");
+
+                    _logger.LogInformation("ProcessLogStream: Finished writing to the destination stream.");
                 }
             }
-            // It should not happen, but if it does log it for better diagnostics.
-            catch (StorageException ex)
+            catch (Exception ex)
             {
-                _logger.LogCritical("ProcessLogStream: An exception while processing the stream {Exception}.", ex);
-                throw ex;
+                _logger.LogCritical(
+                    ex,
+                    "Failed to process raw log line number {LineNumber} with content {LineContent}",
+                    rawLineNumber,
+                    rawLine);
+                throw;
             }
         }
 

--- a/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
@@ -103,7 +103,7 @@ namespace Stats.AzureCdnLogs.Common.Collect
 
         private void AddException(ConcurrentBag<Exception> exceptions, Exception e, string fileUri = "")
         {
-            if(e == null)
+            if (e == null)
             {
                 return;
             }
@@ -137,6 +137,8 @@ namespace Stats.AzureCdnLogs.Common.Collect
         protected void ProcessLogStream(Stream sourceStream, Stream targetStream)
         {
             var rawLineNumber = 0;
+            var targetLineNumber = 0;
+
             string rawLine = string.Empty;
 
             try
@@ -146,7 +148,6 @@ namespace Stats.AzureCdnLogs.Common.Collect
                 {
                     targetStreamWriter.WriteLine(OutputLogLine.Header);
 
-                    var targetLineNumber = 0;
                     while (!sourceStreamReader.EndOfStream)
                     {
                         rawLine = sourceStreamReader.ReadLine();
@@ -156,10 +157,10 @@ namespace Stats.AzureCdnLogs.Common.Collect
                         if (transformedLine != null)
                         {
                             targetLineNumber++;
-                            var logLine = GetParsedModifiedLogEntry(targetLineNumber, transformedLine.ToString());
-                            if (!string.IsNullOrEmpty(logLine))
+                            var targetLine = GetParsedModifiedLogEntry(targetLineNumber, transformedLine.ToString());
+                            if (!string.IsNullOrEmpty(targetLine))
                             {
-                                targetStreamWriter.Write(logLine);
+                                targetStreamWriter.Write(targetLine);
                             }
                         }
                     };

--- a/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.Globalization;
+using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Stats.AzureCdnLogs.Common;
 using Stats.AzureCdnLogs.Common.Collect;
-using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 
 namespace Stats.CollectAzureChinaCDNLogs
 {

--- a/src/Stats.CollectAzureChinaCDNLogs/Program.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/Program.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IO;
 using NuGet.Jobs;
 
 namespace Stats.CollectAzureChinaCDNLogs

--- a/src/Stats.CollectAzureChinaCDNLogs/Program.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.IO;
 using NuGet.Jobs;
 
 namespace Stats.CollectAzureChinaCDNLogs

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.Logging;
+using Moq;
+using Stats.AzureCdnLogs.Common.Collect;
 using Stats.CollectAzureChinaCDNLogs;
 using Xunit;
 
@@ -13,13 +16,18 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
         [InlineData("c-ip, timestamp, cs-method, cs-uri-stem, http-ver, sc-status, sc-bytes, c-referer, c-user-agent, rs-duration(ms), hit-miss, s-ip", null)]
         [InlineData("66.102.6.172,7/27/2017 4:50:09 PM +00:00,GET,\"/favicon.ico\",HTTP/1.1,200,726,\"-\",\"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google+Favicon\",216,TCP_MISS,150.138.143.19", "1501174209 0 66.102.6.172 0 150.138.143.19 0 TCP_MISS/200 726 GET /favicon.ico - 216 0 - Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google+Favicon na na")]
         [InlineData("66.102.6.172,7/27/2017 4:50:09 PM +00:00,GET,\"/favicon.ico\",HTTP/1.1,200,726,\"-\",\"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google,Favicon\",216,TCP_MISS,150.138.143.19", "1501174209 0 66.102.6.172 0 150.138.143.19 0 TCP_MISS/200 726 GET /favicon.ico - 216 0 - Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google,Favicon na na")]
+        [InlineData("127.0.0.1,1/1/2020 1:23:45 PM +00:00,GET,\"/?q=foo(\"bar\", 2)\",HTTP/1.1,123,456,\"http://nuget.test/?\",\"Mozilla/4.0\",1,HIT,127.0.0.2", null)]
         public void TransformRawLogLine(string input, string expectedOutput)
         {
-            var collector  = new ChinaStatsCollector();
+            var collector  = new ChinaStatsCollector(
+                Mock.Of<ILogSource>(),
+                Mock.Of<ILogDestination>(),
+                Mock.Of<ILogger<ChinaStatsCollector>>());
 
             var tranformedinput = collector.TransformRawLogLine(input);
             string output = tranformedinput == null ? null : tranformedinput.ToString();
-            Assert.Equal(expectedOutput,output);
+            Assert.Equal(expectedOutput, output);
         }
     }
 }
+ 


### PR DESCRIPTION
There's several deadlettered blobs on PROD Mooncake CDN logs queue. This makes the job a little more resilient to malformed lines and improves logging to make this kind of debugging easier.