### PR TITLE
Change the icon used for the validation subsystem in README

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/README.md
+++ b/src/NuGet.Services.Validation.Orchestrator/README.md
@@ -1,6 +1,6 @@
 ﻿## Overview
 
-**Subsystem:** 🔎 Validation
+**Subsystem: Validation 📝**
 
 This job manages ("orchestrates") the validation of packages (.nupkg files) and symbol packages (.snupkg files) before
 they become available for consumption on nuget.org.

--- a/src/Validation.PackageSigning.ProcessSignature/README.md
+++ b/src/Validation.PackageSigning.ProcessSignature/README.md
@@ -1,6 +1,6 @@
 ﻿## Overview
 
-**Subsystem:** 🔎 Validation
+**Subsystem: Validation 📝**
 
 This job manages the validation of a package's signature. A NuGet package (.nupkg) can be signed using a cryptographic
 certificate and the signature is embedded in the package file. On nuget.org all packages must have a repository


### PR DESCRIPTION
I want to use that icon for search subsystem, related to https://github.com/NuGet/NuGetGallery/issues/8006.

Also moved the emoji to the end to improve searchability.