### PR TITLE
Orchestrator save/delete readme file to flat container

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,7 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-<<<<<<< HEAD
-    <ServerCommonPackageVersion>2.81.0</ServerCommonPackageVersion>
-=======
     <ServerCommonPackageVersion>2.82.0</ServerCommonPackageVersion>
->>>>>>> 04922c30c376992f6faf72e161fd77ede4f32e43
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.80.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.81.0</ServerCommonPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -93,7 +93,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.6-gallery-2configuration-4385211</Version>
+      <Version>4.4.5-dev-4433264</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -93,11 +93,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-<<<<<<< HEAD
       <Version>4.4.6-gallery-2configuration-4385211</Version>
-=======
-      <Version>4.4.5-dev-4422931</Version>
->>>>>>> 04922c30c376992f6faf72e161fd77ede4f32e43
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -93,7 +93,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4220086</Version>
+      <Version>4.4.6-gallery-2configuration-4385211</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -69,8 +69,6 @@ namespace NuGet.Services.Validation.Orchestrator
         private const string ScanAndSignBindingKey = ScanAndSignSectionName;
         private const string SymbolsScanBindingKey = "SymbolsScan";
         private const string OrchestratorBindingKey = "Orchestrator";
-        //private const string CoreLicenseFileServiceBindingKey = "CoreLicenseFileService";
-        //private const string CoreReadmeFileServiceBindingKey = "CoreReadmeFileService";
         private const string FlatContainerBindingKey = "FlatContainer";
 
         private const string SymbolsValidatorSectionName = "SymbolsValidator";

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -70,6 +70,7 @@ namespace NuGet.Services.Validation.Orchestrator
         private const string SymbolsScanBindingKey = "SymbolsScan";
         private const string OrchestratorBindingKey = "Orchestrator";
         private const string CoreLicenseFileServiceBindingKey = "CoreLicenseFileService";
+        private const string CoreReadmeFileServiceBindingKey = "CoreReadmeFileService";
 
         private const string SymbolsValidatorSectionName = "SymbolsValidator";
         private const string SymbolsValidationBindingKey = SymbolsValidatorSectionName;
@@ -474,6 +475,11 @@ namespace NuGet.Services.Validation.Orchestrator
                 .RegisterType<CoreLicenseFileService>()
                 .WithKeyedParameter(typeof(ICoreFileStorageService), CoreLicenseFileServiceBindingKey)
                 .As<ICoreLicenseFileService>();
+
+            builder
+                .RegisterType<CoreReadmeFileService>()
+                .WithKeyedParameter(typeof(ICoreFileStorageService), CoreReadmeFileServiceBindingKey)
+                .As<ICoreReadmeFileService>();
         }
 
         private static void ConfigureOrchestratorMessageHandler(IServiceCollection services, IConfigurationRoot configurationRoot)

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -69,8 +69,9 @@ namespace NuGet.Services.Validation.Orchestrator
         private const string ScanAndSignBindingKey = ScanAndSignSectionName;
         private const string SymbolsScanBindingKey = "SymbolsScan";
         private const string OrchestratorBindingKey = "Orchestrator";
-        private const string CoreLicenseFileServiceBindingKey = "CoreLicenseFileService";
-        private const string CoreReadmeFileServiceBindingKey = "CoreReadmeFileService";
+        //private const string CoreLicenseFileServiceBindingKey = "CoreLicenseFileService";
+        //private const string CoreReadmeFileServiceBindingKey = "CoreReadmeFileService";
+        private const string FlatContainerBindingKey = "FlatContainer";
 
         private const string SymbolsValidatorSectionName = "SymbolsValidator";
         private const string SymbolsValidationBindingKey = SymbolsValidatorSectionName;
@@ -460,12 +461,12 @@ namespace NuGet.Services.Validation.Orchestrator
                         configurationAccessor.Value.ConnectionString,
                         readAccessGeoRedundant: false);
                 })
