### PR TITLE
Hide test data by default in search results

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -201,6 +201,7 @@
     <Compile Include="SearchService\SearchStatusOptions.cs" />
     <Compile Include="SearchService\SearchStatusService.cs" />
     <Compile Include="SearchService\ParsedQuery.cs" />
+    <Compile Include="SearchService\SearchText.cs" />
     <Compile Include="SearchService\SearchTextBuilder.cs" />
     <Compile Include="AzureSearchTelemetryService.cs" />
     <Compile Include="SearchService\SecretRefresher.cs" />

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchTextBuilder.cs
@@ -30,7 +30,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// </summary>
         /// <param name="parsed">The parsed query.</param>
         /// <returns>The Lucene search text to pass to Azure Search.</returns>
-        string Build(ParsedQuery parsed);
+        SearchText Build(ParsedQuery parsed);
 
         /// <summary>
         /// Map an autocomplete request to Azure Search.
@@ -38,6 +38,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// <param name="request">The autocomplete request.</param>
         /// <returns>The Azure Search query.</returns>
         /// <exception cref="InvalidSearchRequestException">Thrown on invalid autocomplete requests.</exception>
-        string Autocomplete(AutocompleteRequest request);
+        SearchText Autocomplete(AutocompleteRequest request);
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
@@ -44,8 +44,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             var text = _textBuilder.Build(parsed);
-            var parameters = _parametersBuilder.V3Search(request, IsEmptySearchQuery(text));
-            return IndexOperation.Search(text, parameters);
+            var parameters = _parametersBuilder.V3Search(request, text.IsDefaultSearch);
+            return IndexOperation.Search(text.Value, parameters);
         }
 
         public IndexOperation V2SearchWithSearchIndex(V2SearchRequest request)
@@ -65,8 +65,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             var text = _textBuilder.Build(parsed);
-            var parameters = _parametersBuilder.V2Search(request, IsEmptySearchQuery(text));
-            return IndexOperation.Search(text, parameters);
+            var parameters = _parametersBuilder.V2Search(request, text.IsDefaultSearch);
+            return IndexOperation.Search(text.Value, parameters);
         }
 
         public IndexOperation V2SearchWithHijackIndex(V2SearchRequest request)
@@ -85,8 +85,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             var text = _textBuilder.Build(parsed);
-            var parameters = _parametersBuilder.V2Search(request, IsEmptySearchQuery(text));
-            return IndexOperation.Search(text, parameters);
+            var parameters = _parametersBuilder.V2Search(request, text.IsDefaultSearch);
+            return IndexOperation.Search(text.Value, parameters);
         }
 
         public IndexOperation Autocomplete(AutocompleteRequest request)
