### PR TITLE
[Fix] Try more efficient aggregation for stats-import job

### DIFF
--- a/src/Stats.ImportAzureCdnStatistics/ApplicationInsightsHelper.cs
+++ b/src/Stats.ImportAzureCdnStatistics/ApplicationInsightsHelper.cs
@@ -92,21 +92,13 @@ namespace Stats.ImportAzureCdnStatistics
             _telemetryClient.Flush();
         }
 
-        public void TrackMetric(string metricName, double value, string logFileName = null, string packageId = null, string packageVersion = null)
+        public void TrackMetric(string metricName, double value, string logFileName = null)
         {
             var telemetry = new MetricTelemetry(metricName, value);
 
             if (!string.IsNullOrWhiteSpace(logFileName))
             {
                 telemetry.Properties.Add("LogFile", logFileName);
-            }
-            if (!string.IsNullOrWhiteSpace(packageId))
-            {
-                telemetry.Properties.Add("PackageId", packageId);
-            }
-            if (!string.IsNullOrWhiteSpace(packageVersion))
-            {
-                telemetry.Properties.Add("PackageVersion", packageVersion);
             }
 
             _telemetryClient.TrackMetric(telemetry);

--- a/src/Stats.ImportAzureCdnStatistics/ApplicationInsightsHelper.cs
+++ b/src/Stats.ImportAzureCdnStatistics/ApplicationInsightsHelper.cs
@@ -92,13 +92,21 @@ namespace Stats.ImportAzureCdnStatistics
             _telemetryClient.Flush();
         }
 
-        public void TrackMetric(string metricName, double value, string logFileName = null)
+        public void TrackMetric(string metricName, double value, string logFileName = null, string packageId = null, string packageVersion = null)
         {
             var telemetry = new MetricTelemetry(metricName, value);
 
             if (!string.IsNullOrWhiteSpace(logFileName))
             {
                 telemetry.Properties.Add("LogFile", logFileName);
+            }
+            if (!string.IsNullOrWhiteSpace(packageId))
+            {
+                telemetry.Properties.Add("PackageId", packageId);
+            }
+            if (!string.IsNullOrWhiteSpace(packageVersion))
+            {
+                telemetry.Properties.Add("PackageVersion", packageVersion);
             }
 
             _telemetryClient.TrackMetric(telemetry);

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -239,6 +239,7 @@ namespace Stats.ImportAzureCdnStatistics
             _logger.LogDebug("  DONE (" + factsDataTable.Rows.Count + " facts, " + stopwatch.ElapsedMilliseconds + "ms)");
             _applicationInsightsHelper.TrackMetric("Facts creation time (ms)", stopwatchCreatingFacts.ElapsedMilliseconds, logFileName);
             _applicationInsightsHelper.TrackMetric("Blob record count", factsDataTable.Rows.Count, logFileName);
+
             return factsDataTable;
         }
 

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -168,6 +168,7 @@ namespace Stats.ImportAzureCdnStatistics
                     }
 
                     var packageId = package.Id;
+                    var stopwatchCreatingDictionary = Stopwatch.StartNew();
                     var dimensionIdsDictionary = new Dictionary<(int, int, int, int, int, int), int>();
                     foreach (var element in groupedByPackageIdAndVersion)
                     {
@@ -215,6 +216,9 @@ namespace Stats.ImportAzureCdnStatistics
                             dimensionIdsDictionary[dimensionIds] = 1;
                         }
                     }
