### PR TITLE
Switch to NuGetTestData for static test packages

### DIFF
--- a/tests/BasicSearchTests.FunctionalTests.Core/Constants.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Constants.cs
@@ -24,7 +24,7 @@ namespace BasicSearchTests.FunctionalTests.Core
         public const string TestPackageAuthor = "clayco";
         public const string TestPackageCopyright = "Copyright 2013";
         public const string NonExistentSearchString = "asadfasdfsadfwerfasdf23423rafdsf";
-        public const string TestPackageOwner = "NugetTestAccount";
+        public const string TestPackageOwner = "NuGetTestData";
         public const string TestPackageTag = "json";
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/3513

All temporary test data will be owed by the NugetTestAccount and orgs. This data should be cleaned up.
All static test data that should not be deleted will be owned by NuGetTestData organization.