@@ -97,8 +97,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             var text = _textBuilder.Autocomplete(request);
-            var parameters = _parametersBuilder.Autocomplete(request, IsEmptySearchQuery(text));
-            return IndexOperation.Search(text, parameters);
+            var parameters = _parametersBuilder.Autocomplete(request, text.IsDefaultSearch);
+            return IndexOperation.Search(text.Value, parameters);
         }
 
         private bool TryGetSearchDocumentByKey(
@@ -189,11 +189,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         private static bool PagedToFirstItem(SearchRequest request)
         {
             return request.Skip <= 0 && request.Take >= 1;
-        }
-
-        private static bool IsEmptySearchQuery(string parsedText)
-        {
-            return parsedText.Equals(SearchTextBuilder.MatchAllDocumentsQuery);
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/SearchRequest.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/SearchRequest.cs
@@ -10,6 +10,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public bool IncludePrerelease { get; set; }
         public bool IncludeSemVer2 { get; set; }
         public string Query { get; set; }
+        public bool IncludeTestData { get; set; }
         public bool ShowDebug { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/ParsedQuery.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ParsedQuery.cs
@@ -7,15 +7,18 @@ using System.Collections.Generic;
 namespace NuGet.Services.AzureSearch.SearchService
 {
     /// <summary>
-    /// Contains the parsed in-memory model of the user's query.
+    /// Contains the parsed in-memory model of the user's query and any additional parameters used to construct the
+    /// final Lucene query text.
     /// </summary>
     public class ParsedQuery
     {
-        public ParsedQuery(Dictionary<QueryField, HashSet<string>> grouping)
+        public ParsedQuery(Dictionary<QueryField, HashSet<string>> grouping, bool includeTestData)
         {
             Grouping = grouping ?? throw new ArgumentNullException(nameof(grouping));
+            IncludeTestData = includeTestData;
         }
 
         public Dictionary<QueryField, HashSet<string>> Grouping { get; }
+        public bool IncludeTestData { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
@@ -139,14 +139,14 @@ namespace NuGet.Services.AzureSearch.SearchService
         private void ApplySearchIndexFilter(
             SearchParameters searchParameters,
             SearchRequest request,
-            bool excludePackagesHiddenByDefault,
+            bool isDefaultSearch,
             string packageType)
         {
             var searchFilters = GetSearchFilters(request);
 
             var filterString = $"{IndexFields.Search.SearchFilters} eq '{DocumentUtilities.GetSearchFilterString(searchFilters)}'";
 
-            if (excludePackagesHiddenByDefault)
+            if (isDefaultSearch)
             {
                 filterString += $" and ({IndexFields.Search.IsExcludedByDefault} eq false or {IndexFields.Search.IsExcludedByDefault} eq null)";
             }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -17,5 +18,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         public TimeSpan SecretRefreshFrequency { get; set; } = TimeSpan.FromHours(12);
         public TimeSpan SecretRefreshFailureRetryFrequency { get; set; } = TimeSpan.FromMinutes(5);
         public string DeploymentLabel { get; set; }
+        public List<string> TestOwners { get; set; } = new List<string>();
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchText.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchText.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class SearchText
+    {
+        public SearchText(string value, bool isDefaultSearch)
+        {
+            Value = value;
+            IsDefaultSearch = isDefaultSearch;
+        }
+
+        /// <summary>
+        /// The search text, which is a Lucene expression.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Whether or not the search text represents a default search without any user provided terms.
+        /// </summary>
+        public bool IsDefaultSearch { get; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
@@ -14,7 +14,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 {
     public partial class SearchTextBuilder : ISearchTextBuilder
     {
-        public const string MatchAllDocumentsQuery = "*";
+        private readonly SearchText MatchAllDocumentsIncludingTestData = new SearchText("*", isDefaultSearch: true);
+
         private static readonly char[] PackageIdSeparators = new[] { '.', '-', '_' };
         private static readonly char[] TokenizationSeparators = new[] { '.', '-', '_', ',' };
         private static readonly Regex TokenizePackageIdRegex = new Regex(
@@ -55,19 +56,22 @@ namespace NuGet.Services.AzureSearch.SearchService
                 query = "packageid:" + query.Substring(3);
             }
 
-            return GetParsedQuery(query);
+            // We must include test data when we are querying the hijack index since the owners field is not
+            // available in that index. The hijack index is queried when "ignoreFilter=true". Otherwise, the search
+            // index is queried and which means it is possible to filter out test data.
+            return GetParsedQuery(query, request.IncludeTestData || request.IgnoreFilter);
         }
 
         public ParsedQuery ParseV3Search(V3SearchRequest request)
         {
-            return GetParsedQuery(request.Query);
+            return GetParsedQuery(request.Query, request.IncludeTestData);
         }
 
-        public string Autocomplete(AutocompleteRequest request)
+        public SearchText Autocomplete(AutocompleteRequest request)
         {
             if (string.IsNullOrWhiteSpace(request.Query))
             {
-                return MatchAllDocumentsQuery;
+                return GetMatchAllDocuments(request.IncludeTestData);
             }
 
             // Query package ids. If autocompleting package ids, allow prefix matches.
@@ -93,7 +97,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     builder.AppendScopedTerm(
                         fieldName: IndexFields.TokenizedPackageId,
                         term: piece,
-                        required: true,
+                        prefix: TermPrefix.And,
                         prefixSearch: true);
                 }
 
@@ -110,27 +114,31 @@ namespace NuGet.Services.AzureSearch.SearchService
                     prefixSearch: false);
             }
 
+            if (!request.IncludeTestData)
+            {
+                ExcludeTestData(builder);
+            }
 
-            return builder.ToString();
+            return new SearchText(builder.ToString(), isDefaultSearch: false);
         }
 
-        private ParsedQuery GetParsedQuery(string query)
+        private ParsedQuery GetParsedQuery(string query, bool includeTestData)
         {
             if (string.IsNullOrWhiteSpace(query))
             {
-                return new ParsedQuery(new Dictionary<QueryField, HashSet<string>>());
+                return new ParsedQuery(new Dictionary<QueryField, HashSet<string>>(), includeTestData);
             }
 
             var grouping = _parser.ParseQuery(query.Trim(), skipWhiteSpace: true);
 
-            return new ParsedQuery(grouping);
+            return new ParsedQuery(grouping, includeTestData);
         }
 
-        public string Build(ParsedQuery parsed)
+        public SearchText Build(ParsedQuery parsed)
         {
             if (!parsed.Grouping.Any())
             {
-                return MatchAllDocumentsQuery;
+                return GetMatchAllDocuments(parsed.IncludeTestData);
             }
 
             var scopedTerms = parsed.Grouping.Where(g => g.Key != QueryField.Any && g.Key != QueryField.Invalid).ToList();
@@ -143,7 +151,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             var hasUnscopedTerms = unscopedTerms != null && unscopedTerms.Count > 0;
             if (scopedTerms.Count == 0 && !hasUnscopedTerms)
             {
-                return MatchAllDocumentsQuery;
+                return GetMatchAllDocuments(parsed.IncludeTestData);
             }
 
             // Add the terms that are scoped to specific fields.
@@ -166,7 +174,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 }
                 else
                 {
-                    builder.AppendScopedTerm(fieldName, values.First(), required: requireScopedTerms);
+                    builder.AppendScopedTerm(fieldName, values.First(), prefix: requireScopedTerms ? TermPrefix.And : TermPrefix.None);
                 }
             }
 
@@ -199,7 +207,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                         builder.AppendScopedTerm(
                             fieldName: IndexFields.PackageId,
                             term: lastUnscopedTerm,
-                            required: false,
+                            prefix: TermPrefix.None,
                             prefixSearch: true,
                             boost: _options.Value.PrefixMatchBoost);
                     }
@@ -212,7 +220,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                         builder.AppendScopedTerm(
                             fieldName: IndexFields.TokenizedPackageId,
                             term: lastUnscopedTerm,
-                            required: false,
+                            prefix: TermPrefix.None,
                             prefixSearch: true,
                             boost: boost);
                     }
@@ -229,13 +237,19 @@ namespace NuGet.Services.AzureSearch.SearchService
                 builder.AppendExactMatchPackageIdBoost(unscopedTerms[0], _options.Value.ExactMatchBoost);
             }
 
-            var result = builder.ToString();
-            if (string.IsNullOrWhiteSpace(result))
+            if (!parsed.IncludeTestData)
             {
-                return MatchAllDocumentsQuery;
+                ExcludeTestData(builder);
             }
 
-            return result;
+            var result = builder.ToString();
+
+            if (string.IsNullOrWhiteSpace(result))
+            {
+                return GetMatchAllDocuments(parsed.IncludeTestData);
+            }
+
+            return new SearchText(result, isDefaultSearch: false);
         }
 
         private static IEnumerable<string> ProcessFieldValues(QueryField field, IEnumerable<string> values)
@@ -305,6 +319,43 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             return TokenizationSeparators.Any(separator => input[0] == separator);
+        }
+
+        private void ExcludeTestData(AzureSearchTextBuilder builder)
+        {
+            if (_options.Value.TestOwners != null)
+            {
+                foreach (var owner in _options.Value.TestOwners)
+                {
+                    builder.AppendScopedTerm(
+                        IndexFields.Search.Owners,
+                        owner,
+                        prefix: TermPrefix.Not);
+                }
+            }
+        }
+
+        private SearchText GetMatchAllDocuments(bool includeTestData)
+        {
+            if (includeTestData
+                || _options.Value.TestOwners == null
+                || _options.Value.TestOwners.Count == 0)
+            {
+                return MatchAllDocumentsIncludingTestData;
+            }
+
+            var builder = new AzureSearchTextBuilder();
+
+            // We can't use '*' to match all documents here since it doesn't work in conjunction with anyy other terms.
+            // Instead, we match all documents by finding every doument that has a package ID (which is all documents).
+            builder.AppendVerbatim($"{IndexFields.PackageId}:/.*/");
+
+            foreach (var owner in _options.Value.TestOwners)
+            {
+                builder.AppendScopedTerm(IndexFields.Search.Owners, owner, prefix: TermPrefix.Not);
+            }
+
+            return new SearchText(builder.ToString(), isDefaultSearch: true);
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchTextBuilder.cs
@@ -327,10 +327,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 foreach (var owner in _options.Value.TestOwners)
                 {
-                    builder.AppendScopedTerm(
-                        IndexFields.Search.Owners,
-                        owner,
-                        prefix: TermPrefix.Not);
+                    builder.AppendScopedTerm(IndexFields.Search.Owners, owner, prefix: TermPrefix.Not);
                 }
             }
         }
