### PR TITLE
Cross-target Azure Search dependencies to .NET Core

### DIFF
--- a/src/Catalog/CollectorHttpClient.cs
+++ b/src/Catalog/CollectorHttpClient.cs
@@ -8,7 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+#if NETFRAMEWORK
 using VDS.RDF;
+#endif
 
 namespace NuGet.Services.Metadata.Catalog
 {
@@ -17,6 +19,7 @@ namespace NuGet.Services.Metadata.Catalog
         private int _requestCount;
         private readonly IHttpRetryStrategy _retryStrategy;
 
+#if NETFRAMEWORK
         public CollectorHttpClient()
             : this(new WebRequestHandler { AllowPipelining = true })
         {
@@ -28,6 +31,19 @@ namespace NuGet.Services.Metadata.Catalog
             _requestCount = 0;
             _retryStrategy = retryStrategy ?? new RetryWithExponentialBackoff();
         }
+#else
+        public CollectorHttpClient()
+            : this(new HttpClientHandler())
+        {
+        }
+
+        public CollectorHttpClient(HttpMessageHandler handler, IHttpRetryStrategy retryStrategy = null)
+            : base(handler ?? new HttpClientHandler())
+        {
+            _requestCount = 0;
+            _retryStrategy = retryStrategy ?? new RetryWithExponentialBackoff();
+        }
+#endif
 
         public int RequestCount
         {
@@ -70,6 +86,7 @@ namespace NuGet.Services.Metadata.Catalog
             }
         }
 
+#if NETFRAMEWORK
         public virtual Task<IGraph> GetGraphAsync(Uri address)
         {
             return GetGraphAsync(address, readOnly: false, token: CancellationToken.None);
@@ -91,6 +108,7 @@ namespace NuGet.Services.Metadata.Catalog
                 }
             }, token);
         }
+#endif
 
         public virtual async Task<string> GetStringAsync(Uri address, CancellationToken token)
         {

--- a/src/Catalog/CollectorHttpClient.cs
+++ b/src/Catalog/CollectorHttpClient.cs
@@ -19,21 +19,8 @@ namespace NuGet.Services.Metadata.Catalog
         private int _requestCount;
         private readonly IHttpRetryStrategy _retryStrategy;
 
-#if NETFRAMEWORK
         public CollectorHttpClient()
-            : this(new WebRequestHandler { AllowPipelining = true })
-        {
-        }
-
-        public CollectorHttpClient(HttpMessageHandler handler, IHttpRetryStrategy retryStrategy = null)
-            : base(handler ?? new WebRequestHandler { AllowPipelining = true })
-        {
-            _requestCount = 0;
-            _retryStrategy = retryStrategy ?? new RetryWithExponentialBackoff();
-        }
-#else
-        public CollectorHttpClient()
-            : this(new HttpClientHandler())
+            : this(handler: null)
         {
         }
 
@@ -43,7 +30,6 @@ namespace NuGet.Services.Metadata.Catalog
             _requestCount = 0;
             _retryStrategy = retryStrategy ?? new RetryWithExponentialBackoff();
         }
-#endif
 
         public int RequestCount
         {

--- a/src/Catalog/Helpers/FeedHelpers.cs
+++ b/src/Catalog/Helpers/FeedHelpers.cs
@@ -16,7 +16,11 @@ namespace NuGet.Services.Metadata.Catalog.Helpers
         /// </summary>
         public static HttpClient CreateHttpClient(Func<HttpMessageHandler> handlerFunc)
         {
+#if NETFRAMEWORK
             var handler = (handlerFunc != null) ? handlerFunc() : new WebRequestHandler { AllowPipelining = true };
+#else
+            var handler = (handlerFunc != null) ? handlerFunc() : new HttpClientHandler();
+#endif
             return new HttpClient(handler);
         }
     }

--- a/src/Catalog/Helpers/FeedHelpers.cs
+++ b/src/Catalog/Helpers/FeedHelpers.cs
@@ -16,11 +16,7 @@ namespace NuGet.Services.Metadata.Catalog.Helpers
         /// </summary>
         public static HttpClient CreateHttpClient(Func<HttpMessageHandler> handlerFunc)
         {
-#if NETFRAMEWORK
-            var handler = (handlerFunc != null) ? handlerFunc() : new WebRequestHandler { AllowPipelining = true };
-#else
             var handler = (handlerFunc != null) ? handlerFunc() : new HttpClientHandler();
-#endif
             return new HttpClient(handler);
         }
     }

