### PR TITLE
Update NuGetGallery.Core and use version-specific ID in Db2AzureSearch

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
     <ServerCommonPackageVersion>2.86.0</ServerCommonPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-jver-caseofcase-4628723</NuGetGalleryPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
     <ServerCommonPackageVersion>2.86.0</ServerCommonPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-jver-caseofcase-4628723</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-dev-4633971</NuGetGalleryPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -64,7 +64,7 @@
       <Version>0.7.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Entities">
-      <Version>4.4.5-dev-4589840</Version>
+      <Version>$(NuGetGalleryPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Services.Logging">
       <Version>$(ServerCommonPackageVersion)</Version>

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -93,7 +93,7 @@
       <Version>0.32.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4589840</Version>
+      <Version>$(NuGetGalleryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
@@ -85,6 +85,10 @@ namespace NuGet.Services.AzureSearch
             string packageId,
             Package package)
         {
+            // If the version-specific ID is available, use it. Not all records have this value populated so fall back
+            // to whatever package ID casing is provided.
+            packageId = package.Id ?? packageId;
+
             document.Authors = package.FlattenedAuthors;
             document.Copyright = package.Copyright;
             document.Created = AssumeUtc(package.Created);

--- a/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
+++ b/src/Stats.CDNLogsSanitizer/Stats.CDNLogsSanitizer.csproj
@@ -67,7 +67,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4589840</Version>
+      <Version>$(NuGetGalleryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -37,7 +37,7 @@
       <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="NuGetGallery.Core">
-      <Version>4.4.5-dev-4589840</Version>
+      <Version>$(NuGetGalleryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
The Db2AzureSearch was very easy so I opted to pull it in as well. 

Progress on https://github.com/NuGet/NuGetGallery/issues/3349.