@@ -346,14 +343,11 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             var builder = new AzureSearchTextBuilder();
 
-            // We can't use '*' to match all documents here since it doesn't work in conjunction with anyy other terms.
+            // We can't use '*' to match all documents here since it doesn't work in conjunction with any other terms.
             // Instead, we match all documents by finding every doument that has a package ID (which is all documents).
             builder.AppendVerbatim($"{IndexFields.PackageId}:/.*/");
 
-            foreach (var owner in _options.Value.TestOwners)
-            {
-                builder.AppendScopedTerm(IndexFields.Search.Owners, owner, prefix: TermPrefix.Not);
-            }
+            ExcludeTestData(builder);
 
             return new SearchText(builder.ToString(), isDefaultSearch: true);
         }

--- a/src/NuGet.Services.SearchService/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService/Controllers/SearchController.cs
@@ -85,6 +85,7 @@ namespace NuGet.Services.SearchService.Controllers
             string sortBy = null,
             bool? luceneQuery = true,
             string packageType = null,
+            bool? testData = false,
             bool? debug = false)
         {
             await EnsureInitializedAsync();
@@ -101,6 +102,7 @@ namespace NuGet.Services.SearchService.Controllers
                 SortBy = GetSortBy(sortBy),
                 LuceneQuery = luceneQuery ?? true,
                 PackageType = packageType,
+                IncludeTestData = testData ?? false,
                 ShowDebug = debug ?? false,
             };
 
