### PR TITLE
Update to latest AI library for .NET Core search and fix tracing

### DIFF
--- a/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
+++ b/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
-    
-    <!--
-    These references are used to "lift" transitive dependencies of Microsoft.ApplicationInsights.AspNetCore to versions
-    that are accepted by Azure DevOps Component Governance, which scans the project.assets.json file. At runtime, the
-    real versions of these packages are actually higher and defined by the shared ASP.NET Core SDK installed on the
-    hosting machine.
-    -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
   </ItemGroup>
 

--- a/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
+++ b/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
@@ -9,7 +9,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.16.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
+
+    <!--
+    This reference is used to "lift" a transitive dependency of Microsoft.ApplicationInsights.AspNetCore to a version
+    that is accepted by Azure DevOps Component Governance, which scans the project.assets.json file. At runtime, the
+    real version this package are actually higher and is defined by the shared ASP.NET Core SDK installed on the
+    hosting machine.
+    -->
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -68,7 +68,6 @@ namespace NuGet.Services.SearchService
             services.Configure<SearchServiceConfiguration>(Configuration.GetSection(ConfigurationSectionName));
 
             services.AddApplicationInsightsTelemetry();
-            services.AddSingleton<ITelemetryInitializer, AzureWebAppTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer>(new KnownOperationNameEnricher(new[]
             {
                 GetOperationName<SearchController>(HttpMethod.Get, nameof(SearchController.AutocompleteAsync)),

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -67,7 +67,7 @@ namespace NuGet.Services.SearchService
             services.Configure<AzureSearchConfiguration>(Configuration.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(Configuration.GetSection(ConfigurationSectionName));
 
-            services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsTelemetry(Configuration.GetValue<string>("ApplicationInsights_InstrumentationKey"));
             services.AddSingleton<ITelemetryInitializer>(new KnownOperationNameEnricher(new[]
             {
                 GetOperationName<SearchController>(HttpMethod.Get, nameof(SearchController.AutocompleteAsync)),

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -68,6 +68,7 @@ namespace NuGet.Services.SearchService
             services.Configure<SearchServiceConfiguration>(Configuration.GetSection(ConfigurationSectionName));
 
             services.AddApplicationInsightsTelemetry();
+            services.AddSingleton<ITelemetryInitializer, AzureWebAppTelemetryInitializer>();
             services.AddSingleton<ITelemetryInitializer>(new KnownOperationNameEnricher(new[]
             {
                 GetOperationName<SearchController>(HttpMethod.Get, nameof(SearchController.AutocompleteAsync)),

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -67,7 +67,7 @@ namespace NuGet.Services.SearchService
             services.Configure<AzureSearchConfiguration>(Configuration.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(Configuration.GetSection(ConfigurationSectionName));
 
-            services.AddApplicationInsightsTelemetry(Configuration.GetValue<string>("ApplicationInsights_InstrumentationKey"));
+            services.AddApplicationInsightsTelemetry();
             services.AddSingleton<ITelemetryInitializer>(new KnownOperationNameEnricher(new[]
             {
                 GetOperationName<SearchController>(HttpMethod.Get, nameof(SearchController.AutocompleteAsync)),

--- a/src/NuGet.Services.SearchService.Core/appsettings.json
+++ b/src/NuGet.Services.SearchService.Core/appsettings.json
@@ -4,6 +4,11 @@
       "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Default": "Information"
+      }
     }
   },
   "AllowedHosts": "*"

--- a/src/NuGet.Services.SearchService.Core/appsettings.json
+++ b/src/NuGet.Services.SearchService.Core/appsettings.json
@@ -7,7 +7,9 @@
     },
     "ApplicationInsights": {
       "LogLevel": {
-        "Default": "Information"
+        "Default": "Information",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
       }
     }
   },


### PR DESCRIPTION
For tracing that goes to Application Insights, we must explicitly use the "ApplicationInsights" section. See:
https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core#how-do-i-customize-ilogger-logs-collection

We don't want ASP.NET Core information traces but we do want NuGet information traces.

Also, fix up the comment in the csproj.