### PR TITLE
Disable sampling in AI

### DIFF
--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -69,7 +69,11 @@ namespace NuGet.Services.SearchService
             services.Configure<AzureSearchConfiguration>(Configuration.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(Configuration.GetSection(ConfigurationSectionName));
 
-            services.AddApplicationInsightsTelemetry(Configuration.GetValue<string>("ApplicationInsights_InstrumentationKey"));
+            services.AddApplicationInsightsTelemetry(o =>
+            {
+                o.InstrumentationKey = Configuration.GetValue<string>("ApplicationInsights_InstrumentationKey");
+                o.EnableAdaptiveSampling = false;
+            });
             services.AddSingleton<ITelemetryInitializer>(new KnownOperationNameEnricher(new[]
             {
                 GetOperationName<SearchController>(HttpMethod.Get, nameof(SearchController.AutocompleteAsync)),


### PR DESCRIPTION
We have this disabled on .NET Framework search and gallery. It makes investigations and summaries easier and more accurate.