@@ -115,6 +117,7 @@ namespace NuGet.Services.SearchService.Controllers
             string semVerLevel = null,
             string q = null,
             string packageType = null,
+            bool? testData = false,
             bool? debug = false)
         {
             await EnsureInitializedAsync();
@@ -127,6 +130,7 @@ namespace NuGet.Services.SearchService.Controllers
                 IncludeSemVer2 = GetIncludeSemVer2(semVerLevel),
                 Query = q,
                 PackageType = packageType,
+                IncludeTestData = testData ?? false,
                 ShowDebug = debug ?? false,
             };
 
@@ -142,6 +146,7 @@ namespace NuGet.Services.SearchService.Controllers
             string q = null,
             string id = null,
             string packageType = null,
+            bool? testData = false,
             bool? debug = false)
         {
             await EnsureInitializedAsync();
@@ -160,6 +165,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Query = q ?? id,
                 Type = type,
                 PackageType = packageType,
+                IncludeTestData = testData ?? false,
                 ShowDebug = debug ?? false,
             };
 

--- a/src/NuGet.Services.SearchService/README.md
+++ b/src/NuGet.Services.SearchService/README.md
@@ -185,7 +185,7 @@ The `packageType` parameter is a free form input. It defaults to an empty string
 
 Test data may be always returned (i.e. the `testData` parameter is ignored) for certain optimized queries. For example,
 performing a `packageid:BaseTestPackage` query with `testData=false` will still return a result because internally this
