### PR TITLE
China CDN log fix + minor global CDN log fix

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
@@ -89,7 +89,7 @@ namespace Stats.AzureCdnLogs.Common.Collect
 
         private static string Quote(string input)
         {
-            if ( input.StartsWith("\"") && input.EndsWith("\"") )
+            if (input.StartsWith("\"") && input.EndsWith("\""))
             {
                 // already quoted
                 return input;

--- a/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/OutputLogLine.cs
@@ -84,7 +84,22 @@ namespace Stats.AzureCdnLogs.Common.Collect
 
         public override string ToString()
         {
-            return $"{TimeStamp} {TimeTaken} {CIp} {FileSize} {SIp} {SPort} {ScStatus} {ScBytes} {CsMethod} {CsUriStem} - {RsDuration} {RsBytes} {CReferrer} {CUserAgent} {CustomerId} {XEc_Custom_1}";
+            return $"{TimeStamp} {TimeTaken} {CIp} {FileSize} {SIp} {SPort} {ScStatus} {ScBytes} {CsMethod} {CsUriStem} - {RsDuration} {RsBytes} {CReferrer} {Quote(CUserAgent)} {CustomerId} {Quote(XEc_Custom_1)}";
+        }
+
+        private static string Quote(string input)
+        {
+            if ( input.StartsWith("\"") && input.EndsWith("\"") )
+            {
+                // already quoted
+                return input;
+            }
+            if (input.IndexOfAny(new[] { ' ', '\t' }) >= 0)
+            {
+                return $"\"{input}\"";
+            }
+
+            return input;
         }
     }
 }

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -378,7 +378,7 @@ namespace Stats.CollectAzureCdnLogs
             // customer-id
             stringBuilder.Append((parsedEntry.CustomerId ?? dashCharacter) + spaceCharacter);
             // x-ec_custom-1
-            stringBuilder.AppendLine((parsedEntry.CustomField ?? dashCharacter) + spaceCharacter);
+            stringBuilder.AppendLine((parsedEntry.CustomField ?? dashCharacter));
 
             return stringBuilder.ToString();
         }

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -342,41 +342,41 @@ namespace Stats.CollectAzureCdnLogs
             var stringBuilder = new StringBuilder();
 
             // timestamp
-            stringBuilder.Append(ToUnixTimeStamp(parsedEntry.EdgeServerTimeDelivered) + spaceCharacter);
+            stringBuilder.Append(ToUnixTimeStamp(parsedEntry.EdgeServerTimeDelivered)).Append(spaceCharacter);
             // time-taken
-            stringBuilder.Append((parsedEntry.EdgeServerTimeTaken.HasValue ? parsedEntry.EdgeServerTimeTaken.Value.ToString() : dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.EdgeServerTimeTaken.HasValue ? parsedEntry.EdgeServerTimeTaken.Value.ToString() : dashCharacter)).Append(spaceCharacter);
 
             // REMOVE c-ip
-            stringBuilder.Append(dashCharacter + spaceCharacter);
+            stringBuilder.Append(dashCharacter).Append(spaceCharacter);
 
             // filesize
-            stringBuilder.Append((parsedEntry.FileSize.HasValue ? parsedEntry.FileSize.Value.ToString() : dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.FileSize.HasValue ? parsedEntry.FileSize.Value.ToString() : dashCharacter)).Append(spaceCharacter);
             // s-ip
-            stringBuilder.Append((parsedEntry.EdgeServerIpAddress ?? dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.EdgeServerIpAddress ?? dashCharacter)).Append(spaceCharacter);
             // s-port
-            stringBuilder.Append((parsedEntry.EdgeServerPort.HasValue ? parsedEntry.EdgeServerPort.Value.ToString() : dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.EdgeServerPort.HasValue ? parsedEntry.EdgeServerPort.Value.ToString() : dashCharacter)).Append(spaceCharacter);
             // sc-status
-            stringBuilder.Append((parsedEntry.CacheStatusCode ?? dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.CacheStatusCode ?? dashCharacter)).Append(spaceCharacter);
             // sc-bytes
-            stringBuilder.Append((parsedEntry.EdgeServerBytesSent.HasValue ? parsedEntry.EdgeServerBytesSent.Value.ToString() : dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.EdgeServerBytesSent.HasValue ? parsedEntry.EdgeServerBytesSent.Value.ToString() : dashCharacter)).Append(spaceCharacter);
             // cs-method
-            stringBuilder.Append((parsedEntry.HttpMethod ?? dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.HttpMethod ?? dashCharacter)).Append(spaceCharacter);
             // cs-uri-stem
