### PR TITLE
Promote "camel-join" A/B test to dev

### DIFF
--- a/src/NuGet.Services.AzureSearch/Analysis/DescriptionCustomAnalyzer.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/DescriptionCustomAnalyzer.cs
@@ -21,8 +21,8 @@ namespace NuGet.Services.AzureSearch
             new List<TokenFilterName>
             {
                 IdentifierCustomTokenFilter.Name,
-                TokenFilterName.Stopwords,
                 TokenFilterName.Lowercase,
+                TokenFilterName.Stopwords,
                 TruncateCustomTokenFilter.Name,
             });
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -8,8 +8,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 {
     public class SearchServiceConfiguration : AzureSearchConfiguration
     {
-        public float MatchAllTermsBoost { get; set; } = 3;
-        public float PrefixMatchBoost { get; set; } = 20;
+        public float NamespaceBoost { get; set; } = 100;
+        public float SeparatorSplitBoost { get; set; } = 2;
         public float ExactMatchBoost { get; set; } = 1000;
         public string SemVer1RegistrationsBaseUrl { get; set; }
         public string SemVer2RegistrationsBaseUrl { get; set; }

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Analysis/TagsCustomAnalyzerFunctionalTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Analysis/TagsCustomAnalyzerFunctionalTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/AutocompleteProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/AutocompleteProtocolTests.cs
@@ -40,9 +40,9 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         }
 
         [Theory]
-        [InlineData("DOTnettOoL", "DotnetTool", Constants.TestPackageId_PackageType)]
-        [InlineData("depenDENCY", "Dependency", Constants.TestPackageId)]
-        public async Task TreatsPackageTypeAsCaseInsensitive(string packageTypeQuery, string expected, string id)
+        [InlineData("DOTnettOoL", Constants.TestPackageId_PackageType)]
+        [InlineData("depenDENCY", Constants.TestPackageId)]
+        public async Task TreatsPackageTypeAsCaseInsensitive(string packageTypeQuery, string id)
         {
             var searchBuilder = new AutocompleteBuilder
             {

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V2SearchProtocolTests.cs
@@ -291,9 +291,9 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         }
 
         [Theory]
-        [InlineData("DOTnettOoL", "DotnetTool", Constants.TestPackageId_PackageType)]
-        [InlineData("depenDENCY", "Dependency", Constants.TestPackageId)]
-        public async Task TreatsPackageTypeAsCaseInsensitive(string packageTypeQuery, string expected, string id)
+        [InlineData("DOTnettOoL", Constants.TestPackageId_PackageType)]
+        [InlineData("depenDENCY", Constants.TestPackageId)]
+        public async Task TreatsPackageTypeAsCaseInsensitive(string packageTypeQuery, string id)
         {
             var searchBuilder = new V2SearchBuilder
             {

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Relevancy/V3RelevancyFunctionalTests.cs
@@ -77,7 +77,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
         [MemberData(nameof(EnsureTopResultsData))]
         public async Task EnsureTopResults(string searchTerm, string[] expectedTopResults)
         {
-            var results = await SearchAsync(searchTerm, take: 10);
+            var results = await SearchAsync(searchTerm, take: 20);
 
             Assert.True(results.Count > expectedTopResults.Length);
 

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/Support/TokenizationData.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/Support/TokenizationData.cs
@@ -94,7 +94,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
             { "foo2bar", new[] { "foo2bar", "foo", "2", "bar" } },
             { "HTML", new[] { "html"} },
             { "HTMLThing", new[] { "htmlthing" } },
-            { "HTMLThingA", new[] { "htmlthinga", "htmlthing", "a" } },
+            { "HTMLThingA", new[] { "htmlthinga", "htmlthing" } },
             { "HelloWorld𠈓Foo", new[] { "helloworld𠈓foo", "hello", "world𠈓foo" } },
         });
 
@@ -114,6 +114,13 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
                 new[]
                 {
                     "once", "upon", "time", "little", "test", "case"
+                }
+            },
+            {
+                "ONCE UPON A TIME, THERE WAS A YELLING TEST-CASE!",
+                new[]
+                {
+                    "once", "upon", "time", "yelling", "test", "case"
                 }
             }
         });

--- a/tests/Scripts/RunAzureSearchFunctionalTests.bat
+++ b/tests/Scripts/RunAzureSearchFunctionalTests.bat
@@ -9,7 +9,7 @@ set solutionPath="NuGetServicesMetadata.FunctionalTests.sln"
 set exitCode=0
 
 REM Required Tools
-set msbuild="%PROGRAMFILES(X86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild"
+set msbuild="%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild"
 set xunit="..\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe"
 set nuget="nuget.exe"
 


### PR DESCRIPTION
The A/B test has indicated a strong improvement for nuget.org traffic.

**A/B test start time:** 2020-10-28T23:30:00Z
**A/B test results query time:** 2020-11-09T23:30:00Z (12 full days)

KPI | Control | Treatment | Delta
--- | --- | --- | ---
Avg. click index on first page | 1.592 | 1.367 | ✔ -0.225
Bounce % | 31.117% | 31.376% | ⚠   +0.259
Clicks on first page % | 96.152% | 97.026% | ✔ +0.874

The improvement on the click index on the first page is significant. As you may recall, we mitigated the outlier affect in the average click index metric by scoping it to values on the first page (integers from 0 to 19). The improvement of clicks on the first page is respectable. The increase (bad) in bounce rate is small but it jumped around quite a bit during the course of the test (sometimes worse, sometime better than the control) so I’m not worried. Overall, this change indicates a solid improvement in customer experience when searching for packages on nuget.org.

The original PR for the A/B test is here: https://github.com/NuGet/NuGet.Jobs/pull/925

This merge will allow us to take the change to our primary search services, enabling the new behavior for Visual Studio searches.
