### PR TITLE
Set connection limits based on App Service SNAT limits

### DIFF
--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -241,14 +241,6 @@ namespace NuGet.Services.AzureSearch
                 p.GetRequiredService<ILogger<DocumentsOperationsWrapper>>()));
 
             services
-                .AddSingleton<HttpClientHandler>(s => new HttpClientHandler
-                {
-                    // The maximum SNAT ports on Azure App Service is 128:
-                    // https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-intermittent-outbound-connection-errors#cause
-                    MaxConnectionsPerServer = 128,
-                });
-
-            services
                 .AddTransient<ISearchServiceClient>(p =>
                 {
                     var options = p.GetRequiredService<IOptionsSnapshot<AzureSearchConfiguration>>();

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -28,6 +28,7 @@ using NuGet.Services.SearchService.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Timers;
 
@@ -48,6 +49,10 @@ namespace NuGet.Services.SearchService
 
         public void ConfigureServices(IServiceCollection services)
         {
+            // The maximum SNAT ports on Azure App Service is 128:
+            // https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-intermittent-outbound-connection-errors#cause
+            ServicePointManager.DefaultConnectionLimit = 128;
+
             var refreshableConfig = GetSecretInjectedConfiguration(Configuration);
             Configuration = refreshableConfig.Root;
             services.AddSingleton(refreshableConfig.SecretReaderFactory);

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -49,10 +49,6 @@ namespace NuGet.Services.SearchService
 
         public void ConfigureServices(IServiceCollection services)
         {
-            // The maximum SNAT ports on Azure App Service is 128:
-            // https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-intermittent-outbound-connection-errors#cause
-            ServicePointManager.DefaultConnectionLimit = 128;
-
             var refreshableConfig = GetSecretInjectedConfiguration(Configuration);
             Configuration = refreshableConfig.Root;
             services.AddSingleton(refreshableConfig.SecretReaderFactory);
@@ -90,6 +86,15 @@ namespace NuGet.Services.SearchService
             services.AddHostedService<SecretRefresherBackgroundService>();
 
             services.AddAzureSearch(new Dictionary<string, string>());
+
+            // The maximum SNAT ports on Azure App Service is 128:
+            // https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-intermittent-outbound-connection-errors#cause
+            ServicePointManager.DefaultConnectionLimit = 128;
+            services
+                .AddSingleton<HttpClientHandler>(s => new HttpClientHandler
+                {
+                    MaxConnectionsPerServer = 128,
+                });
         }
 
         public void ConfigureContainer(ContainerBuilder builder)

--- a/src/NuGet.Services.SearchService.Core/appsettings.json
+++ b/src/NuGet.Services.SearchService.Core/appsettings.json
@@ -1,15 +1,11 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Information"
     },
     "ApplicationInsights": {
       "LogLevel": {
-        "Default": "Information",
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
+        "Default": "Information"
       }
     }
   },


### PR DESCRIPTION
Also, increase log verbosity for now, as we are evaluating the .NET Core search service.

The plan is to roll this out to PROD at 1% of gallery traffic to see how it fairs.

Progress on https://github.com/NuGet/Engineering/issues/3531.