### PR TITLE
Migrate nuget-build feed from myget to Azure DevOps

### DIFF
--- a/.nuget/NuGet.config
+++ b/.nuget/NuGet.config
@@ -5,9 +5,8 @@
   </activePackageSource>
   <packageSources>
     <clear />
-    <add key="nugetbuild" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet.core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
For: NuGet/Engineering#2909

~`build.cmd` had several errors, but none related to restore, so maybe the script has machine state requirements.~

Removing the `dotnet-core` didn't have any restore errors, so I removed it, rather than replaced it.