-query is implemented as a document lookup rather than a full Lucene search. Test data cannot be filtred out when
+query is implemented as a document lookup rather than a full Lucene search. Also, test data cannot be filtered out when
 `ignoreFilter=true` because the owners field is not populated in the hijack index.
 
 #### Response

--- a/src/NuGet.Services.SearchService/README.md
+++ b/src/NuGet.Services.SearchService/README.md
@@ -140,6 +140,7 @@ countOnly    | boolean | `true` to return only the total count and no metadata
 sortBy       | string  | Sort results using a specified ordering
 packageType  | string  | Filter results to those with the specified package type
 luceneQuery  | bool    | `true` to treat a `q` starting with `id:` like `packageid:` (yes, it's silly, see [#7366](https://github.com/NuGet/NuGetGallery/issues/7366))
+testData     | bool    | `true` to include packages owned by nuget.org test accounts
 debug        | bool    | `true` to shows the raw Azure Search document and other diagnostic information
 
 If no `q` is provided, all packages should be returned, within the boundaries imposed by skip and take.
@@ -181,6 +182,11 @@ For `title-asc` and `title-desc`, a package's ID is used if the package has no e
 `title` is no longer prominently shown in NuGet experiences, this sorting order is only maintained for legacy reasons.
 
 The `packageType` parameter is a free form input. It defaults to an empty string, which means no filter. If there are no packages with the specified packageType in a request, an empty `data` array will be returned.
+
+Test data may be always returned (i.e. the `testData` parameter is ignored) for certain optimized queries. For example,
+performing a `packageid:BaseTestPackage` query with `testData=false` will still return a result because internally this
+query is implemented as a document lookup rather than a full Lucene search. Test data cannot be filtred out when
+`ignoreFilter=true` because the owners field is not populated in the hijack index.
 
 #### Response
 

--- a/tests/BasicSearchTests.FunctionalTests.Core/Models/AutocompleteResult.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Models/AutocompleteResult.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace BasicSearchTests.FunctionalTests.Core.Models
 {

--- a/tests/BasicSearchTests.FunctionalTests.Core/Models/V2SearchResult.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Models/V2SearchResult.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace BasicSearchTests.FunctionalTests.Core.Models

--- a/tests/BasicSearchTests.FunctionalTests.Core/Models/V3SearchResult.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Models/V3SearchResult.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/tests/BasicSearchTests.FunctionalTests.Core/Properties/AssemblyInfo.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/AutocompleteBuilder.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/AutocompleteBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Specialized;
-using System.Web;
 
 namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 {
@@ -20,9 +19,7 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 
         protected override NameValueCollection GetQueryString()
         {
-            var queryString = HttpUtility.ParseQueryString(string.Empty);
-            queryString["q"] = Query;
-            queryString["prerelease"] = Prerelease.ToString();
+            var queryString = base.GetQueryString();
 
             if (Skip.HasValue)
             {

--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/QueryBuilder.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/QueryBuilder.cs
@@ -12,6 +12,7 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 
         public string Query { get; set; }
         public bool Prerelease { get; set; }
+        public bool IncludeTestData { get; set; } = true;
 
         public QueryBuilder(string endpoint)
         {
@@ -23,6 +24,12 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
             var queryString = System.Web.HttpUtility.ParseQueryString(string.Empty);
             queryString["q"] = Query;
             queryString["prerelease"] = Prerelease.ToString();
+            
+            if (IncludeTestData)
+            {
+                queryString["testData"] = "true";
+            }
+
             return queryString;
         }
 

--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V2SearchBuilder.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V2SearchBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Specialized;
-using System.Web;
 
 namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 {
@@ -28,9 +27,8 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 
         protected override NameValueCollection GetQueryString()
         {
-            var queryString = HttpUtility.ParseQueryString(string.Empty);
-            queryString["q"] = Query;
-            queryString["prerelease"] = Prerelease.ToString();
+            var queryString = base.GetQueryString();
+
             queryString["ignoreFilter"] = IgnoreFilter.ToString();
             queryString["CountOnly"] = CountOnly.ToString();
 

--- a/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V3SearchBuilder.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/TestSupport/V3SearchBuilder.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Specialized;
-using System.Web;
 
 namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 {
@@ -20,9 +19,7 @@ namespace BasicSearchTests.FunctionalTests.Core.TestSupport
 
         protected override NameValueCollection GetQueryString()
         {
-            var queryString = HttpUtility.ParseQueryString(string.Empty);
-            queryString["q"] = Query;
-            queryString["prerelease"] = Prerelease.ToString();
+            var queryString = base.GetQueryString();
 
             if (Skip.HasValue)
             {

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
@@ -514,11 +514,11 @@ namespace NuGet.Services.AzureSearch.SearchService
                 V3SearchRequest = new V3SearchRequest { Skip = 0, Take = 20 };
                 Text = "";
                 Parameters = new SearchParameters();
-                ParsedQuery = new ParsedQuery(new Dictionary<QueryField, HashSet<string>>());
+                ParsedQuery = new ParsedQuery(new Dictionary<QueryField, HashSet<string>>(), includeTestData: false);
 
                 TextBuilder
                     .Setup(x => x.Autocomplete(It.IsAny<AutocompleteRequest>()))
-                    .Returns(() => Text);
+                    .Returns(() => new SearchText(Text, isDefaultSearch: false));
                 TextBuilder
                     .Setup(x => x.ParseV2Search(It.IsAny<V2SearchRequest>()))
                     .Returns(() => ParsedQuery);
@@ -527,7 +527,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     .Returns(() => ParsedQuery);
                 TextBuilder
                     .Setup(x => x.Build(It.IsAny<ParsedQuery>()))
-                    .Returns(() => Text);
+                    .Returns(() => new SearchText(Text, isDefaultSearch: false));
                 ParametersBuilder
                     .Setup(x => x.Autocomplete(It.IsAny<AutocompleteRequest>(), It.IsAny<bool>()))
                     .Returns(() => Parameters);

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -149,6 +149,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexName"": ""hijack-index"",
@@ -491,6 +492,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
@@ -787,6 +789,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
@@ -967,6 +970,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
@@ -1131,6 +1135,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexName"": ""search-index"",
@@ -1251,6 +1256,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexOperationType"": ""Empty""
@@ -1291,6 +1297,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexOperationType"": ""Empty""
@@ -1331,6 +1338,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""Take"": 0,
     ""IncludePrerelease"": true,
     ""IncludeSemVer2"": true,
+    ""IncludeTestData"": true,
     ""ShowDebug"": true
   },
   ""IndexOperationType"": ""Empty""
@@ -1420,16 +1428,19 @@ namespace NuGet.Services.AzureSearch.SearchService
                 {
                     IncludePrerelease = true,
                     IncludeSemVer2 = true,
+                    IncludeTestData = true,
                 };
                 _v3Request = new V3SearchRequest
                 {
                     IncludePrerelease = true,
-                    IncludeSemVer2 = true
+                    IncludeSemVer2 = true,
+                    IncludeTestData = true,
                 };
                 _autocompleteRequest = new AutocompleteRequest
                 {
                     IncludePrerelease = true,
                     IncludeSemVer2 = true,
+                    IncludeTestData = true,
                 };
                 _searchParameters = new SearchParameters();
                 _text = "azure storage sdk";

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Net;
 using Microsoft.Azure.Search.Models;
 using Microsoft.Extensions.Options;
 using Moq;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Data.Entity.Infrastructure;
 using System.Linq;
 using Microsoft.Extensions.Options;
 using Moq;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Data.Entity.Infrastructure;
 using System.Linq;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -21,7 +22,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var actual = _target.Build(parsed);
 
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, actual.Value);
             }
 
             [Theory]
@@ -37,7 +38,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var actual = _target.Build(parsed);
 
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, actual.Value);
             }
 
             [Theory]
@@ -69,6 +70,31 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 Assert.Equal("Query terms cannot exceed 32768 bytes.", e.Message);
             }
+
+            [Theory]
+            [InlineData("foo", false, false, "foo tokenizedPackageId:foo*^20 -owners:TestUserA -owners:TestUserB")]
+            [InlineData("", false, false, "packageId:/.*/ -owners:TestUserA -owners:TestUserB")]
+            [InlineData("foo", true, false, "foo tokenizedPackageId:foo*^20")]
+            [InlineData("", true, false, "*")]
+            [InlineData("foo", false, true, "foo tokenizedPackageId:foo*^20")]
+            [InlineData("", false, true, "*")]
+            [InlineData("foo", true, true, "foo tokenizedPackageId:foo*^20")]
+            [InlineData("", true, true, "*")]
+            public void CanExcludeTestData(string query, bool ignoreFilter, bool includeTestData, string expected)
+            {
+                _config.TestOwners = new List<string> { "TestUserA", "TestUserB" };
+                var request = new V2SearchRequest
+                {
+                    Query = query,
+                    IgnoreFilter = ignoreFilter,
+                    IncludeTestData = includeTestData,
+                };
+                var parsed = _target.ParseV2Search(request);
+
+                var actual = _target.Build(parsed);
+
+                Assert.Equal(expected, actual.Value);
+            }
         }
 
         public class V3Search : FactsBase
@@ -81,7 +107,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var actual = _target.Build(parsed);
 
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, actual.Value);
             }
 
             [Theory]
@@ -113,6 +139,26 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 Assert.Equal("Query terms cannot exceed 32768 bytes.", e.Message);
             }
