### PR TITLE
Use System.Text.Json instead of Newtonsoft.Json

### DIFF
--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -9,9 +9,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Search">
-      <Version>5.0.3</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.3" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteContext.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteContext.cs
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class AutocompleteContext
     {
         [JsonProperty("@vocab")]
+        [JsonPropertyName("@vocab")]
         public string Vocab { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteResponse.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -12,12 +13,15 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class AutocompleteResponse
     {
         [JsonProperty("@context")]
+        [JsonPropertyName("@context")]
         public AutocompleteContext Context { get; set; }
 
         [JsonProperty("totalHits")]
+        [JsonPropertyName("totalHits")]
         public long TotalHits { get; set; }
 
         [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public List<string> Data { get; set; }
 
         public DebugInformation Debug { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 {
     public class DebugInformation
     {
-        public SearchRequest SearchRequest { get; set; }
+        public object SearchRequest { get; set; }
         public string IndexName { get; set; }
         public IndexOperationType IndexOperationType { get; set; }
         public string DocumentKey { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
@@ -6,6 +6,15 @@ using Microsoft.Azure.Search.Models;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
+    /// <summary>
+    /// Note that the <c>object</c> type properties in this class are set like that purposefully. This enables
+    /// System.Text.Json to dynamically serialize all properties of the type at runtime:
+    /// https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-polymorphism#serialize-properties-of-derived-classes
+    /// 
+    /// The alternative is using a complex set of generics to express the actual type. This is not useful given this
+    /// object is just for serializing some useful debug information. This model is rarely seen by users since it
+    /// requires an unofficial query parameter.
+    /// </summary>
     public class DebugInformation
     {
         public object SearchRequest { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchResponse.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -9,9 +10,11 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class V2SearchResponse
     {
         [JsonProperty("totalHits")]
+        [JsonPropertyName("totalHits")]
         public long TotalHits { get; set; }
 
         [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public List<V2SearchPackage> Data { get; set; }
 
         public DebugInformation Debug { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchContext.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchContext.cs
@@ -2,15 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class V3SearchContext
     {
         [JsonProperty("@vocab")]
+        [JsonPropertyName("@vocab")]
         public string Vocab { get; set; }
 
         [JsonProperty("@base")]
+        [JsonPropertyName("@base")]
         public string Base { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -12,54 +13,71 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class V3SearchPackage
     {
         [JsonProperty("@id")]
+        [JsonPropertyName("@id")]
         public string AtId { get; set; }
 
         [JsonProperty("@type")]
+        [JsonPropertyName("@type")]
         public string Type { get; set; }
 
         [JsonProperty("registration")]
+        [JsonPropertyName("registration")]
         public string Registration { get; set; }
 
         [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
         [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public string Version { get; set; }
 
         [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
 
         [JsonProperty("summary")]
+        [JsonPropertyName("summary")]
         public string Summary { get; set; }
 
         [JsonProperty("title")]
+        [JsonPropertyName("title")]
         public string Title { get; set; }
 
         [JsonProperty("iconUrl")]
+        [JsonPropertyName("iconUrl")]
         public string IconUrl { get; set; }
 
         [JsonProperty("licenseUrl")]
+        [JsonPropertyName("licenseUrl")]
         public string LicenseUrl { get; set; }
 
         [JsonProperty("projectUrl")]
+        [JsonPropertyName("projectUrl")]
         public string ProjectUrl { get; set; }
 
         [JsonProperty("tags")]
+        [JsonPropertyName("tags")]
         public string[] Tags { get; set; }
 
         [JsonProperty("authors")]
+        [JsonPropertyName("authors")]
         public string[] Authors { get; set; }
 
         [JsonProperty("totalDownloads")]
+        [JsonPropertyName("totalDownloads")]
         public long TotalDownloads { get; set; }
 
         [JsonProperty("verified")]
+        [JsonPropertyName("verified")]
         public bool Verified { get; set; }
 
         [JsonProperty("packageTypes")]
+        [JsonPropertyName("packageTypes")]
         public List<V3SearchPackageType> PackageTypes { get; set; }
 
         [JsonProperty("versions")]
+        [JsonPropertyName("versions")]
         public List<V3SearchVersion> Versions { get; set; }
 
         public object Debug { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackageType.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackageType.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -11,6 +12,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class V3SearchPackageType
     {
         [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchResponse.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -12,12 +13,15 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class V3SearchResponse
     {
         [JsonProperty("@context")]
+        [JsonPropertyName("@context")]
         public V3SearchContext Context { get; set; }
 
         [JsonProperty("totalHits")]
+        [JsonPropertyName("totalHits")]
         public long TotalHits { get; set; }
 
         [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public List<V3SearchPackage> Data { get; set; }
 
         public DebugInformation Debug { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchVersion.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchVersion.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -12,12 +13,15 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class V3SearchVersion
     {
         [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public string Version { get; set; }
 
         [JsonProperty("downloads")]
+        [JsonPropertyName("downloads")]
         public long Downloads { get; set; }
 
         [JsonProperty("@id")]
+        [JsonPropertyName("@id")]
         public string AtId { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/TimeSpanConverter.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/TimeSpanConverter.cs
@@ -5,7 +5,7 @@ using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace NuGet.Services.SearchService
+namespace NuGet.Services.AzureSearch.SearchService
 {
     /// <summary>
     /// See: https://github.com/dotnet/runtime/issues/29932

--- a/src/NuGet.Services.SearchService.Core/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService.Core/Controllers/SearchController.cs
@@ -2,12 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using NuGet.Services.AzureSearch.SearchService;
-using NuGet.Versioning;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 

--- a/src/NuGet.Services.SearchService.Core/Program.cs
+++ b/src/NuGet.Services.SearchService.Core/Program.cs
@@ -6,11 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace NuGet.Services.SearchService
 {

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -3,22 +3,13 @@
 
 using Autofac;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.AspNetCore;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Hosting.Internal;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.Configuration;
@@ -30,7 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Timers;
+using System.Text.Json.Serialization;
 
 namespace NuGet.Services.SearchService
 {
@@ -59,11 +50,12 @@ namespace NuGet.Services.SearchService
                     o.SuppressAsyncSuffixInActionNames = false;
                     o.Filters.Add<ApiExceptionFilterAttribute>();
                 })
-                .AddNewtonsoftJson(o =>
+                .AddJsonOptions(o =>
                 {
-                    o.SerializerSettings.ContractResolver = new DefaultContractResolver();
-                    o.SerializerSettings.Converters.Add(new StringEnumConverter());
-                    o.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+                    o.JsonSerializerOptions.PropertyNamingPolicy = null;
+                    o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    o.JsonSerializerOptions.Converters.Add(new TimeSpanConverter());
+                    o.JsonSerializerOptions.IgnoreNullValues = true;
                 });
 
             services.Configure<AzureSearchConfiguration>(Configuration.GetSection(ConfigurationSectionName));

--- a/src/NuGet.Services.SearchService.Core/Support/TimeSpanConverter.cs
+++ b/src/NuGet.Services.SearchService.Core/Support/TimeSpanConverter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGet.Services.SearchService
+{
+    /// <summary>
+    /// See: https://github.com/dotnet/runtime/issues/29932
+    /// </summary>
+    public class TimeSpanConverter : JsonConverter<TimeSpan>
+    {
+        public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return TimeSpan.Parse(reader.GetString());
+        }
+
+        public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/src/NuGet.Services.SearchService.Core/appsettings.json
+++ b/src/NuGet.Services.SearchService.Core/appsettings.json
@@ -1,11 +1,15 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     },
     "ApplicationInsights": {
       "LogLevel": {
-        "Default": "Information"
+        "Default": "Information",
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
       }
     }
   },

--- a/src/NuGet.Services.SearchService/Web.config
+++ b/src/NuGet.Services.SearchService/Web.config
@@ -28,8 +28,16 @@
         <bindingRedirect oldVersion="0.0.0.0-9.3.2.0" newVersion="9.3.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -40,8 +48,24 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6823" newVersion="5.8.0.6823"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6930" newVersion="5.8.0.6930"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6930" newVersion="5.8.0.6930"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6930" newVersion="5.8.0.6930"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Common" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.8.0.6930" newVersion="5.8.0.6930"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -154,8 +154,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
-    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
+    ""QueryType"": """ + JsonCasing(useNewtonsoftJson, "S") + @"imple"",
+    ""SearchMode"": """ + JsonCasing(useNewtonsoftJson, "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -501,8 +501,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
-    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
+    ""QueryType"": """ + JsonCasing(useNewtonsoftJson, "S") + @"imple"",
+    ""SearchMode"": """ + JsonCasing(useNewtonsoftJson, "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -802,8 +802,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
-    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
+    ""QueryType"": """ + JsonCasing(useNewtonsoftJson, "S") + @"imple"",
+    ""SearchMode"": """ + JsonCasing(useNewtonsoftJson, "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -1156,8 +1156,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
-    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
+    ""QueryType"": """ + JsonCasing(useNewtonsoftJson, "S") + @"imple"",
+    ""SearchMode"": """ + JsonCasing(useNewtonsoftJson, "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -1541,6 +1541,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 };
             }
 
+            protected string JsonCasing(bool useNewtonsoftJson, string letter) => (useNewtonsoftJson ? letter.ToLowerInvariant() : letter.ToUpperInvariant());
             protected string JsonQuote(bool useNewtonsoftJson) => useNewtonsoftJson ? "\\\"" : "\\u0022";
             protected string JsonPlus(bool useNewtonsoftJson) => useNewtonsoftJson ? "+" : "\\u002B";
             protected string JsonCopyright(bool useNewtonsoftJson) => useNewtonsoftJson ? "©" : "\\u00A9";

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using Microsoft.Azure.Search.Models;
 using Microsoft.Extensions.Options;
 using Moq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Support;
 using NuGet.Versioning;
@@ -122,8 +120,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(4, response.Data[0].DownloadCount);
             }
 
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _v2Request.ShowDebug = true;
                 var docResult = _hijackResult.Results[0];
@@ -136,7 +136,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _duration);
 
                 Assert.NotNull(response.Debug);
-                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""IgnoreFilter"": false,
@@ -154,8 +154,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": ""simple"",
-    ""SearchMode"": ""any""
+    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
+    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -168,27 +168,29 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
-      ""ETag"": ""\""etag-a\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-a" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
-      ""ETag"": ""\""etag-b\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-b" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""PopularityTransfers"": {
       ""LastModified"": ""2019-01-03T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:45"",
       ""FileSize"": 9876,
-      ""ETag"": ""\""etag-c\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-c" + JsonQuote(useNewtonsoftJson) + @"""
     }
   }
 }", actualJson);
                 Assert.Same(docResult, response.Data[0].Debug);
             }
 
-            [Fact]
-            public void ProducesExpectedResponse()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ProducesExpectedResponse(bool useNewtonsoftJson)
             {
                 var response = Target.V2FromHijack(
                     _v2Request,
@@ -197,7 +199,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _hijackResult,
                     _duration);
 
-                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""totalHits"": 1,
   ""data"": [
@@ -212,13 +214,13 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""transfer2""
         ]
       },
-      ""Version"": ""7.1.2.0-alpha+git"",
+      ""Version"": ""7.1.2.0-alpha" + JsonPlus(useNewtonsoftJson) + @"git"",
       ""NormalizedVersion"": ""7.1.2-alpha"",
       ""Title"": ""Windows Azure Storage"",
       ""Description"": ""Description."",
       ""Summary"": ""Summary."",
       ""Authors"": ""Microsoft"",
-      ""Copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""Copyright"": """ + JsonCopyright(useNewtonsoftJson) + @" Microsoft Corporation. All rights reserved."",
       ""Language"": ""en-US"",
       ""Tags"": ""Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial"",
       ""ReleaseNotes"": ""Release notes."",
@@ -236,7 +238,7 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""Dependencies"": [],
       ""SupportedFrameworks"": [],
       ""MinClientVersion"": ""2.12"",
-      ""Hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""Hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33" + JsonPlus(useNewtonsoftJson) + @"Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
       ""HashAlgorithm"": ""SHA512"",
       ""PackageFileSize"": 3039254,
       ""LicenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
@@ -465,8 +467,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal("bar", transfers[1]);
             }
 
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _v2Request.ShowDebug = true;
                 var docResult = _searchResult.Results[0];
@@ -479,7 +483,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _duration);
 
                 Assert.NotNull(response.Debug);
-                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""IgnoreFilter"": false,
@@ -497,8 +501,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": ""simple"",
-    ""SearchMode"": ""any""
+    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
+    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -511,27 +515,29 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
-      ""ETag"": ""\""etag-a\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-a" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
-      ""ETag"": ""\""etag-b\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-b" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""PopularityTransfers"": {
       ""LastModified"": ""2019-01-03T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:45"",
       ""FileSize"": 9876,
-      ""ETag"": ""\""etag-c\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-c" + JsonQuote(useNewtonsoftJson) + @"""
     }
   }
 }", actualJson);
                 Assert.Same(docResult, response.Data[0].Debug);
             }
 
-            [Fact]
-            public void ProducesExpectedResponse()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ProducesExpectedResponse(bool useNewtonsoftJson)
             {
                 var response = Target.V2FromSearch(
                     _v2Request,
@@ -540,7 +546,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _searchResult,
                     _duration);
 
-                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""totalHits"": 1,
   ""data"": [
@@ -558,13 +564,13 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""transfer2""
         ]
       },
-      ""Version"": ""7.1.2.0-alpha+git"",
+      ""Version"": ""7.1.2.0-alpha" + JsonPlus(useNewtonsoftJson) + @"git"",
       ""NormalizedVersion"": ""7.1.2-alpha"",
       ""Title"": ""Windows Azure Storage"",
       ""Description"": ""Description."",
       ""Summary"": ""Summary."",
       ""Authors"": ""Microsoft"",
-      ""Copyright"": ""© Microsoft Corporation. All rights reserved."",
+      ""Copyright"": """ + JsonCopyright(useNewtonsoftJson) + @" Microsoft Corporation. All rights reserved."",
       ""Language"": ""en-US"",
       ""Tags"": ""Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial"",
       ""ReleaseNotes"": ""Release notes."",
@@ -582,7 +588,7 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""Dependencies"": [],
       ""SupportedFrameworks"": [],
       ""MinClientVersion"": ""2.12"",
-      ""Hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
+      ""Hash"": ""oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33" + JsonPlus(useNewtonsoftJson) + @"Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ=="",
       ""HashAlgorithm"": ""SHA512"",
       ""PackageFileSize"": 3039254,
       ""LicenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
@@ -764,8 +770,10 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Null(response.Data[0].PackageTypes);
             }
 
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _v3Request.ShowDebug = true;
                 var docResult = _searchResult.Results[0];
@@ -780,7 +788,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Same(docResult, response.Data[0].Debug);
 
                 Assert.NotNull(response.Debug);
-                var rootDebugJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var rootDebugJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""Skip"": 0,
@@ -794,8 +802,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": ""simple"",
-    ""SearchMode"": ""any""
+    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
+    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -808,26 +816,28 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
-      ""ETag"": ""\""etag-a\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-a" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
-      ""ETag"": ""\""etag-b\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-b" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""PopularityTransfers"": {
       ""LastModified"": ""2019-01-03T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:45"",
       ""FileSize"": 9876,
-      ""ETag"": ""\""etag-c\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-c" + JsonQuote(useNewtonsoftJson) + @"""
     }
   }
 }", rootDebugJson);
             }
 
-            [Fact]
-            public void ProducesExpectedResponse()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ProducesExpectedResponse(bool useNewtonsoftJson)
             {
                 var docResult = _searchResult.Results[0];
                 docResult.Document.FilterablePackageTypes = new[] { "dependency", "dotnettool" };
@@ -840,7 +850,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _searchResult,
                     _duration);
 
-                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""@context"": {
     ""@vocab"": ""http://schema.nuget.org/schema#"",
@@ -853,7 +863,7 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""@type"": ""Package"",
       ""registration"": ""https://example/reg-gz-semver2/windowsazure.storage/index.json"",
       ""id"": ""WindowsAzure.Storage"",
-      ""version"": ""7.1.2-alpha+git"",
+      ""version"": ""7.1.2-alpha" + JsonPlus(useNewtonsoftJson) + @"git"",
       ""description"": ""Description."",
       ""summary"": ""Summary."",
       ""title"": ""Windows Azure Storage"",
@@ -891,7 +901,7 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/1.0.0.json""
         },
         {
-          ""version"": ""2.0.0+git"",
+          ""version"": ""2.0.0" + JsonPlus(useNewtonsoftJson) + @"git"",
           ""downloads"": 23,
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/2.0.0.json""
         },
@@ -901,7 +911,7 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/3.0.0-alpha.1.json""
         },
         {
-          ""version"": ""7.1.2-alpha+git"",
+          ""version"": ""7.1.2-alpha" + JsonPlus(useNewtonsoftJson) + @"git"",
           ""downloads"": 23,
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/7.1.2-alpha.json""
         }
@@ -945,8 +955,10 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public class V3FromSearchDocument : BaseFacts
         {
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _v3Request.ShowDebug = true;
                 var doc = _searchResult.Results[0].Document;
@@ -961,7 +973,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Same(doc, debugDoc.Document);
 
                 Assert.NotNull(response.Debug);
-                var rootDebugJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var rootDebugJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""Skip"": 0,
@@ -981,26 +993,28 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""LastModified"": ""2019-01-01T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:15"",
       ""FileSize"": 1234,
-      ""ETag"": ""\""etag-a\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-a" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""VerifiedPackages"": {
       ""LastModified"": ""2019-01-02T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:30"",
       ""FileSize"": 5678,
-      ""ETag"": ""\""etag-b\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-b" + JsonQuote(useNewtonsoftJson) + @"""
     },
     ""PopularityTransfers"": {
       ""LastModified"": ""2019-01-03T11:00:00+00:00"",
       ""LoadDuration"": ""00:00:45"",
       ""FileSize"": 9876,
-      ""ETag"": ""\""etag-c\""""
+      ""ETag"": """ + JsonQuote(useNewtonsoftJson) + @"etag-c" + JsonQuote(useNewtonsoftJson) + @"""
     }
   }
 }", rootDebugJson);
             }
 
-            [Fact]
-            public void ProducesExpectedResponse()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ProducesExpectedResponse(bool useNewtonsoftJson)
             {
                 var doc = _searchResult.Results[0].Document;
 
@@ -1010,7 +1024,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     doc,
                     _duration);
 
-                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""@context"": {
     ""@vocab"": ""http://schema.nuget.org/schema#"",
@@ -1023,7 +1037,7 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""@type"": ""Package"",
       ""registration"": ""https://example/reg-gz-semver2/windowsazure.storage/index.json"",
       ""id"": ""WindowsAzure.Storage"",
-      ""version"": ""7.1.2-alpha+git"",
+      ""version"": ""7.1.2-alpha" + JsonPlus(useNewtonsoftJson) + @"git"",
       ""description"": ""Description."",
       ""summary"": ""Summary."",
       ""title"": ""Windows Azure Storage"",
@@ -1058,7 +1072,7 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/1.0.0.json""
         },
         {
-          ""version"": ""2.0.0+git"",
+          ""version"": ""2.0.0" + JsonPlus(useNewtonsoftJson) + @"git"",
           ""downloads"": 23,
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/2.0.0.json""
         },
@@ -1068,7 +1082,7 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/3.0.0-alpha.1.json""
         },
         {
-          ""version"": ""7.1.2-alpha+git"",
+          ""version"": ""7.1.2-alpha" + JsonPlus(useNewtonsoftJson) + @"git"",
           ""downloads"": 23,
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/7.1.2-alpha.json""
         }
@@ -1112,8 +1126,10 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public class AutocompleteFromSearch : BaseFacts
         {
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _autocompleteRequest.ShowDebug = true;
 
@@ -1125,7 +1141,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _duration);
 
                 Assert.NotNull(response.Debug);
-                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""Type"": ""PackageIds"",
@@ -1140,8 +1156,8 @@ namespace NuGet.Services.AzureSearch.SearchService
   ""IndexOperationType"": ""Search"",
   ""SearchParameters"": {
     ""IncludeTotalResultCount"": false,
-    ""QueryType"": ""simple"",
-    ""SearchMode"": ""any""
+    ""QueryType"": """ + (useNewtonsoftJson ? "s" : "S") + @"imple"",
+    ""SearchMode"": """ + (useNewtonsoftJson ? "a" : "A") + @"ny""
   },
   ""SearchText"": ""azure storage sdk"",
   ""DocumentSearchResult"": {
@@ -1223,12 +1239,14 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public class EmptyV3 : BaseFacts
         {
-            [Fact]
-            public void ProducesExpectedResponse()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ProducesExpectedResponse(bool useNewtonsoftJson)
             {
                 var response = Target.EmptyV3(_v3Request);
 
-                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                var actualJson =  GetActualJson(response, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""@context"": {
     ""@vocab"": ""http://schema.nuget.org/schema#"",
@@ -1239,15 +1257,17 @@ namespace NuGet.Services.AzureSearch.SearchService
 }", actualJson);
             }
 
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _v3Request.ShowDebug = true;
 
                 var response = Target.EmptyV3(_v3Request);
 
                 Assert.NotNull(response.Debug);
-                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""Skip"": 0,
@@ -1264,27 +1284,31 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public class EmptyV2 : BaseFacts
         {
-            [Fact]
-            public void ProducesExpectedResponse()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ProducesExpectedResponse(bool useNewtonsoftJson)
             {
                 var response = Target.EmptyV2(_v2Request);
 
-                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""totalHits"": 0,
   ""data"": []
 }", actualJson);
             }
 
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _v2Request.ShowDebug = true;
 
                 var response = Target.EmptyV2(_v2Request);
 
                 Assert.NotNull(response.Debug);
-                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""IgnoreFilter"": false,
@@ -1305,12 +1329,14 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public class EmptyAutocomplete : BaseFacts
         {
-            [Fact]
-            public void ProducesExpectedResponse()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ProducesExpectedResponse(bool useNewtonsoftJson)
             {
                 var response = Target.EmptyAutocomplete(_autocompleteRequest);
 
-                var actualJson = JsonConvert.SerializeObject(response, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""@context"": {
     ""@vocab"": ""http://schema.nuget.org/schema#""
@@ -1320,15 +1346,17 @@ namespace NuGet.Services.AzureSearch.SearchService
 }", actualJson);
             }
 
-            [Fact]
-            public void CanIncludeDebugInformation()
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CanIncludeDebugInformation(bool useNewtonsoftJson)
             {
                 _autocompleteRequest.ShowDebug = true;
 
                 var response = Target.EmptyAutocomplete(_autocompleteRequest);
 
                 Assert.NotNull(response.Debug);
-                var actualJson = JsonConvert.SerializeObject(response.Debug, _jsonSerializerSettings);
+                var actualJson = GetActualJson(response.Debug, useNewtonsoftJson);
                 Assert.Equal(@"{
   ""SearchRequest"": {
     ""Type"": ""PackageIds"",
@@ -1360,7 +1388,6 @@ namespace NuGet.Services.AzureSearch.SearchService
             protected readonly DocumentSearchResult<SearchDocument.Full> _emptySearchResult;
             protected readonly DocumentSearchResult<SearchDocument.Full> _manySearchResults;
             protected readonly DocumentSearchResult<HijackDocument.Full> _hijackResult;
-            protected readonly JsonSerializerSettings _jsonSerializerSettings;
             protected readonly AuxiliaryFilesMetadata _auxiliaryMetadata;
 
             public SearchResponseBuilder Target => new SearchResponseBuilder(
@@ -1512,16 +1539,39 @@ namespace NuGet.Services.AzureSearch.SearchService
                         },
                     },
                 };
+            }
 
-                _jsonSerializerSettings = new JsonSerializerSettings
+            protected string JsonQuote(bool useNewtonsoftJson) => useNewtonsoftJson ? "\\\"" : "\\u0022";
+            protected string JsonPlus(bool useNewtonsoftJson) => useNewtonsoftJson ? "+" : "\\u002B";
+            protected string JsonCopyright(bool useNewtonsoftJson) => useNewtonsoftJson ? "©" : "\\u00A9";
+
+            protected string GetActualJson(object response, bool useNewtonsoftJson)
+            {
+                if (useNewtonsoftJson)
                 {
-                    NullValueHandling = NullValueHandling.Ignore,
-                    Converters =
+                    return Newtonsoft.Json.JsonConvert.SerializeObject(response, new Newtonsoft.Json.JsonSerializerSettings
                     {
-                        new StringEnumConverter(),
-                    },
-                    Formatting = Formatting.Indented,
-                };
+                        NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
+                        Converters =
+                        {
+                            new Newtonsoft.Json.Converters.StringEnumConverter(),
+                        },
+                        Formatting = Newtonsoft.Json.Formatting.Indented,
+                    });
+                }
+                else
+                {
+                    return System.Text.Json.JsonSerializer.Serialize(response, new System.Text.Json.JsonSerializerOptions
+                    {
+                        IgnoreNullValues = true,
+                        Converters =
+                        {
+                            new System.Text.Json.Serialization.JsonStringEnumConverter(),
+                            new TimeSpanConverter(),
+                        },
+                        WriteIndented = true,
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
This was an idea I brainstormed with Brian on the .NET team. We are seeing increased time spent in serialization. To eliminate the non-default we currently have in of using Newtonsoft.Json, we decided to try the default System.Text.Json. This will help us narrow the scope of investigation.

Several changes required:
- Add a reference to System.Text.Json
- Add `[JsonPropertyName(...)]` wherever Newtonsoft.Json's `[JsonProperty(...)]` is used
- Add a `TimeSpan` converter since it is not serialized to a string by default
- Modify response JSON unit tests to allow some minor differences in JSON
  - A new "secure default" from System.Text.Json Unicode escapes characters like plus, double quote, and copyright
  - Some models from the Azure Search SDK have Newtonsoft.Json attributes, which are not observed by System.Text.Json

Verifications:
- E2E and functional tests
- manually cURL'ing all search endpoints for a big response and diff'ing them with the .NET Framework baseline

Progress on https://github.com/NuGet/Engineering/issues/3531.