-                .Keyed<ICloudBlobClient>(CoreLicenseFileServiceBindingKey);
+                .Keyed<ICloudBlobClient>(FlatContainerBindingKey);
 
             builder
                 .RegisterType<CloudBlobCoreFileStorageService>()
-                .WithKeyedParameter(typeof(ICloudBlobClient), CoreLicenseFileServiceBindingKey)
-                .Keyed<ICoreFileStorageService>(CoreLicenseFileServiceBindingKey);
+                .WithKeyedParameter(typeof(ICloudBlobClient), FlatContainerBindingKey)
+                .Keyed<ICoreFileStorageService>(FlatContainerBindingKey);
 
             builder
                 .RegisterType<OrchestratorContentFileMetadataService>()
@@ -473,12 +474,12 @@ namespace NuGet.Services.Validation.Orchestrator
 
             builder
                 .RegisterType<CoreLicenseFileService>()
-                .WithKeyedParameter(typeof(ICoreFileStorageService), CoreLicenseFileServiceBindingKey)
+                .WithKeyedParameter(typeof(ICoreFileStorageService), FlatContainerBindingKey)
                 .As<ICoreLicenseFileService>();
 
             builder
                 .RegisterType<CoreReadmeFileService>()
-                .WithKeyedParameter(typeof(ICoreFileStorageService), CoreReadmeFileServiceBindingKey)
+                .WithKeyedParameter(typeof(ICoreFileStorageService), FlatContainerBindingKey)
                 .As<ICoreReadmeFileService>();
         }
 

--- a/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
@@ -13,6 +13,7 @@ namespace NuGet.Services.Validation.Orchestrator
     public class PackageStatusProcessor : EntityStatusProcessor<Package>
     {
         private readonly ICoreLicenseFileService _coreLicenseFileService;
+        private readonly ICoreReadmeFileService _coreReadmeFileService;
 
         public PackageStatusProcessor(
             IEntityService<Package> galleryPackageService,
@@ -20,10 +21,12 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidatorProvider validatorProvider,
             ITelemetryService telemetryService,
             ILogger<EntityStatusProcessor<Package>> logger,
-            ICoreLicenseFileService coreLicenseFileService) 
+            ICoreLicenseFileService coreLicenseFileService,
+            ICoreReadmeFileService coreReadmeFileService) 
             : base(galleryPackageService, packageFileService, validatorProvider, telemetryService, logger)
         {
             _coreLicenseFileService = coreLicenseFileService ?? throw new ArgumentNullException(nameof(coreLicenseFileService));
+            _coreReadmeFileService = coreReadmeFileService ?? throw new ArgumentNullException(nameof(coreReadmeFileService));
         }
 
         protected override async Task OnBeforeUpdateDatabaseToMakePackageAvailable(
@@ -43,19 +46,43 @@ namespace NuGet.Services.Validation.Orchestrator
                     _logger.LogInformation("Successfully extracted the license file.");
                 }
             }