+
+            [Theory]
+            [InlineData("foo", false, "foo tokenizedPackageId:foo*^20 -owners:TestUserA -owners:TestUserB")]
+            [InlineData("", false, "packageId:/.*/ -owners:TestUserA -owners:TestUserB")]
+            [InlineData("foo", true, "foo tokenizedPackageId:foo*^20")]
+            [InlineData("", true, "*")]
+            public void CanExcludeTestData(string query, bool includeTestData, string expected)
+            {
+                _config.TestOwners = new List<string> { "TestUserA", "TestUserB" };
+                var request = new V3SearchRequest
+                {
+                    Query = query,
+                    IncludeTestData = includeTestData,
+                };
+                var parsed = _target.ParseV3Search(request);
+
+                var actual = _target.Build(parsed);
+
+                Assert.Equal(expected, actual.Value);
+            }
         }
 
         public class Autocomplete : FactsBase
@@ -125,7 +171,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             [InlineData("Hello world ", "packageId:Hello\\ world* +tokenizedPackageId:Hello\\ world*")]
             [InlineData("Hello.world", "packageId:Hello.world* +tokenizedPackageId:Hello* +tokenizedPackageId:world* packageId:Hello.world^1000")]
             [InlineData("Foo.BarBaz", "packageId:Foo.BarBaz* +tokenizedPackageId:Foo* +tokenizedPackageId:BarBaz* packageId:Foo.BarBaz^1000")]