+                    stopwatchCreatingDictionary.Stop();
+                    _logger.LogInformation("Finished creating dictionary with {DictionaryCount} keys for package Id {PackageId} ({CreatedDictionaryDuration} ms).",
+                        dimensionIdsDictionary.Count, packageId, stopwatchCreatingDictionary.ElapsedMilliseconds);
 
                     foreach (var dimensionIds in dimensionIdsDictionary)
                     {
@@ -227,9 +231,9 @@ namespace Stats.ImportAzureCdnStatistics
                         FillDataRow(dataRow, key.dateId, key.timeId, packageId, key.operationId, key.platformId, key.clientId, key.userAgentId, logFileNameId, downloadCount);
                         factsDataTable.Rows.Add(dataRow);
 
-                        _logger.LogDebug("Inserted 1 row into factsDataTable, which counts for {downloadCount} downloads, with the dimension Ids (" +
-                            "dateId: {dateId}, timeId: {timeId}, packageId: {packageId}, operationId: {operationId}, platformId: {platformId}, clientId: {clientId}, " +
-                            "userAgentId: {userAgentId}, logFileNameId: {logFileNameId}).", downloadCount, key.dateId, key.timeId, packageId, key.operationId,
+                        _logger.LogDebug("Inserted 1 row into factsDataTable, which counts for {DownloadCount} downloads, with the dimension Ids (" +
+                            "dateId: {DateId}, timeId: {TimeId}, packageId: {PackageId}, operationId: {OperationId}, platformId: {PlatformId}, clientId: {ClientId}, " +
+                            "userAgentId: {UserAgentId}, logFileNameId: {LogFileNameId}).", downloadCount, key.dateId, key.timeId, packageId, key.operationId,
                             key.platformId, key.clientId, key.userAgentId, logFileNameId);
                     }
                 }
@@ -237,7 +241,7 @@ namespace Stats.ImportAzureCdnStatistics
             stopwatchCreatingFacts.Stop();
             stopwatch.Stop();
             _logger.LogDebug("  DONE (" + factsDataTable.Rows.Count + " facts, " + stopwatch.ElapsedMilliseconds + "ms)");
-            _applicationInsightsHelper.TrackMetric("Facts creation time (ms)", stopwatchCreatingFacts.ElapsedMilliseconds, logFileName);
+            _logger.LogInformation("Finished creating facts for log file {LogFileName} ({CreatedFactsDuration} ms).", logFileName, stopwatchCreatingFacts.ElapsedMilliseconds);
             _applicationInsightsHelper.TrackMetric("Blob record count", factsDataTable.Rows.Count, logFileName);
             return factsDataTable;
         }

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -149,6 +149,7 @@ namespace Stats.ImportAzureCdnStatistics
             }
 
             _logger.LogDebug("Creating facts...");
+            var stopwatchCreatingFacts = Stopwatch.StartNew();
             foreach (var groupedByPackageId in sourceData.GroupBy(e => e.PackageId, StringComparer.OrdinalIgnoreCase))
             {
                 var packagesForId = packages.Where(e => string.Equals(e.PackageId, groupedByPackageId.Key, StringComparison.OrdinalIgnoreCase)).ToList();
@@ -167,7 +168,7 @@ namespace Stats.ImportAzureCdnStatistics
                     }
 
                     var packageId = package.Id;
-
+                    var dimensionIdsDictionary = new Dictionary<(int, int, int, int, int, int), int>();
                     foreach (var element in groupedByPackageIdAndVersion)
                     {
                         // required dimensions
@@ -204,17 +205,40 @@ namespace Stats.ImportAzureCdnStatistics
                             }
                         }
 
+                        var dimensionIds = (dateId, timeId, operationId, platformId, clientId, userAgentId);
+                        if (dimensionIdsDictionary.ContainsKey(dimensionIds))
+                        {
+                            dimensionIdsDictionary[dimensionIds] += 1;
+                        }
+                        else
+                        {
+                            dimensionIdsDictionary[dimensionIds] = 1;
+                        }
+                    }
+
+                    foreach (var dimensionIds in dimensionIdsDictionary)
+                    {
                         // create fact
                         var dataRow = factsDataTable.NewRow();
-                        FillDataRow(dataRow, dateId, timeId, packageId, operationId, platformId, clientId, userAgentId, logFileNameId);
+
+                        (int dateId, int timeId, int operationId, int platformId, int clientId, int userAgentId) key = dimensionIds.Key;
+                        var downloadCount = dimensionIds.Value;
+
+                        FillDataRow(dataRow, key.dateId, key.timeId, packageId, key.operationId, key.platformId, key.clientId, key.userAgentId, logFileNameId, downloadCount);
                         factsDataTable.Rows.Add(dataRow);
+
+                        _logger.LogDebug("Inserted 1 row into factsDataTable, which counts for {downloadCount} downloads, with the dimension Ids (" +
+                            "dateId: {dateId}, timeId: {timeId}, packageId: {packageId}, operationId: {operationId}, platformId: {platformId}, clientId: {clientId}, " +
+                            "userAgentId: {userAgentId}, logFileNameId: {logFileNameId}).", downloadCount, key.dateId, key.timeId, packageId, key.operationId,
+                            key.platformId, key.clientId, key.userAgentId, logFileNameId);
                     }
                 }
             }
