### PR TITLE
[Stats-1-Job] Detach IP Address for "Stats.ImportAzureCdnStatistics" job

### DIFF
--- a/src/Stats.ImportAzureCdnStatistics/DataImporter.cs
+++ b/src/Stats.ImportAzureCdnStatistics/DataImporter.cs
@@ -56,6 +56,12 @@ namespace Stats.ImportAzureCdnStatistics
                 dataTable.Columns.Remove("Timestamp");
             }
 
+            // Remove Fact_EdgeServer_IpAddress_Id column from in-memory data table if it exists.
+            if (dataTable.Columns.Contains("Fact_EdgeServer_IpAddress_Id"))
+            {
+                dataTable.Columns.Remove("Fact_EdgeServer_IpAddress_Id");
+            }
+
             dataTable.TableName = $"dbo.{tableName}";
             return dataTable;
         }


### PR DESCRIPTION
We decide to drop the IP Address data saved on the stats DB, which we don't use now.
This PR is used to detach "Stats.ImportAzureCdnStatistics" job from inserting the true IP Address info.
@xavierdecoster 

**WARNING**: The job can only be deployed after we make the column "Fact_EdgeServer_IpAddress_Id" null-able on tables "Fact_Download" and "Fact_Dist_Download".

```
ALTER TABLE Fact_Download ALTER COLUMN Fact_EdgeServer_IpAddress_Id INT NULL;
GO
ALTER TABLE Fact_Dist_Download ALTER COLUMN Fact_EdgeServer_IpAddress_Id INT NULL;
GO
```