### PR TITLE
Fix emitting internal events on .NET Core Search Service

### DIFF
--- a/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
+++ b/src/NuGet.Services.SearchService.Core/NuGet.Services.SearchService.Core.csproj
@@ -24,4 +24,6 @@
     <ProjectReference Include="..\NuGet.Services.AzureSearch\NuGet.Services.AzureSearch.csproj" />
   </ItemGroup>
   
+  <Import Project="$(NuGetBuildExtensions)" Condition="'$(NuGetBuildExtensions)' != '' And Exists('$(NuGetBuildExtensions)')" />
+  
 </Project>

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -55,6 +55,7 @@ namespace NuGet.Services.SearchService
             services
                 .AddControllers(o =>
                 {
+                    o.SuppressAsyncSuffixInActionNames = false;
                     o.Filters.Add<ApiExceptionFilterAttribute>();
                 })
                 .AddNewtonsoftJson(o =>
@@ -173,12 +174,6 @@ namespace NuGet.Services.SearchService
 
         private static string GetOperationName<T>(HttpMethod verb, string actionName) where T : ControllerBase
         {
-            const string asyncSuffix = "Async";
-            if (actionName.EndsWith(asyncSuffix))
-            {
-                actionName = actionName.Substring(0, actionName.Length - asyncSuffix.Length);
-            }
-
             return $"{verb} {GetControllerName<T>()}/{actionName}";
         }
 


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/3514.

I missed the build hook that exists in the .NET Framework Search Service.

Also, I updated a setting so action names align with the .NET Framework, for simplicity.