-            stringBuilder.Append((parsedEntry.RequestUrl ?? dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.RequestUrl ?? dashCharacter)).Append(spaceCharacter);
 
             // -
-            stringBuilder.Append(dashCharacter + spaceCharacter);
+            stringBuilder.Append(dashCharacter).Append(spaceCharacter);
 
             // rs-duration
-            stringBuilder.Append((parsedEntry.RemoteServerTimeTaken.HasValue ? parsedEntry.RemoteServerTimeTaken.Value.ToString() : dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.RemoteServerTimeTaken.HasValue ? parsedEntry.RemoteServerTimeTaken.Value.ToString() : dashCharacter)).Append(spaceCharacter);
             // rs-bytes
-            stringBuilder.Append((parsedEntry.RemoteServerBytesSent.HasValue ? parsedEntry.RemoteServerBytesSent.Value.ToString() : dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.RemoteServerBytesSent.HasValue ? parsedEntry.RemoteServerBytesSent.Value.ToString() : dashCharacter)).Append(spaceCharacter);
             // c-referrer
-            stringBuilder.Append((parsedEntry.Referrer ?? dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.Referrer ?? dashCharacter)).Append(spaceCharacter);
             // c-user-agent
-            stringBuilder.Append((parsedEntry.UserAgent ?? dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.UserAgent ?? dashCharacter)).Append(spaceCharacter);
             // customer-id
-            stringBuilder.Append((parsedEntry.CustomerId ?? dashCharacter) + spaceCharacter);
+            stringBuilder.Append((parsedEntry.CustomerId ?? dashCharacter)).Append(spaceCharacter);
             // x-ec_custom-1
             stringBuilder.AppendLine((parsedEntry.CustomField ?? dashCharacter));
 

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -342,43 +342,76 @@ namespace Stats.CollectAzureCdnLogs
             var stringBuilder = new StringBuilder();
 
             // timestamp
-            stringBuilder.Append(ToUnixTimeStamp(parsedEntry.EdgeServerTimeDelivered)).Append(spaceCharacter);
+            stringBuilder
+                .Append(ToUnixTimeStamp(parsedEntry.EdgeServerTimeDelivered))
+                .Append(spaceCharacter);
             // time-taken
-            stringBuilder.Append((parsedEntry.EdgeServerTimeTaken.HasValue ? parsedEntry.EdgeServerTimeTaken.Value.ToString() : dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.EdgeServerTimeTaken.HasValue ? parsedEntry.EdgeServerTimeTaken.Value.ToString() : dashCharacter))
+                .Append(spaceCharacter);
 
             // REMOVE c-ip
-            stringBuilder.Append(dashCharacter).Append(spaceCharacter);
+            stringBuilder
+                .Append(dashCharacter)
+                .Append(spaceCharacter);
 
             // filesize
-            stringBuilder.Append((parsedEntry.FileSize.HasValue ? parsedEntry.FileSize.Value.ToString() : dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.FileSize.HasValue ? parsedEntry.FileSize.Value.ToString() : dashCharacter))
+                .Append(spaceCharacter);
             // s-ip
-            stringBuilder.Append((parsedEntry.EdgeServerIpAddress ?? dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.EdgeServerIpAddress ?? dashCharacter))
+                .Append(spaceCharacter);
             // s-port
-            stringBuilder.Append((parsedEntry.EdgeServerPort.HasValue ? parsedEntry.EdgeServerPort.Value.ToString() : dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.EdgeServerPort.HasValue ? parsedEntry.EdgeServerPort.Value.ToString() : dashCharacter))
+                .Append(spaceCharacter);
             // sc-status
-            stringBuilder.Append((parsedEntry.CacheStatusCode ?? dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.CacheStatusCode ?? dashCharacter))
+                .Append(spaceCharacter);
             // sc-bytes
-            stringBuilder.Append((parsedEntry.EdgeServerBytesSent.HasValue ? parsedEntry.EdgeServerBytesSent.Value.ToString() : dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.EdgeServerBytesSent.HasValue ? parsedEntry.EdgeServerBytesSent.Value.ToString() : dashCharacter))
+                .Append(spaceCharacter);
             // cs-method
-            stringBuilder.Append((parsedEntry.HttpMethod ?? dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.HttpMethod ?? dashCharacter))
+                .Append(spaceCharacter);
             // cs-uri-stem
-            stringBuilder.Append((parsedEntry.RequestUrl ?? dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.RequestUrl ?? dashCharacter))
+                .Append(spaceCharacter);
 
             // -
