### PR TITLE
Update ServerCommon packages to 2.80.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,10 @@
 <Project>
+
+  <!-- NuGet dependencies shared across projects -->
+  <PropertyGroup>
+    <ServerCommonPackageVersion>2.79.0</ServerCommonPackageVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
       <Version>3.0.0</Version>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.79.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.80.0</ServerCommonPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SdkProjects.props
+++ b/SdkProjects.props
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <SignPath>..\..\build</SignPath>
+    <SignPath>build</SignPath>
     <SignPath Condition="'$(BUILD_SOURCESDIRECTORY)' != ''">$(BUILD_SOURCESDIRECTORY)\build</SignPath>
     <SignPath Condition="'$(NuGetBuildPath)' != ''">$(NuGetBuildPath)</SignPath>
     <SignType Condition="'$(SignType)' == ''">none</SignType>

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
@@ -67,10 +67,10 @@
       <Version>4.4.5-dev-4220086</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>

--- a/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
+++ b/src/Gallery.CredentialExpiration/Gallery.CredentialExpiration.csproj
@@ -93,7 +93,7 @@
       <Version>5.8.4</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Ng/Ng.csproj
+++ b/src/Ng/Ng.csproj
@@ -155,16 +155,16 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
       <Version>4.0.0</Version>

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -26,19 +26,19 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.Messaging.Email">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
+++ b/src/NuGet.Services.Metadata.Catalog.Monitoring/NuGet.Services.Metadata.Catalog.Monitoring.csproj
@@ -170,7 +170,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
+++ b/src/NuGet.Services.Revalidate/NuGet.Services.Revalidate.csproj
@@ -119,7 +119,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/PackageHash/PackageHash.csproj
+++ b/src/PackageHash/PackageHash.csproj
@@ -77,7 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.Cursor">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/SplitLargeFiles/SplitLargeFiles.csproj
+++ b/src/SplitLargeFiles/SplitLargeFiles.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NuGet.Services.KeyVault">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
       <Version>9.3.3</Version>

--- a/src/StatusAggregator/StatusAggregator.csproj
+++ b/src/StatusAggregator/StatusAggregator.csproj
@@ -160,13 +160,13 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Incidents">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Status.Table">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -40,10 +40,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Storage">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
+++ b/src/Validation.ScanAndSign.Core/Validation.ScanAndSign.Core.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Services.ServiceBus">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="MicroBuild.Core">
       <Version>0.3.0</Version>

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -326,7 +326,7 @@
       <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NgTests/NgTests.csproj
+++ b/tests/NgTests/NgTests.csproj
@@ -185,10 +185,10 @@
       <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/NuGet.Services.AzureSearch.FunctionalTests.csproj
@@ -77,7 +77,7 @@
       <Version>2.2.0</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Configuration">
-      <Version>2.79.0</Version>
+      <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>5.8.0-preview.3.6823</Version>


### PR DESCRIPTION
The symbol ingester job needs the latest version of ServerCommon packages to manually flush Application Insights telemetry. As part of this change, I've centralized the version in the `Directory.Build.props` file.