+            stopwatchCreatingFacts.Stop();
             stopwatch.Stop();
             _logger.LogDebug("  DONE (" + factsDataTable.Rows.Count + " facts, " + stopwatch.ElapsedMilliseconds + "ms)");
+            _applicationInsightsHelper.TrackMetric("Facts creation time (ms)", stopwatchCreatingFacts.ElapsedMilliseconds, logFileName);
             _applicationInsightsHelper.TrackMetric("Blob record count", factsDataTable.Rows.Count, logFileName);
-
             return factsDataTable;
         }
 
@@ -603,7 +627,7 @@ namespace Stats.ImportAzureCdnStatistics
             return Enumerable.Empty<T>().ToList();
         }
 
-        private static void FillDataRow(DataRow dataRow, int dateId, int timeId, int packageId, int operationId, int platformId, int clientId, int userAgentId, int logFileNameId)
+        private static void FillDataRow(DataRow dataRow, int dateId, int timeId, int packageId, int operationId, int platformId, int clientId, int userAgentId, int logFileNameId, int downloadCount)
         {
             dataRow["Dimension_Package_Id"] = packageId;
             dataRow["Dimension_Date_Id"] = dateId;
@@ -613,7 +637,7 @@ namespace Stats.ImportAzureCdnStatistics
             dataRow["Dimension_Platform_Id"] = platformId;
             dataRow["Fact_UserAgent_Id"] = userAgentId;
             dataRow["Fact_LogFileName_Id"] = logFileNameId;
-            dataRow["DownloadCount"] = 1;
+            dataRow["DownloadCount"] = downloadCount;
         }
 
         private static void FillToolDataRow(DataRow dataRow, int dateId, int timeId, int toolId, int platformId, int clientId, int userAgentId, int logFileNameId)

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -217,8 +217,7 @@ namespace Stats.ImportAzureCdnStatistics
                         }
                     }
                     stopwatchCreatingDictionary.Stop();
-                    _logger.LogInformation("Finished creating dictionary with {DictionaryCount} keys for package Id {PackageId} ({CreatedDictionaryDuration} ms).",
-                        dimensionIdsDictionary.Count, packageId, stopwatchCreatingDictionary.ElapsedMilliseconds);
+                    _applicationInsightsHelper.TrackMetric("Dictionary creation time for aggregation (ms)", stopwatchCreatingDictionary.ElapsedMilliseconds, logFileName, package.PackageId, package.PackageVersion);
 
                     foreach (var dimensionIds in dimensionIdsDictionary)
                     {
@@ -241,7 +240,7 @@ namespace Stats.ImportAzureCdnStatistics
             stopwatchCreatingFacts.Stop();
             stopwatch.Stop();
             _logger.LogDebug("  DONE (" + factsDataTable.Rows.Count + " facts, " + stopwatch.ElapsedMilliseconds + "ms)");
-            _logger.LogInformation("Finished creating facts for log file {LogFileName} ({CreatedFactsDuration} ms).", logFileName, stopwatchCreatingFacts.ElapsedMilliseconds);
+            _applicationInsightsHelper.TrackMetric("Facts creation time (ms)", stopwatchCreatingFacts.ElapsedMilliseconds, logFileName);
             _applicationInsightsHelper.TrackMetric("Blob record count", factsDataTable.Rows.Count, logFileName);
             return factsDataTable;
         }

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -217,7 +217,8 @@ namespace Stats.ImportAzureCdnStatistics
                         }
                     }
                     stopwatchCreatingDictionary.Stop();