--- a/src/Catalog/Helpers/Utils.cs
+++ b/src/Catalog/Helpers/Utils.cs
@@ -14,13 +14,15 @@ using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Xsl;
-using JsonLD.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Services.Metadata.Catalog.Helpers;
+#if NETFRAMEWORK
+using JsonLD.Core;
 using NuGet.Services.Metadata.Catalog.JsonLDIntegration;
 using VDS.RDF;
 using VDS.RDF.Parsing;
+#endif
 
 namespace NuGet.Services.Metadata.Catalog
 {
@@ -59,6 +61,7 @@ namespace NuGet.Services.Metadata.Catalog
             return assembly.GetManifestResourceStream($"{name}.{resourceName}");
         }
 
+#if NETFRAMEWORK
         public static IGraph CreateNuspecGraph(XDocument nuspec, string baseAddress, bool normalizeXml = false)
         {
             XsltArgumentList arguments = new XsltArgumentList();
@@ -82,6 +85,7 @@ namespace NuGet.Services.Metadata.Catalog
 
             return graph;
         }
+#endif
 
         private static void NormalizeXml(XmlNode xmlNode)
         {
@@ -165,6 +169,7 @@ namespace NuGet.Services.Metadata.Catalog
             return null;
         }
 
+#if NETFRAMEWORK
         public static JToken CreateJson(IGraph graph, JToken frame = null)
         {
             System.IO.StringWriter writer = new System.IO.StringWriter();
@@ -267,6 +272,7 @@ namespace NuGet.Services.Metadata.Catalog
                 }
             }
         }
+#endif
 
         public static Uri Expand(JToken context, string term)
         {
@@ -285,6 +291,7 @@ namespace NuGet.Services.Metadata.Catalog
             return new Uri(context["@vocab"] + term);
         }
 
+#if NETFRAMEWORK
         //  where the property exists on the graph being merged in remove it from the existing graph
         public static void RemoveExistingProperties(IGraph existingGraph, IGraph graphToMerge, Uri[] properties)
         {
@@ -303,6 +310,7 @@ namespace NuGet.Services.Metadata.Catalog
                 }
             }
         }
+#endif
 
         public static string GenerateHash(Stream stream)
         {
@@ -369,6 +377,7 @@ namespace NuGet.Services.Metadata.Catalog
             }
         }
 
+#if NETFRAMEWORK
         public static PackageCatalogItem CreateCatalogItem(
             string origin,
             Stream stream,
@@ -402,6 +411,7 @@ namespace NuGet.Services.Metadata.Catalog
                 throw new Exception(string.Format("Exception processsing {0}", origin), e);
             }
         }
+#endif
 
         public static void TraceException(Exception e)
         {

--- a/src/Catalog/Helpers/Utils.cs
+++ b/src/Catalog/Helpers/Utils.cs
@@ -61,32 +61,6 @@ namespace NuGet.Services.Metadata.Catalog
             return assembly.GetManifestResourceStream($"{name}.{resourceName}");
         }
 
-#if NETFRAMEWORK
-        public static IGraph CreateNuspecGraph(XDocument nuspec, string baseAddress, bool normalizeXml = false)
-        {
-            XsltArgumentList arguments = new XsltArgumentList();
-            arguments.AddParam("base", "", baseAddress);
-            arguments.AddParam("extension", "", ".json");
-
-            arguments.AddExtensionObject("urn:helper", new XsltHelper());
-
-            nuspec = SafeXmlTransform(nuspec.CreateReader(), XslTransformNormalizeNuSpecNamespaceCache.Value);
-            var rdfxml = SafeXmlTransform(nuspec.CreateReader(), XslTransformNuSpecCache.Value, arguments);
-
-            var doc = SafeCreateXmlDocument(rdfxml.CreateReader());
-            if (normalizeXml)
-            {
-                NormalizeXml(doc);
-            }
-
-            RdfXmlParser rdfXmlParser = new RdfXmlParser();
-            IGraph graph = new Graph();
-            rdfXmlParser.Load(graph, doc);
-
-            return graph;
-        }
-#endif
-
         private static void NormalizeXml(XmlNode xmlNode)
         {
             if (xmlNode.Attributes != null)
@@ -123,22 +97,6 @@ namespace NuGet.Services.Metadata.Catalog
             return xmlDoc;
         }
 
