### PR TITLE
Fix header case sensitivity bug in the GitHub indexer job

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
@@ -40,7 +40,7 @@ namespace NuGet.Jobs.GitHubIndexer
                 throw new InvalidDataException("Date is missing, has a wrong format or is not in GMT timezone");
             }
 
-            if (!apiResponse.HttpResponse.Headers.TryGetValue("X-Ratelimit-Reset", out var ghStrResetLimit)
+            if (!caseInsensitiveHeaders.TryGetValue("X-Ratelimit-Reset", out var ghStrResetLimit)
                 || !long.TryParse(ghStrResetLimit, out var ghResetTime))
             {
                 throw new InvalidDataException("X-Ratelimit-Reset is required to compute the throttling time.");

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
@@ -34,9 +34,8 @@ namespace NuGet.Jobs.GitHubIndexer
             // According to RFC 2616, Http headers are case-insensitive. We should treat them as such.
             var caseInsensitiveHeaders = apiResponse.HttpResponse.Headers
                 .AsEnumerable()
-                .GroupBy(x => x.Key.ToLower())
-                .Select(x => x.First())
-                .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+                .GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(x => x.Key, x => x.First().Value, StringComparer.OrdinalIgnoreCase);
 
             if (!caseInsensitiveHeaders.TryGetValue("Date", out var ghStrDate)
                 || !DateTimeOffset.TryParseExact(ghStrDate.Replace("GMT", "+0"), "ddd',' dd MMM yyyy HH:mm:ss z", CultureInfo.InvariantCulture, DateTimeStyles.None, out var ghTime))

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
@@ -32,7 +32,11 @@ namespace NuGet.Jobs.GitHubIndexer
             var apiResponse = await _client.Connection.Get<SearchRepositoryResult>(ApiUrls.SearchRepositories(), request.Parameters, null);
 
             // According to RFC 2616, Http headers are case-insensitive. We should treat them as such.
-            var caseInsensitiveHeaders = apiResponse.HttpResponse.Headers.AsEnumerable().ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+            var caseInsensitiveHeaders = apiResponse.HttpResponse.Headers
+                .AsEnumerable()
+                .GroupBy(x => x.Key.ToLower())
+                .Select(x => x.First())
+                .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
 
             if (!caseInsensitiveHeaders.TryGetValue("Date", out var ghStrDate)
                 || !DateTimeOffset.TryParseExact(ghStrDate.Replace("GMT", "+0"), "ddd',' dd MMM yyyy HH:mm:ss z", CultureInfo.InvariantCulture, DateTimeStyles.None, out var ghTime))

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearchWrapperFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearchWrapperFacts.cs
@@ -45,7 +45,6 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
 
         public class GetResponseMethod
         {
-
             [Fact]
             public async Task CaseInsensitiveHeader()
             {

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearchWrapperFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearchWrapperFacts.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Moq;
-using Octokit;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
+using Moq;
+using Octokit;
 using Xunit;
 
 namespace NuGet.Jobs.GitHubIndexer.Tests
@@ -22,9 +22,9 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
             var mockResponse = new Mock<IResponse>();
 
             mockApiResponse.Setup(x => x.HttpResponse)
-                    .Returns(mockResponse.Object);
+                .Returns(mockResponse.Object);
             mockApiResponse.Setup(x => x.Body)
-                    .Returns(new SearchRepositoryResult(totalCount: 0, incompleteResults: false, items: new List<Repository>()));
+                .Returns(new SearchRepositoryResult(totalCount: 0, incompleteResults: false, items: new List<Repository>()));
             mockResponse
                 .Setup(x => x.Headers)
                 .Returns(headers);
@@ -40,13 +40,12 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                     return mockApiResponse.Object;
                 });
             return new GitHubSearchWrapper(mockClient.Object);
-
         }
 
         public class GetResponseMethod
         {
             [Fact]
-            public async Task CaseInsensitiveHeader()
+            public async Task DoesNotThrowIfCaseInsensitiveHeader()
             {
                 var headers = new ReadOnlyDictionary<string, string>(
                     new Dictionary<string, string>()
@@ -57,8 +56,6 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                 var searcher = GetTestSearcher(headers);
 
                 await searcher.GetResponse(new SearchRepositoriesRequest { });
-
-                Assert.True(true);
             }
 
             [Fact]
@@ -72,9 +69,9 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                 var searcher = GetTestSearcher(headers);
 
                 await Assert.ThrowsAsync<InvalidDataException>(async () =>
-                 {
-                     await searcher.GetResponse(new SearchRepositoriesRequest { });
-                 });
+                {
+                    await searcher.GetResponse(new SearchRepositoriesRequest { });
+                });
             }
 
             [Fact]

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearchWrapperFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearchWrapperFacts.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Jobs.GitHubIndexer.Tests
+{
+    public class GitHubSearchWrapperFacts
+    {
+        private static GitHubSearchWrapper GetTestSearcher(IReadOnlyDictionary<string, string> headers = null)
+        {
+            var mockClient = new Mock<IGitHubClient>();
+            var mockConnection = new Mock<IConnection>();
+            var mockApiResponse = new Mock<IApiResponse<SearchRepositoryResult>>();
+            var mockResponse = new Mock<IResponse>();
+
+            mockApiResponse.Setup(x => x.HttpResponse)
+                    .Returns(mockResponse.Object);
+            mockApiResponse.Setup(x => x.Body)
+                    .Returns(new SearchRepositoryResult(totalCount: 0, incompleteResults: false, items: new List<Repository>()));
+            mockResponse
+                .Setup(x => x.Headers)
+                .Returns(headers);
+
+            mockClient
+                .SetupGet(x => x.Connection)
+                .Returns(mockConnection.Object);
+
+            mockConnection
+                .Setup(x => x.Get<SearchRepositoryResult>(It.IsAny<Uri>(), It.IsAny<IDictionary<string, string>>(), It.IsAny<string>()))
+                .Returns(async (Uri uri, IDictionary<string, string> parameters, string accepts) =>
+                {
+                    return mockApiResponse.Object;
+                });
+            return new GitHubSearchWrapper(mockClient.Object);
+
+        }
+
+        public class GetResponseMethod
+        {
+
+            [Fact]
+            public async Task CaseInsensitiveHeader()
+            {
+                var headers = new ReadOnlyDictionary<string, string>(
+                    new Dictionary<string, string>()
+                    {
+                        { "dAtE", "Fri, 12 Oct 2012 23:33:14 GMT" },
+                        { "x-RaTeLiMiT-rEsEt", "1350085394"}
+                    });
+                var searcher = GetTestSearcher(headers);
+
+                await searcher.GetResponse(new SearchRepositoriesRequest { });
+
+                Assert.True(true);
+            }
+
+            [Fact]
+            public async Task TestMissingDateHeader()
+            {
+                var headers = new ReadOnlyDictionary<string, string>(
+                    new Dictionary<string, string>()
+                    {
+                        { "x-RaTeLiMiT-rEsEt", "1350085394"}
+                    });
+                var searcher = GetTestSearcher(headers);
+
+                await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                 {
+                     await searcher.GetResponse(new SearchRepositoriesRequest { });
+                 });
+            }
+
+            [Fact]
+            public async Task TestMissingRateLimitHeader()
+            {
+                var headers = new ReadOnlyDictionary<string, string>(
+                    new Dictionary<string, string>()
+                    {
+                        { "dAtE", "Fri, 12 Oct 2012 23:33:14 GMT" }
+                    });
+                var searcher = GetTestSearcher(headers);
+
+                await Assert.ThrowsAsync<InvalidDataException>(async () =>
+                {
+                    await searcher.GetResponse(new SearchRepositoriesRequest { });
+                });
+            }
+        }
+    }
+}

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/NuGet.Jobs.GitHubIndexer.Tests.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="FiltersFacts.cs" />
     <Compile Include="GitHubSearcherFacts.cs" />
+    <Compile Include="GitHubSearchWrapperFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReposIndexerFacts.cs" />
     <Compile Include="RepoUtilsFacts.cs" />


### PR DESCRIPTION
According to HTTP standards, the headers of a request are case insensitive. The GitHub Indexer job didn't handle headers as case insensitive which lead to a bug in the handling of the GitHub API response and made the job crash. This PR fixes that bug by making sure headers from a response are accessible in a case insensitive way.