-            public void PackageIdAutocomplete(string input, string expected)
+            public void PackageIdsAutocomplete(string input, string expected)
             {
                 var request = new AutocompleteRequest
                 {
@@ -135,7 +181,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var actual = _target.Autocomplete(request);
 
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, actual.Value);
             }
 
             [Theory]
@@ -151,19 +197,58 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 var actual = _target.Autocomplete(request);
 
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, actual.Value);
+            }
+
+            [Theory]
+            [InlineData("Test", false, "packageId:Test* +tokenizedPackageId:Test* packageId:Test^1000 -owners:TestUserA -owners:TestUserB")]
+            [InlineData("", false, "packageId:/.*/ -owners:TestUserA -owners:TestUserB")]
+            [InlineData("Test", true, "packageId:Test* +tokenizedPackageId:Test* packageId:Test^1000")]
+            [InlineData("", true, "*")]
+            public void PackageIdsCanExcludeTestData(string query, bool includeTestData, string expected)
+            {
+                _config.TestOwners = new List<string> { "TestUserA", "TestUserB" };
+                var request = new AutocompleteRequest
+                {
+                    Query = query,
+                    Type = AutocompleteRequestType.PackageIds,
+                    IncludeTestData = includeTestData,
+                };
+
+                var actual = _target.Autocomplete(request);
+
+                Assert.Equal(expected, actual.Value);
+            }
+
+            [Theory]
+            [InlineData("Test", false, "packageId:Test -owners:TestUserA -owners:TestUserB")]
+            [InlineData("Test", true, "packageId:Test")]
+            public void PackageVersionsCanExcludeTestData(string query, bool includeTestData, string expected)
+            {
+                _config.TestOwners = new List<string> { "TestUserA", "TestUserB" };
+                var request = new AutocompleteRequest
+                {
+                    Query = query,
+                    Type = AutocompleteRequestType.PackageVersions,
+                    IncludeTestData = includeTestData,
+                };
+
+                var actual = _target.Autocomplete(request);
+
+                Assert.Equal(expected, actual.Value);
             }
         }
 
         public class FactsBase
         {
             protected readonly SearchTextBuilder _target;
+            protected readonly SearchServiceConfiguration _config;
 
             public FactsBase()
             {
-                var config = new SearchServiceConfiguration { MatchAllTermsBoost = 2.0f };
+                _config = new SearchServiceConfiguration { MatchAllTermsBoost = 2.0f };
                 var options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
-                options.Setup(o => o.Value).Returns(config);
+                options.Setup(o => o.Value).Returns(_config);
 
                 _target = new SearchTextBuilder(options.Object);
             }

--- a/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
+++ b/tests/NuGet.Services.SearchService.Tests/Controllers/SearchControllerFacts.cs
@@ -149,6 +149,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.False(lastRequest.CountOnly);
                 Assert.False(lastRequest.IncludePrerelease);
                 Assert.False(lastRequest.IncludeSemVer2);
+                Assert.False(lastRequest.IncludeTestData);
                 Assert.Null(lastRequest.Query);
                 Assert.True(lastRequest.LuceneQuery);
                 Assert.False(lastRequest.ShowDebug);
@@ -300,6 +301,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.Equal(20, lastRequest.Take);
                 Assert.False(lastRequest.IncludePrerelease);
                 Assert.False(lastRequest.IncludeSemVer2);
+                Assert.False(lastRequest.IncludeTestData);
                 Assert.Null(lastRequest.Query);
                 Assert.Null(lastRequest.PackageType);
                 Assert.False(lastRequest.ShowDebug);
@@ -402,6 +404,7 @@ namespace NuGet.Services.SearchService.Controllers
                 Assert.Equal(20, lastRequest.Take);
                 Assert.False(lastRequest.IncludePrerelease);
                 Assert.False(lastRequest.IncludeSemVer2);
+                Assert.False(lastRequest.IncludeTestData);
                 Assert.Null(lastRequest.Query);
                 Assert.False(lastRequest.ShowDebug);
                 Assert.Null(lastRequest.PackageType);


### PR DESCRIPTION
Address https://github.com/NuGet/NuGetGallery/issues/8172

Add a `testData` parameter to allow test data to be filtered in and out. Test code that needs to see test packages will pass `testData=true`. This parameter is off by default so that our users don't see pointless test packages.

Introduced a `SearchText` type which has a `IsDefaultSearch` property. This is necessary since it is no longer possible to determine whether a query is a default (empty) search by checking if the Lucene query is `*`. This check is needed by the code that builds the Azure Search `$filter` to filter out framework-like packages that we don't want on the default search results, via the `IsExcludedByDefault` field.

Enhanced `SearchTextBuilder` to allow adding excluded (NOT) terms. This is used for to exclude packages with certain owners, e.g. `foo -owners:NugetTestAccount`.

 