-        private static XDocument SafeXmlTransform(XmlReader reader, XslCompiledTransform transform, XsltArgumentList arguments = null)
-        {
-            XDocument result = new XDocument();
-            using (XmlWriter writer = result.CreateWriter())
-            {
-                if (arguments == null)
-                {
-                    arguments = new XsltArgumentList();
-                }
-
-                // CodeAnalysis / XslCompiledTransform.Transform: set resolver property to null or instance
-                transform.Transform(reader, arguments, writer, documentResolver: null);
-            }
-            return result;
-        }
-
         private static XslCompiledTransform SafeLoadXslTransform(string resourceName)
         {
             var transform = new XslCompiledTransform();
@@ -169,7 +127,154 @@ namespace NuGet.Services.Metadata.Catalog
             return null;
         }
 
+        public static Uri Expand(JToken context, string term)
+        {
+            if (term.StartsWith("http:", StringComparison.OrdinalIgnoreCase))
+            {
+                return new Uri(term);
+            }
+
+            int indexOf = term.IndexOf(':');
+            if (indexOf > 0)
+            {
+                string ns = term.Substring(0, indexOf);
+                return new Uri(context[ns].ToString() + term.Substring(indexOf + 1));
+            }
+
+            return new Uri(context["@vocab"] + term);
+        }
+
+        public static string GenerateHash(Stream stream)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using (var hashAlgorithm = HashAlgorithm.Create(Constants.Sha512))
+            {
+                return Convert.ToBase64String(hashAlgorithm.ComputeHash(stream));
+            }
+        }
+
+        public static IEnumerable<PackageEntry> GetEntries(ZipArchive package)
+        {
+            IList<PackageEntry> result = new List<PackageEntry>();
+
+            foreach (ZipArchiveEntry entry in package.Entries)
+            {
+                if (entry.FullName.EndsWith("/.rels", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (entry.FullName.EndsWith("[Content_Types].xml", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (entry.FullName.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                result.Add(new PackageEntry(entry));
+            }
+
+            return result;
+        }
+
+        public static NupkgMetadata GetNupkgMetadata(Stream stream, string packageHash)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            var packageSize = stream.Length;
+
+            packageHash = packageHash ?? GenerateHash(stream);
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using (var package = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
+            {
+                var nuspec = GetNuspec(package);
+
+                if (nuspec == null)
+                {
+                    throw new InvalidDataException("Unable to find nuspec");
+                }
+
+                var entries = GetEntries(package);
+
+                return new NupkgMetadata(nuspec, entries, packageSize, packageHash);
+            }
+        }
+
+        public static void TraceException(Exception e)
+        {
+            if (e is AggregateException)
+            {
+                foreach (Exception ex in ((AggregateException)e).InnerExceptions)
+                {
+                    TraceException(ex);
+                }
+            }
+            else
+            {
+                Trace.TraceError("{0} {1}", e.GetType().Name, e.Message);
+                Trace.TraceError("{0}", e.StackTrace);
+
+                if (e.InnerException != null)
+                {
+                    TraceException(e.InnerException);
+                }
+            }
+        }
+
+        internal static T Deserialize<T>(JObject jObject, string propertyName)
+        {
+            if (jObject == null)
+            {
+                throw new ArgumentNullException(nameof(jObject));
+            }
+
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                throw new ArgumentException(Strings.ArgumentMustNotBeNullOrEmpty, nameof(propertyName));
+            }
+
+            if (!jObject.TryGetValue(propertyName, out var value) || value == null)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Strings.PropertyRequired, propertyName));
+            }
+
+            return value.ToObject<T>();
+        }
+
 #if NETFRAMEWORK
+        public static IGraph CreateNuspecGraph(XDocument nuspec, string baseAddress, bool normalizeXml = false)
+        {
+            XsltArgumentList arguments = new XsltArgumentList();
+            arguments.AddParam("base", "", baseAddress);
+            arguments.AddParam("extension", "", ".json");
+
+            arguments.AddExtensionObject("urn:helper", new XsltHelper());
+
+            nuspec = SafeXmlTransform(nuspec.CreateReader(), XslTransformNormalizeNuSpecNamespaceCache.Value);
+            var rdfxml = SafeXmlTransform(nuspec.CreateReader(), XslTransformNuSpecCache.Value, arguments);
+
+            var doc = SafeCreateXmlDocument(rdfxml.CreateReader());
+            if (normalizeXml)
+            {
+                NormalizeXml(doc);
+            }
+
+            RdfXmlParser rdfXmlParser = new RdfXmlParser();
+            IGraph graph = new Graph();
+            rdfXmlParser.Load(graph, doc);
+
+            return graph;
+        }
+
         public static JToken CreateJson(IGraph graph, JToken frame = null)
         {
             System.IO.StringWriter writer = new System.IO.StringWriter();
@@ -272,26 +377,7 @@ namespace NuGet.Services.Metadata.Catalog
                 }
             }
         }
