### PR TITLE
Update jobs to reflect the latest validation database

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.83.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.84.0-loshar-uvp-db-4454369</ServerCommonPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.84.0-loshar-uvp-db-4454369</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.84.0</ServerCommonPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -64,7 +64,7 @@
       <Version>0.7.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>4.4.5-dev-4422931</Version>
+      <Version>4.4.5-dev-4466597</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
       <Version>$(ServerCommonPackageVersion)</Version>

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -93,7 +93,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4433264</Version>
+      <Version>4.4.5-loshar-uvp-db-4454444</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -93,7 +93,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-loshar-uvp-db-4454444</Version>
+      <Version>4.4.5-dev-4466597</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
@@ -116,13 +116,15 @@ namespace NuGet.Services.Validation.Orchestrator
                     return false;
                 }
 
+                // TODO: Add support for the "generic" validating type.
+                // Tracked by: https://github.com/NuGet/Engineering/issues/3583
                 if (validationSet.ValidatingType != ValidatingType)
                 {
                     _logger.LogError("Validation set {ValidationSetId} is not for a {TypeName}.", message.ValidationId, ValidatingType);
                     return false;
                 }
 
-                entity = _entityService.FindPackageByKey(validationSet.PackageKey);
+                entity = _entityService.FindPackageByKey(validationSet.PackageKey.Value);
                 if (entity == null)
                 {
                     _logger.LogError(

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
@@ -72,11 +72,18 @@ namespace NuGet.Services.Validation.Orchestrator
 
         public async Task StorePackageFileInBackupLocationAsync(PackageValidationSet validationSet, Stream packageFile)
         {
+            if (validationSet.ValidatingType == ValidatingType.Generic)
+            {
+                throw new ArgumentException(
+                    $"This method is not supported for validation set's of validating type {validationSet.ValidatingType}",
+                    nameof(validationSet));
+            }
+
             Package packageFromValidationSet = new Package()
             {
                 PackageRegistration = new PackageRegistration() { Id = validationSet.PackageId },
                 NormalizedVersion = validationSet.PackageNormalizedVersion,
-                Key = validationSet.PackageKey
+                Key = validationSet.PackageKey.Value,
             };
 
             await StorePackageFileInBackupLocationAsync(packageFromValidationSet, packageFile);

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationPackageFileService.cs
@@ -70,15 +70,8 @@ namespace NuGet.Services.Validation.Orchestrator
             return _fileStorageService.FileExistsAsync(_fileMetadataService.FileFolderName, fileName);
         }
 
-        public async Task StorePackageFileInBackupLocationAsync(PackageValidationSet validationSet, Stream packageFile)
+        private async Task StorePackageFileInBackupLocationAsync(PackageValidationSet validationSet, Stream packageFile)
         {
-            if (validationSet.ValidatingType == ValidatingType.Generic)
-            {
-                throw new ArgumentException(
-                    $"This method is not supported for validation set's of validating type {validationSet.ValidatingType}",
-                    nameof(validationSet));
-            }
-
             Package packageFromValidationSet = new Package()
             {
                 PackageRegistration = new PackageRegistration() { Id = validationSet.PackageId },
@@ -125,6 +118,13 @@ namespace NuGet.Services.Validation.Orchestrator
 
         public async Task BackupPackageFileFromValidationSetPackageAsync(PackageValidationSet validationSet)
         {
+            if (validationSet.ValidatingType == ValidatingType.Generic)
+            {
+                throw new ArgumentException(
+                    $"This method is not supported for validation sets of validating type {validationSet.ValidatingType}",
+                    nameof(validationSet));
+            }
+
             using (_telemetryService.TrackDurationToBackupPackage(validationSet))
             {
                 _logger.LogInformation(

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
@@ -287,7 +287,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
             var validationRequest = new NuGetValidationRequest(
                 validationId: packageValidation.Key,
-                packageKey: packageValidationSet.PackageKey,
+                packageKey: packageValidationSet.PackageKey.Value,
                 packageId: packageValidationSet.PackageId,
                 packageVersion: packageValidationSet.PackageNormalizedVersion,
                 nupkgUrl: nupkgUrl.AbsoluteUri);

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-loshar-uvp-db-4454444</Version>
+      <Version>4.4.5-dev-4466597</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4433264</Version>
+      <Version>4.4.5-loshar-uvp-db-4454444</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -34,7 +34,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-loshar-uvp-db-4454444</Version>
+      <Version>4.4.5-dev-4466597</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -34,7 +34,7 @@
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4433264</Version>
+      <Version>4.4.5-loshar-uvp-db-4454444</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
@@ -79,7 +79,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 .ReturnsAsync(validationSet)
                 .Verifiable();
             CoreSymbolPackageServiceMock
-                .Setup(ps => ps.FindPackageByKey(validationSet.PackageKey))
+                .Setup(ps => ps.FindPackageByKey(validationSet.PackageKey.Value))
                 .Returns<SymbolPackage>(null)
                 .Verifiable();
 
@@ -91,7 +91,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ps => ps.TryGetParentValidationSetAsync(messageData.CheckValidator.ValidationId),
                 Times.Once);
             CoreSymbolPackageServiceMock.Verify(
-                ps => ps.FindPackageByKey(validationSet.PackageKey),
+                ps => ps.FindPackageByKey(validationSet.PackageKey.Value),
                 Times.Once);
 
             Assert.False(result, "The handler should not have succeeded.");

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/SymbolValidationMessageHandlerFacts.cs
@@ -44,12 +44,14 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             Assert.False(result, "The handler should not have succeeded.");
         }
 
-        [Fact]
-        public async Task RejectsNonSymbolPackageValidationSetWithCheckValidator()
+        [Theory]
+        [InlineData(ValidatingType.Package)]
+        [InlineData(ValidatingType.Generic)]
+        public async Task RejectsNonSymbolPackageValidationSetWithCheckValidator(ValidatingType validatingType)
         {
             var messageData = PackageValidationMessageData.NewCheckValidator(Guid.NewGuid());
             var validationConfiguration = new ValidationConfiguration();
-            var validationSet = new PackageValidationSet { PackageKey = 42, ValidatingType = ValidatingType.Package };
+            var validationSet = new PackageValidationSet { PackageKey = 42, ValidatingType = validatingType };
 
             ValidationSetProviderMock
                 .Setup(ps => ps.TryGetParentValidationSetAsync(messageData.CheckValidator.ValidationId))

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -46,12 +46,14 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             Assert.False(result, "The handler should not have succeeded.");
         }
 
-        [Fact]
-        public async Task RejectsNonPackageValidationSetWithCheckValidator()
+        [Theory]
+        [InlineData(ValidatingType.SymbolPackage)]
+        [InlineData(ValidatingType.Generic)]
+        public async Task RejectsNonPackageValidationSetWithCheckValidator(ValidatingType validatingType)
         {
             var messageData = PackageValidationMessageData.NewCheckValidator(Guid.NewGuid());
             var validationConfiguration = new ValidationConfiguration();
-            var validationSet = new PackageValidationSet { PackageKey = 42, ValidatingType = ValidatingType.SymbolPackage };
+            var validationSet = new PackageValidationSet { PackageKey = 42, ValidatingType = validatingType };
 
             ValidationSetProviderMock
                 .Setup(ps => ps.TryGetParentValidationSetAsync(messageData.CheckValidator.ValidationId))

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -81,7 +81,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 .ReturnsAsync(validationSet)
                 .Verifiable();
             CorePackageServiceMock
-                .Setup(ps => ps.FindPackageByKey(validationSet.PackageKey))
+                .Setup(ps => ps.FindPackageByKey(validationSet.PackageKey.Value))
                 .Returns<SymbolPackage>(null)
                 .Verifiable();
 
@@ -93,7 +93,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ps => ps.TryGetParentValidationSetAsync(messageData.CheckValidator.ValidationId),
                 Times.Once);
             CorePackageServiceMock.Verify(
-                ps => ps.FindPackageByKey(validationSet.PackageKey),
+                ps => ps.FindPackageByKey(validationSet.PackageKey.Value),
                 Times.Once);
 
             Assert.False(result, "The handler should not have succeeded.");

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
@@ -55,6 +55,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             _validationSet = new PackageValidationSet
             {
                 ValidationTrackingId = new Guid("0b44d53f-0689-4f82-9530-f25f26b321aa"),
+                PackageKey = 9999,
                 PackageId = _package.PackageRegistration.Id,
                 PackageNormalizedVersion = _package.NormalizedVersion,
             };

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationPackageFileServiceFacts.cs
@@ -135,6 +135,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Fact]
+        public async Task CannotBackupGenericValidationSet()
+        {
+            _validationSet.ValidatingType = ValidatingType.Generic;
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => _target.BackupPackageFileFromValidationSetPackageAsync(_validationSet));
+
+            Assert.Equal("validationSet", exception.ParamName);
+            Assert.Contains(
+                "This method is not supported for validation sets of validating type Generic",
+                exception.Message);
+        }
+
+        [Fact]
         public async Task DownloadPackageFileToDiskAsync()
         {
             _fileStorageService

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
@@ -419,6 +419,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             ValidationSet = new PackageValidationSet
             {
                 Key = 238423,
+                PackageKey = 9999,
                 PackageId = Package.PackageRegistration.Id,
                 PackageNormalizedVersion = Package.NormalizedVersion,
                 PackageValidations = new List<PackageValidation>


### PR DESCRIPTION
Updates jobs to the latest validation database entities, which had breaking changes.

See: https://github.com/NuGet/ServerCommon/pull/357

Part of: https://github.com/NuGet/Engineering/issues/3576