### PR TITLE
[Signing] Test expired signing certificates in the process signature job

### DIFF
--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -209,6 +209,24 @@ namespace Validation.PackageSigning.Core.Tests.Support
             return new UntrustedSigningCertificate(untrustedRootCertificate, certificate, disposable);
         }
 
+        public async Task<X509Certificate2> CreateExpiringSigningCertificateAsync()
+        {
+            var ca = await _certificateAuthority.Value;
+
+            void CustomizeExpiringSigningCertificate(X509V3CertificateGenerator generator)
+            {
+                generator.AddSigningEku();
+                generator.AddAuthorityInfoAccess(ca, addOcsp: true, addCAIssuers: true);
+
+                generator.SetNotBefore(DateTime.UtcNow.AddSeconds(-2));
+                generator.SetNotAfter(DateTime.UtcNow.AddSeconds(10));
+            }
+
+            var (@public, certificate) = IssueCertificate(ca, "Expired Signing", CustomizeExpiringSigningCertificate);
+
+            return certificate;
+        }
+
         public async Task<CustomTimestampService> CreateCustomTimestampServiceAsync(TimestampServiceOptions options)
         {
             var testServer = await _testServer.Value;


### PR DESCRIPTION
The old repository signing certificate will expire on April 14th, 2021. Regardless, we should be able to revalidate packages signed with the old repository signing certificate. This adds tests to ensure that expired signing certificates are accepted by the Process Signature job.

Note that nuget.org rejects expired certificates for new uploads. This is done by the Validate Certificate job, and tested here:

https://github.com/NuGet/NuGet.Jobs/blob/376ac06e6e07d4ee8d1e28f6b2346e3891487496/tests/Validation.PackageSigning.ValidateCertificate.Tests/SignatureDeciderFactoryFacts.cs#L311-L316

Addresses https://github.com/NuGet/Engineering/issues/3714