-                    _applicationInsightsHelper.TrackMetric("Dictionary creation time for aggregation (ms)", stopwatchCreatingDictionary.ElapsedMilliseconds, logFileName, package.PackageId, package.PackageVersion);
+                    _logger.LogInformation("Finished creating dictionary with {DictionaryCount} keys for package Id {PackageId} ({CreatedDictionaryDuration} ms).",
+                        dimensionIdsDictionary.Count, packageId, stopwatchCreatingDictionary.ElapsedMilliseconds);
 
                     foreach (var dimensionIds in dimensionIdsDictionary)
                     {
@@ -240,7 +241,7 @@ namespace Stats.ImportAzureCdnStatistics
             stopwatchCreatingFacts.Stop();
             stopwatch.Stop();
             _logger.LogDebug("  DONE (" + factsDataTable.Rows.Count + " facts, " + stopwatch.ElapsedMilliseconds + "ms)");
-            _applicationInsightsHelper.TrackMetric("Facts creation time (ms)", stopwatchCreatingFacts.ElapsedMilliseconds, logFileName);
+            _logger.LogInformation("Finished creating facts for log file {LogFileName} ({CreatedFactsDuration} ms).", logFileName, stopwatchCreatingFacts.ElapsedMilliseconds);
             _applicationInsightsHelper.TrackMetric("Blob record count", factsDataTable.Rows.Count, logFileName);
             return factsDataTable;
         }

--- a/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
+++ b/src/Stats.ImportAzureCdnStatistics/Warehouse.cs
@@ -168,7 +168,6 @@ namespace Stats.ImportAzureCdnStatistics
                     }
 
                     var packageId = package.Id;
-                    var stopwatchCreatingDictionary = Stopwatch.StartNew();
                     var dimensionIdsDictionary = new Dictionary<(int, int, int, int, int, int), int>();
                     foreach (var element in groupedByPackageIdAndVersion)
                     {
@@ -216,9 +215,6 @@ namespace Stats.ImportAzureCdnStatistics
                             dimensionIdsDictionary[dimensionIds] = 1;
                         }
                     }
-                    stopwatchCreatingDictionary.Stop();
-                    _logger.LogInformation("Finished creating dictionary with {DictionaryCount} keys for package Id {PackageId} ({CreatedDictionaryDuration} ms).",
-                        dimensionIdsDictionary.Count, packageId, stopwatchCreatingDictionary.ElapsedMilliseconds);
 
                     foreach (var dimensionIds in dimensionIdsDictionary)
                     {
@@ -241,7 +237,7 @@ namespace Stats.ImportAzureCdnStatistics
             stopwatchCreatingFacts.Stop();
             stopwatch.Stop();
             _logger.LogDebug("  DONE (" + factsDataTable.Rows.Count + " facts, " + stopwatch.ElapsedMilliseconds + "ms)");
-            _logger.LogInformation("Finished creating facts for log file {LogFileName} ({CreatedFactsDuration} ms).", logFileName, stopwatchCreatingFacts.ElapsedMilliseconds);
+            _applicationInsightsHelper.TrackMetric("Facts creation time (ms)", stopwatchCreatingFacts.ElapsedMilliseconds, logFileName);
             _applicationInsightsHelper.TrackMetric("Blob record count", factsDataTable.Rows.Count, logFileName);
             return factsDataTable;
         }


### PR DESCRIPTION
This is pretty much the same PR compare with: https://github.com/NuGet/NuGet.Jobs/pull/895
We notice a performance degradation (takes more than 20 minutes to finish the aggregation) for the stats-import job with the above PR, which can not be reproduced locally (takes less than 1.5 minutes for a 150 MB log file).

This approach uses ValueTuple rather than Tuple, to alleviate the burden of GC.
ValueTuple is a struct while Tuple is an object. This may be the reason which leads to the degradation.
The telemetry is added to track the time to finish the aggregation. 

It's still under investigation, but considering the increasing space usage of stats DB, and the time to finish the investigation, I'd like to deploy this change to Int and Prod to see whether it can help improving the performance.

I will deploy to Int firstly, and take the same experiment before to verify the aggregation result locally, then I will move to Prod. If it can not help, I will roll back to the current one, which inserts each log item one by one to DB.