+
+            if (validatingEntity.EntityRecord.HasEmbeddedReadme)
+            {
+                using (_telemetryService.TrackDurationToExtractReadmeFile(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId.ToString()))
+                using (var packageStream = await _packageFileService.DownloadPackageFileToDiskAsync(validationSet))
+                {
+                    _logger.LogInformation("Extracting the readme file of type {EmbeddedReadmeType} for the package {PackageId} {PackageVersion}",
+                        validatingEntity.EntityRecord.EmbeddedReadmeType,
+                        validationSet.PackageId,
+                        validationSet.PackageNormalizedVersion);
+                    await _coreReadmeFileService.ExtractAndSaveReadmeFileAsync(validatingEntity.EntityRecord, packageStream);
+                    _logger.LogInformation("Successfully extracted the readme file.");
+                }
+            }
         }
 
         protected override async Task OnCleanupAfterDatabaseUpdateFailure(
             IValidatingEntity<Package> validatingEntity,
             PackageValidationSet validationSet)
         {
-            if (validatingEntity.EntityRecord.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
+            if (validatingEntity.EntityRecord.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent || validatingEntity.EntityRecord.HasEmbeddedReadme)
             {
                 using (_telemetryService.TrackDurationToDeleteLicenseFile(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId.ToString()))
                 {
                     _logger.LogInformation("Cleaning up the license file for the package {PackageId} {PackageVersion}", validationSet.PackageId, validationSet.PackageNormalizedVersion);
                     await _coreLicenseFileService.DeleteLicenseFileAsync(validationSet.PackageId, validationSet.PackageNormalizedVersion);
                     _logger.LogInformation("Deleted the license file for the package {PackageId} {PackageVersion}", validationSet.PackageId, validationSet.PackageNormalizedVersion);
+                }
+            }
+
+            if (validatingEntity.EntityRecord.HasEmbeddedReadme)
+            {
+                using (_telemetryService.TrackDurationToDeleteReadmeFile(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId.ToString()))
+                {
+                    _logger.LogInformation("Cleaning up the readme file for the package {PackageId} {PackageVersion}", validationSet.PackageId, validationSet.PackageNormalizedVersion);
+                    await _coreReadmeFileService.DeleteReadmeFileAsync(validationSet.PackageId, validationSet.PackageNormalizedVersion);
+                    _logger.LogInformation("Deleted the readme file for the package {PackageId} {PackageVersion}", validationSet.PackageId, validationSet.PackageNormalizedVersion);
                 }
             }
         }

--- a/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageStatusProcessor.cs
@@ -33,31 +33,30 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidatingEntity<Package> validatingEntity,
             PackageValidationSet validationSet)
         {
-            if (validatingEntity.EntityRecord.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
+            if (validatingEntity.EntityRecord.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent || validatingEntity.EntityRecord.HasEmbeddedReadme)
             {
-                using (_telemetryService.TrackDurationToExtractLicenseFile(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId.ToString()))
+                using (_telemetryService.TrackDurationToExtractLicenseAndReadmeFile(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId.ToString()))
                 using (var packageStream = await _packageFileService.DownloadPackageFileToDiskAsync(validationSet))
                 {
-                    _logger.LogInformation("Extracting the license file of type {EmbeddedLicenseFileType} for the package {PackageId} {PackageVersion}",
-                        validatingEntity.EntityRecord.EmbeddedLicenseType,
-                        validationSet.PackageId,
-                        validationSet.PackageNormalizedVersion);
-                    await _coreLicenseFileService.ExtractAndSaveLicenseFileAsync(validatingEntity.EntityRecord, packageStream);
-                    _logger.LogInformation("Successfully extracted the license file.");
-                }
-            }
+                    if (validatingEntity.EntityRecord.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
+                    {
+                        _logger.LogInformation("Extracting the license file of type {EmbeddedLicenseFileType} for the package {PackageId} {PackageVersion}",
+                            validatingEntity.EntityRecord.EmbeddedLicenseType,
+                            validationSet.PackageId,
+                            validationSet.PackageNormalizedVersion);
+                        await _coreLicenseFileService.ExtractAndSaveLicenseFileAsync(validatingEntity.EntityRecord, packageStream);
+                        _logger.LogInformation("Successfully extracted the license file.");
+                    }
 
-            if (validatingEntity.EntityRecord.HasEmbeddedReadme)
-            {
-                using (_telemetryService.TrackDurationToExtractReadmeFile(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId.ToString()))
-                using (var packageStream = await _packageFileService.DownloadPackageFileToDiskAsync(validationSet))
-                {
-                    _logger.LogInformation("Extracting the readme file of type {EmbeddedReadmeType} for the package {PackageId} {PackageVersion}",
-                        validatingEntity.EntityRecord.EmbeddedReadmeType,
-                        validationSet.PackageId,
-                        validationSet.PackageNormalizedVersion);
-                    await _coreReadmeFileService.ExtractAndSaveReadmeFileAsync(validatingEntity.EntityRecord, packageStream);
-                    _logger.LogInformation("Successfully extracted the readme file.");
+                    if (validatingEntity.EntityRecord.HasEmbeddedReadme)
+                    {
+                        _logger.LogInformation("Extracting the readme file of type {EmbeddedReadmeType} for the package {PackageId} {PackageVersion}",
+                            validatingEntity.EntityRecord.EmbeddedReadmeType,
+                            validationSet.PackageId,
+                            validationSet.PackageNormalizedVersion);
+                        await _coreReadmeFileService.ExtractAndSaveReadmeFileAsync(validatingEntity.EntityRecord, packageStream);
+                        _logger.LogInformation("Successfully extracted the readme file.");
+                    }
                 }
             }
         }
@@ -66,7 +65,7 @@ namespace NuGet.Services.Validation.Orchestrator
             IValidatingEntity<Package> validatingEntity,
             PackageValidationSet validationSet)
         {
-            if (validatingEntity.EntityRecord.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent || validatingEntity.EntityRecord.HasEmbeddedReadme)
+            if (validatingEntity.EntityRecord.EmbeddedLicenseType != EmbeddedLicenseFileType.Absent)
             {
                 using (_telemetryService.TrackDurationToDeleteLicenseFile(validationSet.PackageId, validationSet.PackageNormalizedVersion, validationSet.ValidationTrackingId.ToString()))
                 {

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -159,13 +159,13 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         void TrackSymbolsMessageEnqueued(string packageId, string normalizedVersion, string validatorName, Guid validationId);
 
         /// <summary>
-        /// A metric to track duration of the license file extraction.
+        /// A metric to track duration of the license/readme file extraction.
         /// </summary>
-        /// <param name="packageId">Package ID from which license file is extracted.</param>
-        /// <param name="normalizedVersion">Normalized version of the package from which license file is extracted.</param>
+        /// <param name="packageId">Package ID from which license/readme file is extracted.</param>
+        /// <param name="normalizedVersion">Normalized version of the package from which license/readme file is extracted.</param>
         /// <param name="validationTrackingId">Validation tracking ID for which extraction is done.</param>
         /// <returns></returns>
-        IDisposable TrackDurationToExtractLicenseFile(string packageId, string normalizedVersion, string validationTrackingId);
+        IDisposable TrackDurationToExtractLicenseAndReadmeFile(string packageId, string normalizedVersion, string validationTrackingId);
 
         /// <summary>
         /// A metric to track duration of the license file deletion from flat container.
@@ -174,15 +174,6 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <param name="normalizedVersion">Normalized version of the package for which license file is deleted.</param>
         /// <param name="validationTrackingId">Validation tracking ID for which delete operation is done.</param>
         IDisposable TrackDurationToDeleteLicenseFile(string packageId, string normalizedVersion, string validationTrackingId);
-
-        /// <summary>
-        /// A metric to track duration of the readme file extraction.
-        /// </summary>
-        /// <param name="packageId">Package ID from which readme file is extracted.</param>
-        /// <param name="normalizedVersion">Normalized version of the package from which readme file is extracted.</param>
-        /// <param name="validationTrackingId">Validation tracking ID for which extraction is done.</param>
-        /// <returns></returns>
-        IDisposable TrackDurationToExtractReadmeFile(string packageId, string normalizedVersion, string validationTrackingId);
 
         /// <summary>
         /// A metric to track duration of the read file deletion from flat container.

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/ITelemetryService.cs
@@ -174,5 +174,22 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         /// <param name="normalizedVersion">Normalized version of the package for which license file is deleted.</param>
         /// <param name="validationTrackingId">Validation tracking ID for which delete operation is done.</param>
         IDisposable TrackDurationToDeleteLicenseFile(string packageId, string normalizedVersion, string validationTrackingId);
+
+        /// <summary>
+        /// A metric to track duration of the readme file extraction.
+        /// </summary>
+        /// <param name="packageId">Package ID from which readme file is extracted.</param>
+        /// <param name="normalizedVersion">Normalized version of the package from which readme file is extracted.</param>
+        /// <param name="validationTrackingId">Validation tracking ID for which extraction is done.</param>
+        /// <returns></returns>
+        IDisposable TrackDurationToExtractReadmeFile(string packageId, string normalizedVersion, string validationTrackingId);
+
+        /// <summary>
+        /// A metric to track duration of the read file deletion from flat container.
+        /// </summary>
+        /// <param name="packageId">Package ID for which readme file is deleted.</param>
+        /// <param name="normalizedVersion">Normalized version of the package for which readme file is deleted.</param>
+        /// <param name="validationTrackingId">Validation tracking ID for which delete operation is done.</param>
+        IDisposable TrackDurationToDeleteReadmeFile(string packageId, string normalizedVersion, string validationTrackingId);
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -37,6 +37,8 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string SymbolsMessageEnqueued = OrchestratorPrefix + "SymbolsMessageEnqueued";
         private const string ExtractLicenseFileDuration = OrchestratorPrefix + "ExtractLicenseFileDuration";
         private const string LicenseFileDeleted = OrchestratorPrefix + "LicenseFileDeleted";
+        private const string ExtractReadmeFileDuration = OrchestratorPrefix + "ExtractReadmeFileDuration";
+        private const string ReadmeFileDeleted = OrchestratorPrefix + "ReadmeFileDeleted";
 
         private const string DurationToStartPackageSigningValidatorSeconds = PackageSigningPrefix + "DurationToStartSeconds";
         private const string DurationToStartPackageCertificatesValidatorSeconds = PackageCertificatesPrefix + "DurationToStartSeconds";
@@ -356,6 +358,22 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
 
         public IDisposable TrackDurationToDeleteLicenseFile(string packageId, string normalizedVersion, string validationTrackingId)
             => _telemetryClient.TrackDuration(LicenseFileDeleted,
+                new Dictionary<string, string> {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId },
+                });
+
+        public IDisposable TrackDurationToExtractReadmeFile(string packageId, string normalizedVersion, string validationTrackingId)
+            => _telemetryClient.TrackDuration(ExtractReadmeFileDuration,
+                new Dictionary<string, string> {
+                    { PackageId, packageId },
+                    { NormalizedVersion, normalizedVersion },
+                    { ValidationTrackingId, validationTrackingId },
+                });
+
+        public IDisposable TrackDurationToDeleteReadmeFile(string packageId, string normalizedVersion, string validationTrackingId)
+            => _telemetryClient.TrackDuration(ReadmeFileDeleted,
                 new Dictionary<string, string> {
                     { PackageId, packageId },
                     { NormalizedVersion, normalizedVersion },

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -35,9 +35,8 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string MessageHandlerDurationSeconds = OrchestratorPrefix + "MessageHandlerDurationSeconds";
         private const string MessageLockLost = OrchestratorPrefix + "MessageLockLost";
         private const string SymbolsMessageEnqueued = OrchestratorPrefix + "SymbolsMessageEnqueued";
-        private const string ExtractLicenseFileDuration = OrchestratorPrefix + "ExtractLicenseFileDuration";
+        private const string ExtractLicenseAndReadmeFileDuration = OrchestratorPrefix + "ExtractLicenseAndReadmeFileDuration";
         private const string LicenseFileDeleted = OrchestratorPrefix + "LicenseFileDeleted";
-        private const string ExtractReadmeFileDuration = OrchestratorPrefix + "ExtractReadmeFileDuration";
         private const string ReadmeFileDeleted = OrchestratorPrefix + "ReadmeFileDeleted";
 
         private const string DurationToStartPackageSigningValidatorSeconds = PackageSigningPrefix + "DurationToStartSeconds";
@@ -348,8 +347,8 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                     { ValidationId, validationId.ToString()}
                 });
 
-        public IDisposable TrackDurationToExtractLicenseFile(string packageId, string normalizedVersion, string validationTrackingId)
-            => _telemetryClient.TrackDuration(ExtractLicenseFileDuration,
+        public IDisposable TrackDurationToExtractLicenseAndReadmeFile(string packageId, string normalizedVersion, string validationTrackingId)
+            => _telemetryClient.TrackDuration(ExtractLicenseAndReadmeFileDuration,
                 new Dictionary<string, string> {
                     { PackageId, packageId },
                     { NormalizedVersion, normalizedVersion },
@@ -358,14 +357,6 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
 
         public IDisposable TrackDurationToDeleteLicenseFile(string packageId, string normalizedVersion, string validationTrackingId)
             => _telemetryClient.TrackDuration(LicenseFileDeleted,
-                new Dictionary<string, string> {
-                    { PackageId, packageId },
-                    { NormalizedVersion, normalizedVersion },
-                    { ValidationTrackingId, validationTrackingId },
-                });
-
-        public IDisposable TrackDurationToExtractReadmeFile(string packageId, string normalizedVersion, string validationTrackingId)
-            => _telemetryClient.TrackDuration(ExtractReadmeFileDuration,
                 new Dictionary<string, string> {
                     { PackageId, packageId },
                     { NormalizedVersion, normalizedVersion },

--- a/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Telemetry/TelemetryService.cs
@@ -35,7 +35,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
         private const string MessageHandlerDurationSeconds = OrchestratorPrefix + "MessageHandlerDurationSeconds";
         private const string MessageLockLost = OrchestratorPrefix + "MessageLockLost";
         private const string SymbolsMessageEnqueued = OrchestratorPrefix + "SymbolsMessageEnqueued";
-        private const string ExtractLicenseAndReadmeFileDuration = OrchestratorPrefix + "ExtractLicenseAndReadmeFileDuration";
+        private const string ExtractLicenseAndReadmeFileDurationSeconds = OrchestratorPrefix + "ExtractLicenseAndReadmeFileDurationSeconds";
         private const string LicenseFileDeleted = OrchestratorPrefix + "LicenseFileDeleted";
         private const string ReadmeFileDeleted = OrchestratorPrefix + "ReadmeFileDeleted";
 
@@ -348,7 +348,7 @@ namespace NuGet.Services.Validation.Orchestrator.Telemetry
                 });
 
         public IDisposable TrackDurationToExtractLicenseAndReadmeFile(string packageId, string normalizedVersion, string validationTrackingId)
-            => _telemetryClient.TrackDuration(ExtractLicenseAndReadmeFileDuration,
+            => _telemetryClient.TrackDuration(ExtractLicenseAndReadmeFileDurationSeconds,
                 new Dictionary<string, string> {
                     { PackageId, packageId },
                     { NormalizedVersion, normalizedVersion },

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,11 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-<<<<<<< HEAD
       <Version>4.4.6-gallery-2configuration-4385211</Version>
-=======
-      <Version>4.4.5-dev-4422931</Version>
->>>>>>> 04922c30c376992f6faf72e161fd77ede4f32e43
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4220086</Version>
+      <Version>4.4.6-gallery-2configuration-4385211</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.6-gallery-2configuration-4385211</Version>
+      <Version>4.4.5-dev-4433264</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -34,7 +34,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.6-gallery-2configuration-4385211</Version>
+      <Version>4.4.5-dev-4433264</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -34,11 +34,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-<<<<<<< HEAD
       <Version>4.4.6-gallery-2configuration-4385211</Version>
-=======
-      <Version>4.4.5-dev-4422931</Version>
->>>>>>> 04922c30c376992f6faf72e161fd77ede4f32e43
     </PackageReference>
   </ItemGroup>
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -34,7 +34,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4220437</Version>
+      <Version>4.4.6-gallery-2configuration-4385211</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
* PackageStatusProcessor added logic to save readme files to flat container
* Added telemetry for readme file operations.
* ServerCommon version upgrade. (This need to be updated after https://github.com/NuGet/NuGetGallery/pull/8377 is merged)