-            stringBuilder.Append(dashCharacter).Append(spaceCharacter);
+            stringBuilder
+                .Append(dashCharacter)
+                .Append(spaceCharacter);
 
             // rs-duration
-            stringBuilder.Append((parsedEntry.RemoteServerTimeTaken.HasValue ? parsedEntry.RemoteServerTimeTaken.Value.ToString() : dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.RemoteServerTimeTaken.HasValue ? parsedEntry.RemoteServerTimeTaken.Value.ToString() : dashCharacter))
+                .Append(spaceCharacter);
             // rs-bytes
-            stringBuilder.Append((parsedEntry.RemoteServerBytesSent.HasValue ? parsedEntry.RemoteServerBytesSent.Value.ToString() : dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.RemoteServerBytesSent.HasValue ? parsedEntry.RemoteServerBytesSent.Value.ToString() : dashCharacter))
+                .Append(spaceCharacter);
             // c-referrer
-            stringBuilder.Append((parsedEntry.Referrer ?? dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.Referrer ?? dashCharacter))
+                .Append(spaceCharacter);
             // c-user-agent
-            stringBuilder.Append((parsedEntry.UserAgent ?? dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.UserAgent ?? dashCharacter))
+                .Append(spaceCharacter);
             // customer-id
-            stringBuilder.Append((parsedEntry.CustomerId ?? dashCharacter)).Append(spaceCharacter);
+            stringBuilder
+                .Append((parsedEntry.CustomerId ?? dashCharacter))
+                .Append(spaceCharacter);
             // x-ec_custom-1
-            stringBuilder.AppendLine((parsedEntry.CustomField ?? dashCharacter));
+            stringBuilder
+                .AppendLine((parsedEntry.CustomField ?? dashCharacter));
 
             return stringBuilder.ToString();
         }

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Stats.AzureCdnLogs.Common;
 using Stats.AzureCdnLogs.Common.Collect;
 using Stats.CollectAzureChinaCDNLogs;
 using Xunit;
