### PR TITLE
v3 search: Return package owners

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
@@ -64,6 +64,10 @@ namespace NuGet.Services.AzureSearch.SearchService
         [JsonPropertyName("authors")]
         public string[] Authors { get; set; }
 
+        [JsonProperty("owners")]
+        [JsonPropertyName("owners")]
+        public string[] Owners { get; set; }
+
         [JsonProperty("totalDownloads")]
         [JsonPropertyName("totalDownloads")]
         public long TotalDownloads { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -377,6 +377,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 ProjectUrl = result.ProjectUrl,
                 Tags = result.Tags ?? Array.Empty<string>(),
                 Authors = new[] { result.Authors ?? string.Empty },
+                Owners = result.Owners ?? Array.Empty<string>(),
                 TotalDownloads = AuxiliaryData.GetTotalDownloadCount(result.PackageId),
                 Verified = AuxiliaryData.IsVerified(result.PackageId),
                 PackageTypes = GetV3SearchPackageTypes(result),

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -682,6 +682,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 doc.Summary = null;
                 doc.Tags = null;
                 doc.Authors = null;
+                doc.Owners = null;
 
                 var response = Target.V3FromSearch(
                     _v3Request,
@@ -695,6 +696,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(string.Empty, result.Summary);
                 Assert.Empty(result.Tags);
                 Assert.Equal(string.Empty, Assert.Single(result.Authors));
+                Assert.Empty(result.Owners);
             }
 
             [Fact]
@@ -884,6 +886,10 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""authors"": [
         ""Microsoft""
       ],
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
+      ],
       ""totalDownloads"": 1001,
       ""verified"": true,
       ""packageTypes"": [
@@ -1057,6 +1063,10 @@ namespace NuGet.Services.AzureSearch.SearchService
       ],
       ""authors"": [
         ""Microsoft""
+      ],
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
       ],
       ""totalDownloads"": 1001,
       ""verified"": true,


### PR DESCRIPTION
Added the "owners" array to search result, see https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result

Closes https://github.com/NuGet/NuGetGallery/issues/5647