-#endif
 
-        public static Uri Expand(JToken context, string term)
-        {
-            if (term.StartsWith("http:", StringComparison.OrdinalIgnoreCase))
-            {
-                return new Uri(term);
-            }
-
-            int indexOf = term.IndexOf(':');
-            if (indexOf > 0)
-            {
-                string ns = term.Substring(0, indexOf);
-                return new Uri(context[ns].ToString() + term.Substring(indexOf + 1));
-            }
-
-            return new Uri(context["@vocab"] + term);
-        }
-
-#if NETFRAMEWORK
         //  where the property exists on the graph being merged in remove it from the existing graph
         public static void RemoveExistingProperties(IGraph existingGraph, IGraph graphToMerge, Uri[] properties)
         {
@@ -310,74 +396,7 @@ namespace NuGet.Services.Metadata.Catalog
                 }
             }
         }
-#endif
 
-        public static string GenerateHash(Stream stream)
-        {
-            stream.Seek(0, SeekOrigin.Begin);
-
-            using (var hashAlgorithm = HashAlgorithm.Create(Constants.Sha512))
-            {
-                return Convert.ToBase64String(hashAlgorithm.ComputeHash(stream));
-            }
-        }
-
-        public static IEnumerable<PackageEntry> GetEntries(ZipArchive package)
-        {
-            IList<PackageEntry> result = new List<PackageEntry>();
-
-            foreach (ZipArchiveEntry entry in package.Entries)
-            {
-                if (entry.FullName.EndsWith("/.rels", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                if (entry.FullName.EndsWith("[Content_Types].xml", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                if (entry.FullName.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-
-                result.Add(new PackageEntry(entry));
-            }
-
-            return result;
-        }
-
-        public static NupkgMetadata GetNupkgMetadata(Stream stream, string packageHash)
-        {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
-
-            var packageSize = stream.Length;
-
-            packageHash = packageHash ?? GenerateHash(stream);
-
-            stream.Seek(0, SeekOrigin.Begin);
-
-            using (var package = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true))
-            {
-                var nuspec = GetNuspec(package);
-
-                if (nuspec == null)
-                {
-                    throw new InvalidDataException("Unable to find nuspec");
-                }
-
-                var entries = GetEntries(package);
-
-                return new NupkgMetadata(nuspec, entries, packageSize, packageHash);
-            }
-        }
-
-#if NETFRAMEWORK
         public static PackageCatalogItem CreateCatalogItem(
             string origin,
             Stream stream,
@@ -411,47 +430,22 @@ namespace NuGet.Services.Metadata.Catalog
                 throw new Exception(string.Format("Exception processsing {0}", origin), e);
             }
         }
+
+        private static XDocument SafeXmlTransform(XmlReader reader, XslCompiledTransform transform, XsltArgumentList arguments = null)
+        {
+            XDocument result = new XDocument();
+            using (XmlWriter writer = result.CreateWriter())
+            {
+                if (arguments == null)
+                {
+                    arguments = new XsltArgumentList();
+                }
+
+                // CodeAnalysis / XslCompiledTransform.Transform: set resolver property to null or instance
+                transform.Transform(reader, arguments, writer, documentResolver: null);
+            }
+            return result;
+        }
 #endif
-
-        public static void TraceException(Exception e)
-        {
-            if (e is AggregateException)
-            {
-                foreach (Exception ex in ((AggregateException)e).InnerExceptions)
-                {
-                    TraceException(ex);
-                }
-            }
-            else
-            {
-                Trace.TraceError("{0} {1}", e.GetType().Name, e.Message);
-                Trace.TraceError("{0}", e.StackTrace);
-
-                if (e.InnerException != null)
-                {
-                    TraceException(e.InnerException);
-                }
-            }
-        }
-
-        internal static T Deserialize<T>(JObject jObject, string propertyName)
-        {
-            if (jObject == null)
-            {
-                throw new ArgumentNullException(nameof(jObject));
-            }
-
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentException(Strings.ArgumentMustNotBeNullOrEmpty, nameof(propertyName));
-            }
-
-            if (!jObject.TryGetValue(propertyName, out var value) || value == null)
-            {
-                throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, Strings.PropertyRequired, propertyName));
-            }
-
-            return value.ToObject<T>();
-        }
     }
 }