@@ -11,15 +14,20 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
 {
     public class ChinaCollectorTests
     {
+        public static IEnumerable<object[]> LogData => new object[][] {
+            new object[]{ "40.125.202.231,7/27/2017 4:50:09 PM +00:00,GET,\"/v3-flatcontainer/system.net.primitives/index.json\",HTTP/1.1,200,1196,\"-\",\"NuGet+Command+Line/4.3.0+(Microsoft+Windows+NT+6.2.9200.0)\",133,TCP_MISS,118.180.6.168", "1501174209 0 40.125.202.231 0 118.180.6.168 0 TCP_MISS/200 1196 GET /v3-flatcontainer/system.net.primitives/index.json - 133 0 - NuGet+Command+Line/4.3.0+(Microsoft+Windows+NT+6.2.9200.0) na na" },
+            new object[]{ "c-ip, timestamp, cs-method, cs-uri-stem, http-ver, sc-status, sc-bytes, c-referer, c-user-agent, rs-duration(ms), hit-miss, s-ip", null },
+            new object[]{ "66.102.6.172,7/27/2017 4:50:09 PM +00:00,GET,\"/favicon.ico\",HTTP/1.1,200,726,\"-\",\"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google+Favicon\",216,TCP_MISS,150.138.143.19", "1501174209 0 66.102.6.172 0 150.138.143.19 0 TCP_MISS/200 726 GET /favicon.ico - 216 0 - \"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google+Favicon\" na na" },
+            new object[]{ "66.102.6.172,7/27/2017 4:50:09 PM +00:00,GET,\"/favicon.ico\",HTTP/1.1,200,726,\"-\",\"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google,Favicon\",216,TCP_MISS,150.138.143.19", "1501174209 0 66.102.6.172 0 150.138.143.19 0 TCP_MISS/200 726 GET /favicon.ico - 216 0 - \"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google,Favicon\" na na" },
+            new object[]{ "1.2.3.4,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1", "1554566420 0 1.2.3.4 0 4.3.2.1 0 MISS/200 2044843 GET /v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg - 796 0 NULL \"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0,VS Enterprise/15.0)\" na na" },
+            new object[]{ "127.0.0.1,1/1/2020 1:23:45 PM +00:00,GET,\"/?q=foo(\"bar\", 2)\",HTTP/1.1,123,456,\"http://nuget.test/?\",\"Mozilla/4.0\",1,HIT,127.0.0.2", null },
+        };
+
         [Theory]
-        [InlineData("40.125.202.231,7/27/2017 4:50:09 PM +00:00,GET,\"/v3-flatcontainer/system.net.primitives/index.json\",HTTP/1.1,200,1196,\"-\",\"NuGet+Command+Line/4.3.0+(Microsoft+Windows+NT+6.2.9200.0)\",133,TCP_MISS,118.180.6.168", "1501174209 0 40.125.202.231 0 118.180.6.168 0 TCP_MISS/200 1196 GET /v3-flatcontainer/system.net.primitives/index.json - 133 0 - NuGet+Command+Line/4.3.0+(Microsoft+Windows+NT+6.2.9200.0) na na")]
-        [InlineData("c-ip, timestamp, cs-method, cs-uri-stem, http-ver, sc-status, sc-bytes, c-referer, c-user-agent, rs-duration(ms), hit-miss, s-ip", null)]
-        [InlineData("66.102.6.172,7/27/2017 4:50:09 PM +00:00,GET,\"/favicon.ico\",HTTP/1.1,200,726,\"-\",\"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google+Favicon\",216,TCP_MISS,150.138.143.19", "1501174209 0 66.102.6.172 0 150.138.143.19 0 TCP_MISS/200 726 GET /favicon.ico - 216 0 - Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google+Favicon na na")]
-        [InlineData("66.102.6.172,7/27/2017 4:50:09 PM +00:00,GET,\"/favicon.ico\",HTTP/1.1,200,726,\"-\",\"Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google,Favicon\",216,TCP_MISS,150.138.143.19", "1501174209 0 66.102.6.172 0 150.138.143.19 0 TCP_MISS/200 726 GET /favicon.ico - 216 0 - Mozilla/5.0+ X11;+Linux+x86_64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/49.0.2623.75+Safari/537.36+Google,Favicon na na")]
-        [InlineData("127.0.0.1,1/1/2020 1:23:45 PM +00:00,GET,\"/?q=foo(\"bar\", 2)\",HTTP/1.1,123,456,\"http://nuget.test/?\",\"Mozilla/4.0\",1,HIT,127.0.0.2", null)]
+        [MemberData(nameof(LogData))]
         public void TransformRawLogLine(string input, string expectedOutput)
         {
-            var collector  = new ChinaStatsCollector(
+            var collector = new ChinaStatsCollector(
                 Mock.Of<ILogSource>(),
                 Mock.Of<ILogDestination>(),
                 Mock.Of<ILogger<ChinaStatsCollector>>());
@@ -27,6 +35,28 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
             var tranformedinput = collector.TransformRawLogLine(input);
             string output = tranformedinput == null ? null : tranformedinput.ToString();
             Assert.Equal(expectedOutput, output);
+        }
+
+        public static IEnumerable<object[]> InputOnlyLogData => LogData.Select(x => new[] { x[0] });
+
+        [Theory]
+        [MemberData(nameof(InputOnlyLogData))]
+        public void CdnLogEntryParserIntegration(string input)
+        {
+            var collector = new ChinaStatsCollector(
+                Mock.Of<ILogSource>(),
+                Mock.Of<ILogDestination>(),
+                Mock.Of<ILogger<ChinaStatsCollector>>());
+
+            var tranformedInput = collector.TransformRawLogLine(input);
+            if (tranformedInput == null)
+            {
+                return;
+            }
+            string output = tranformedInput.ToString();
+            var logEntry = CdnLogEntryParser.ParseLogEntryFromLine(1, output, onErrorAction: null);
+            Assert.Contains(tranformedInput.XEc_Custom_1, logEntry.CustomField);
+            Assert.Contains(tranformedInput.CUserAgent, logEntry.UserAgent);
         }
     }
 }

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
@@ -54,7 +54,8 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
                 return;
             }
             string output = tranformedInput.ToString();
-            var logEntry = CdnLogEntryParser.ParseLogEntryFromLine(1, output, onErrorAction: null);
+            const int lineNumber = 1;
+            var logEntry = CdnLogEntryParser.ParseLogEntryFromLine(lineNumber, output, onErrorAction: null);
             Assert.Contains(tranformedInput.XEc_Custom_1, logEntry.CustomField);
             Assert.Contains(tranformedInput.CUserAgent, logEntry.UserAgent);
         }


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/3548

Some time ago China CDN logs started to use spaces in user agent string (before that those were replaced with `+`), which were left unquoted by the CollectAzureChinaCDNLogs, which causes incorrect parsing of user agent in logs coming from China CDN.

Also, while at it I had removed the code that added trailing space to all logs coming from global CDN and replaced bunch of string concatenations (that cause memory allocation on each call) with utilizing `StringBuilder.Append` which was already present anyway.