--- a/src/Catalog/HttpReadCursor.cs
+++ b/src/Catalog/HttpReadCursor.cs
@@ -37,7 +37,11 @@ namespace NuGet.Services.Metadata.Catalog
             await Retry.IncrementalAsync(
                 async () =>
                 {
+#if NETFRAMEWORK
                     HttpMessageHandler handler = (_handlerFunc != null) ? _handlerFunc() : new WebRequestHandler { AllowPipelining = true };
+#else
+                    HttpMessageHandler handler = (_handlerFunc != null) ? _handlerFunc() : new HttpClientHandler();
+#endif
 
                     using (HttpClient client = new HttpClient(handler))
                     using (HttpResponseMessage response = await client.GetAsync(_address, cancellationToken))

--- a/src/Catalog/HttpReadCursor.cs
+++ b/src/Catalog/HttpReadCursor.cs
@@ -37,11 +37,7 @@ namespace NuGet.Services.Metadata.Catalog
             await Retry.IncrementalAsync(
                 async () =>
                 {
-#if NETFRAMEWORK
-                    HttpMessageHandler handler = (_handlerFunc != null) ? _handlerFunc() : new WebRequestHandler { AllowPipelining = true };
-#else
                     HttpMessageHandler handler = (_handlerFunc != null) ? _handlerFunc() : new HttpClientHandler();
-#endif
 
                     using (HttpClient client = new HttpClient(handler))
                     using (HttpResponseMessage response = await client.GetAsync(_address, cancellationToken))

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -1,12 +1,32 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Description>Create, edit, or read the package metadata catalog.</Description>
     <PackageTags>nuget;services;search;catalog;metadata;collector</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <Compile Remove="AppendOnlyCatalogItem.cs" />
+    <Compile Remove="AppendOnlyCatalogWriter.cs" />
+    <Compile Remove="CatalogItem.cs" />
+    <Compile Remove="CatalogItemSummary.cs" />
+    <Compile Remove="CatalogWriterBase.cs" />
+    <Compile Remove="DeleteCatalogItem.cs" />
+    <Compile Remove="Helpers\CatalogWriterHelper.cs" />
+    <Compile Remove="ICatalogGraphPersistence.cs" />
+    <Compile Remove="IPackageCatalogItemCreator.cs" />
+    <Compile Remove="JsonLdIntegration\JsonLdReader.cs" />
+    <Compile Remove="JsonLdIntegration\JsonLdWriter.cs" />
+    <Compile Remove="PackageCatalog.cs" />
+    <Compile Remove="PackageCatalogItem.cs" />
+    <Compile Remove="PackageCatalogItemCreator.cs" />
+    <Compile Remove="Persistence\AzureStorage.cs" />
+    <Compile Remove="Persistence\AzureStorageFactory.cs" />
+    <Compile Remove="ReadOnlyGraph.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
@@ -40,29 +60,32 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="dotNetRDF">
-      <Version>1.0.8.3533</Version>
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement">
+      <Version>0.7.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Entities">
       <Version>4.4.5-dev-4220086</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.Sql">
+    <PackageReference Include="NuGet.Services.Logging">
       <Version>2.79.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.StrongName.json-ld.net">
-      <Version>1.0.6</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Azure.Storage.DataMovement">
-      <Version>0.7.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager">
-      <Version>3.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="NuGet.Services.Logging">
+    <PackageReference Include="NuGet.Services.Sql">
       <Version>2.79.0</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="dotNetRDF">
+      <Version>1.0.8.3533</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.StrongName.json-ld.net">
+      <Version>1.0.6</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager">
+      <Version>3.1.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Catalog/Persistence/AzureCloudBlockBlob.cs
+++ b/src/Catalog/Persistence/AzureCloudBlockBlob.cs
@@ -41,7 +41,11 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
         public async Task FetchAttributesAsync(CancellationToken cancellationToken)
         {
-            await _blob.FetchAttributesAsync(cancellationToken);
+            await _blob.FetchAttributesAsync(
+                accessCondition: null,
+                options: null,
+                operationContext: null,
+                cancellationToken: cancellationToken);
         }
 
         public async Task<IReadOnlyDictionary<string, string>> GetMetadataAsync(CancellationToken cancellationToken)
@@ -52,7 +56,11 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
         public async Task<Stream> GetStreamAsync(CancellationToken cancellationToken)
         {
-            return await _blob.OpenReadAsync(cancellationToken);
+            return await _blob.OpenReadAsync(
+                accessCondition: null,
+                options: null,
+                operationContext: null,
+                cancellationToken: cancellationToken);
         }
 
         public async Task SetPropertiesAsync(AccessCondition accessCondition, BlobRequestOptions options, OperationContext operationContext)

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -144,7 +144,11 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             string blobName = GetName(resourceUri);
             CloudBlockBlob blob = GetBlockBlobReference(blobName);
 
-            await blob.FetchAttributesAsync(cancellationToken);
+            await blob.FetchAttributesAsync(
+                accessCondition: null,
+                options: null,
+                operationContext: null,
+                cancellationToken: cancellationToken);
 
             return new OptimisticConcurrencyControlToken(blob.Properties.ETag);
         }
@@ -287,7 +291,12 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
             {
                 using (Stream stream = content.GetContentStream())
                 {
-                    await blob.UploadFromStreamAsync(stream, cancellationToken);
+                    await blob.UploadFromStreamAsync(
+                        stream,
+                        accessCondition: null,
+                        options: null,
+                        operationContext: null,
+                        cancellationToken: cancellationToken);
                 }
 
                 Trace.WriteLine(string.Format("Saved uncompressed blob {0} to container {1}", blob.Uri.ToString(), _directory.Container.Name));
@@ -351,7 +360,12 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
                 using (var originalStream = new MemoryStream())
                 {
-                    await blob.DownloadToStreamAsync(originalStream, cancellationToken);
+                    await blob.DownloadToStreamAsync(
+                        originalStream,
+                        accessCondition: null,
+                        options: null,
+                        operationContext: null,
+                        cancellationToken: cancellationToken);
 
                     originalStream.Seek(0, SeekOrigin.Begin);
 

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -3,10 +3,14 @@
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework> 
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <RootNamespace>NuGet.Jobs</RootNamespace>
     <Description>Common infrastructure for running the NuGetGallery back-end jobs.</Description>
   </PropertyGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Configuration\MessageServiceConfiguration.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection">
@@ -24,13 +28,16 @@
     <PackageReference Include="NuGet.Services.Configuration">
       <Version>2.79.0</Version>
     </PackageReference>
-    <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.79.0</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
       <Version>2.79.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
+      <Version>2.79.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="NuGet.Services.Messaging.Email">
       <Version>2.79.0</Version>
     </PackageReference>
   </ItemGroup>

--- a/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
+++ b/src/NuGet.Protocol.Catalog/NuGet.Protocol.Catalog.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <Description>A .NET library for consuming the NuGet API's catalog resource.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -248,11 +248,7 @@ namespace NuGet.Services.AzureSearch
                     var client = new SearchServiceClient(
                         options.Value.SearchServiceName,
                         new SearchCredentials(options.Value.SearchServiceApiKey),
-#if NETFRAMEWORK
-                        new WebRequestHandler(),
-#else
                         new HttpClientHandler(),
-#endif
                         GetSearchDelegatingHandlers(p.GetRequiredService<ILoggerFactory>()));
 
                     client.SetRetryPolicy(GetSearchRetryPolicy());

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -122,6 +122,7 @@ namespace NuGet.Services.AzureSearch
                 })
                 .Keyed<CloudStorageAccount>(key);
 
+#if NETFRAMEWORK
             containerBuilder
                 .Register<IStorageFactory>(c =>
                 {
@@ -140,6 +141,7 @@ namespace NuGet.Services.AzureSearch
                         throttle: NullThrottle.Instance);
                 })
                 .Keyed<IStorageFactory>(key);
+#endif
 
             containerBuilder
                 .Register<IBlobContainerBuilder>(c => new BlobContainerBuilder(
@@ -246,7 +248,11 @@ namespace NuGet.Services.AzureSearch
                     var client = new SearchServiceClient(
                         options.Value.SearchServiceName,
                         new SearchCredentials(options.Value.SearchServiceApiKey),
+#if NETFRAMEWORK
                         new WebRequestHandler(),
+#else
+                        new HttpClientHandler(),
+#endif
                         GetSearchDelegatingHandlers(p.GetRequiredService<ILoggerFactory>()));
 
                     client.SetRetryPolicy(GetSearchRetryPolicy());

--- a/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/DocumentUtilities.cs
@@ -48,12 +48,47 @@ namespace NuGet.Services.AzureSearch
         {
             // First, encode the raw value for uniqueness.
             var bytes = Encoding.UTF8.GetBytes(rawKey);
-            var unique = HttpServerUtility.UrlTokenEncode(bytes);
+            var unique = Base64UrlEncode(bytes);
 
             // Then, prepend a string as close to the raw key as possible, for readability.
             var readable = ReplaceUnsafeKeyCharacters(rawKey).TrimStart('_');
 
             return readable.Length > 0 ? $"{readable}-{unique}" : unique;
+        }
+
+        /// <summary>
+        /// This implementation is designed to be equivalent to the .NET Framework method
+        /// <c>HttpServerUtility.UrlTokenEncode(byte[])</c>.
+        /// </summary>
+        public static string Base64UrlEncode(byte[] bytes)
+        {
+            // Allocate a character array large enough, per https://stackoverflow.com/a/13378842.
+            var charArray = new char[4 * ((bytes.Length / 3) + 1)];
+            var charCount = Convert.ToBase64CharArray(bytes, 0, bytes.Length, charArray, 0);
+
+            // Map unsafe characters to safe ones.
+            var paddingCount = 0;
+            for (var i = charCount - 1; i >= 0; i--)
+            {
+                switch (charArray[i])
+                {
+                    case '=':
+                        paddingCount++;
+                        break;
+                    case '+':
+                        charArray[i] = '-';
+                        break;
+                    case '/':
+                        charArray[i] = '_';
+                        break;
+                }
+            }
+
+            // Append the padding count to the end.
+            var dataCount = charCount - paddingCount;
+            charArray[dataCount] = (char)((int)'0' + paddingCount);
+
+            return new string(charArray, 0, dataCount + 1);
         }
 
         private static string ReplaceUnsafeKeyCharacters(string input)

--- a/src/NuGet.Services.AzureSearch/IndexBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/IndexBuilder.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Services.AzureSearch.ScoringProfiles;
 using NuGet.Services.AzureSearch.Wrappers;
+using Index = Microsoft.Azure.Search.Models.Index;
 
 namespace NuGet.Services.AzureSearch
 {

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Description>Push NuGetGallery DB packages or catalog leaves to Azure Search.</Description>
     <PackageTags>nuget azure search catalog leaf details incremental collector</PackageTags>
   </PropertyGroup>

--- a/src/NuGet.Services.AzureSearch/Wrappers/IndexesOperationsWrapper.cs
+++ b/src/NuGet.Services.AzureSearch/Wrappers/IndexesOperationsWrapper.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.Search;
 using Microsoft.Azure.Search.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Rest.TransientFaultHandling;
+using Index = Microsoft.Azure.Search.Models.Index;
 
 namespace NuGet.Services.AzureSearch.Wrappers
 {

--- a/src/NuGet.Services.V3/NuGet.Services.V3.csproj
+++ b/src/NuGet.Services.V3/NuGet.Services.V3.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <Description>Common infrastructure for V3 back-end jobs, including catalog abstractions and dependency injection setup.</Description>
   </PropertyGroup>
 

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -213,9 +213,8 @@ namespace NuGet.Services.Validation.Orchestrator
                 var assemblyName = assembly.GetName().Name;
                 var assemblyVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
 
-                var client = new HttpClient(new WebRequestHandler
+                var client = new HttpClient(new HttpClientHandler
                 {
-                    AllowPipelining = true,
                     AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate),
                 });
 

--- a/src/Validation.Common.Job/Leases/CloudBlobLeaseService.cs
+++ b/src/Validation.Common.Job/Leases/CloudBlobLeaseService.cs
@@ -58,6 +58,8 @@ namespace NuGet.Jobs.Validation.Leases
             {
                 await blob.ReleaseLeaseAsync(
                     AccessCondition.GenerateLeaseCondition(leaseId),
+                    options: null,
+                    operationContext: null,
                     cancellationToken);
                 return true;
             }
@@ -77,6 +79,9 @@ namespace NuGet.Jobs.Validation.Leases
                     Array.Empty<byte>(),
                     index: 0,
                     count: 0,
+                    accessCondition: null,
+                    options: null,
+                    operationContext: null,
                     cancellationToken: cancellationToken);
 
                 return await TryAcquireAsync(blob, leaseTime, cancellationToken);
@@ -102,6 +107,9 @@ namespace NuGet.Jobs.Validation.Leases
                 var leaseId = await blob.AcquireLeaseAsync(
                     leaseTime: leaseTime,
                     proposedLeaseId: null,
+                    accessCondition: null,
+                    options: null,
+                    operationContext: null,
                     cancellationToken: cancellationToken);
 
                 return LeaseResult.Success(leaseId);

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -3,11 +3,19 @@
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <RootNamespace>NuGet.Jobs.Validation</RootNamespace>
     <AssemblyName>NuGet.Services.Validation.Common.Job</AssemblyName>
     <Description>Common job infrastructure for validation jobs and basic dependency injection setup.</Description>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <Compile Remove="Storage\IValidatorStateService.cs" />
+    <Compile Remove="Storage\ValidatorStateService.cs" />
+    <Compile Remove="Storage\ValidatorStatusExtensions.cs" />
+    <Compile Remove="SubscriptionProcessorJob.cs" />
+    <Compile Remove="ValidationJobBase.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Autofac">
@@ -25,14 +33,17 @@
     <PackageReference Include="NuGet.Packaging">
       <Version>5.8.0-preview.3.6823</Version>
     </PackageReference>
+    <PackageReference Include="NuGetGallery.Core">
+      <Version>4.4.5-dev-4220086</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.ServiceBus">
       <Version>2.79.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
       <Version>2.79.0</Version>
-    </PackageReference>
-    <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4220086</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Validation.Common.Job/ValidationJobBase.cs
+++ b/src/Validation.Common.Job/ValidationJobBase.cs
@@ -88,9 +88,8 @@ namespace NuGet.Jobs.Validation
                 var assemblyName = assembly.GetName().Name;
                 var assemblyVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "0.0.0";
 
-                var client = new HttpClient(new WebRequestHandler
+                var client = new HttpClient(new HttpClientHandler
                 {
-                    AllowPipelining = true,
                     AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate),
                 });
 

--- a/tests/CatalogTests/Persistence/AzureCloudBlockBlobTests.cs
+++ b/tests/CatalogTests/Persistence/AzureCloudBlockBlobTests.cs
@@ -49,7 +49,8 @@ namespace CatalogTests.Persistence
         [Fact]
         public async Task FetchAttributesAsync_CallsUnderlyingMethod()
         {
-            _underlyingBlob.Setup(x => x.FetchAttributesAsync(It.IsAny<CancellationToken>()))
+            _underlyingBlob
+                .Setup(x => x.FetchAttributesAsync(null, null, null, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(0));
 
             var blob = new AzureCloudBlockBlob(_underlyingBlob.Object);
@@ -77,7 +78,7 @@ namespace CatalogTests.Persistence
         {
             var expectedStream = new MemoryStream();
 
-            _underlyingBlob.Setup(x => x.OpenReadAsync(It.IsAny<CancellationToken>()))
+            _underlyingBlob.Setup(x => x.OpenReadAsync(null, null, null, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expectedStream);
 
             var blob = new AzureCloudBlockBlob(_underlyingBlob.Object);

--- a/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/DocumentUtilitiesFacts.cs
@@ -3,12 +3,30 @@
 
 using System;
 using System.Linq;
+using System.Web;
 using Xunit;
 
 namespace NuGet.Services.AzureSearch
 {
     public class DocumentUtilitiesFacts
     {
+        public class Base64UrlEncode
+        {
+            [Fact]
+            public void IsCompatibleWithHttpServerUtilityUrlTokenEncode()
+            {
+                var random = new Random(0);
+                for (var i = 0; i < 1_000_000; i++)
+                {
+                    var bytes = new byte[random.Next(0, 8) + 1];
+                    random.NextBytes(bytes);
+                    var expected = HttpServerUtility.UrlTokenEncode(bytes);
+                    var actual = DocumentUtilities.Base64UrlEncode(bytes);
+                    Assert.Equal(expected, actual);
+                }
+            }
+        }
+
         public class GetHijackDocumentKey
         {
             [Theory]


### PR DESCRIPTION
Changes:
- Move entirely away from `WebRequestHandler`
  - This is not supported on .NET Core and the `AllowPipelining` defaults to true. It's essentially hardcoded to `true` in `HttpClientHandler` on .NET Framework. In short, our usage of it has no value over `HttpClientHandler`.
- Exclude all references to dotNetRDF and JSON-LD from the .NET Core targets
  - These packages don't support .NET Core and are not needed for Azure Search
- Use WindowsAzure.Storage overloads that are available on both .NET Core and .NET Framework where possible
- In places where synchronous storage APIs are used in synchronous methods, these classes are excluded from .NET Core target
  - This is the `AzureStorageFactory` and friends
- Exclude validator state service from .NET Core
  - This requires NuGet.Services.Validation which does not work on .NET Core due to the Service Bus SDK
- Re-implement `HttpServerUtility.UrlTokenEncode` since this API is not available on .NET Core
  - Added an additional test in addition to the existing ones

Progress on https://github.com/NuGet/Engineering/issues/3487.

As the end of this PR, all of the project dependencies of the Azure Search Service will be available in .NET Core.