### PR TITLE
[Search] Add feature flag to disable deep paging

### DIFF
--- a/src/NuGet.Services.AzureSearch/FeatureFlagService.cs
+++ b/src/NuGet.Services.AzureSearch/FeatureFlagService.cs
@@ -10,16 +10,21 @@ namespace NuGet.Services.AzureSearch
     {
         private const string SearchPrefix = "Search.";
 
-        private readonly IFeatureFlagClient _featureFlagClient;
+        private readonly IFeatureFlagClient _features;
 
-        public FeatureFlagService(IFeatureFlagClient featureFlagClient)
+        public FeatureFlagService(IFeatureFlagClient features)
         {
-            _featureFlagClient = featureFlagClient ?? throw new ArgumentNullException(nameof(featureFlagClient));
+            _features = features ?? throw new ArgumentNullException(nameof(features));
         }
 
         public bool IsPopularityTransferEnabled()
         {
-            return _featureFlagClient.IsEnabled(SearchPrefix + "TransferPopularity", defaultValue: true);
+            return _features.IsEnabled(SearchPrefix + "TransferPopularity", defaultValue: true);
+        }
+
+        public bool IsDeepPagingDisabled()
+        {
+            return _features.IsEnabled(SearchPrefix + "DisableDeepPaging", defaultValue: false);
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/IFeatureFlagService.cs
+++ b/src/NuGet.Services.AzureSearch/IFeatureFlagService.cs
@@ -6,5 +6,7 @@ namespace NuGet.Services.AzureSearch
     public interface IFeatureFlagService
     {
         bool IsPopularityTransferEnabled();
+
+        bool IsDeepPagingDisabled();
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Microsoft.Extensions.Options;
+using NuGet.Packaging;
 using NuGet.Versioning;
 
 namespace NuGet.Services.AzureSearch.SearchService

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-using NuGet.Packaging;
+using Microsoft.Extensions.Options;
 using NuGet.Versioning;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -18,13 +18,19 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         private readonly ISearchTextBuilder _textBuilder;
         private readonly ISearchParametersBuilder _parametersBuilder;
+        private readonly IFeatureFlagService _features;
+        private readonly IOptionsSnapshot<SearchServiceConfiguration> _options;
 
         public IndexOperationBuilder(
             ISearchTextBuilder textBuilder,
-            ISearchParametersBuilder parametersBuilder)
+            ISearchParametersBuilder parametersBuilder,
+            IFeatureFlagService features,
+            IOptionsSnapshot<SearchServiceConfiguration> options)
         {
             _textBuilder = textBuilder ?? throw new ArgumentNullException(nameof(textBuilder));
             _parametersBuilder = parametersBuilder ?? throw new ArgumentNullException(nameof(parametersBuilder));
+            _features = features ?? throw new ArgumentNullException(nameof(features));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         public IndexOperation V3Search(V3SearchRequest request)
@@ -91,7 +97,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public IndexOperation Autocomplete(AutocompleteRequest request)
         {
-            if (HasInvalidParameters(request, request.PackageType))
+            if (HasInvalidParameters(request, MaximumSkip, request.PackageType))
             {
                 return IndexOperation.Empty();
             }
@@ -178,12 +184,40 @@ namespace NuGet.Services.AzureSearch.SearchService
             return false;
         }
 
-        private static bool HasInvalidParameters(SearchRequest request, string packageType)
+        private bool HasInvalidParameters(V2SearchRequest request, string packageType)
         {
-            // Requests with bad parameters yield no results. For the package type case, by specification a package type
+            var skipLimit = _features.IsDeepPagingDisabled()
+                ? Math.Min(_options.Value.V2DeepPagingLimit, MaximumSkip)
+                : MaximumSkip;
+
+            return HasInvalidParameters(request, skipLimit, packageType);
+        }
+
+        private bool HasInvalidParameters(V3SearchRequest request, string packageType)
+        {
+            var skipLimit = _features.IsDeepPagingDisabled()
+                ? Math.Min(_options.Value.V3DeepPagingLimit, MaximumSkip)
+                : MaximumSkip;
+
+            return HasInvalidParameters(request, skipLimit, packageType);
+        }
+
+        private static bool HasInvalidParameters(SearchRequest request, int skipLimit, string packageType)
+        {
+            // Requests with bad parameters yield no results.
+            if (request.Skip > skipLimit)
+            {
+                return true;
+            }
+
+            // For the package type case, by specification a package type
             // valid characters are the same as a package ID.
-            return request.Skip > MaximumSkip
-                || (packageType != null && !PackageIdValidator.IsValidPackageId(packageType));
+            if (packageType != null && !PackageIdValidator.IsValidPackageId(packageType))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool PagedToFirstItem(SearchRequest request)

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -19,5 +19,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public TimeSpan SecretRefreshFailureRetryFrequency { get; set; } = TimeSpan.FromMinutes(5);
         public string DeploymentLabel { get; set; }
         public List<string> TestOwners { get; set; } = new List<string>();
+        public int V2DeepPagingLimit { get; set; } = 30_000;
+        public int V3DeepPagingLimit { get; set; } = 3_000;
     }
 }

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -11,11 +10,10 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.PackageManagement.Search.Web;
+using NuGet.Jobs.Validation;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.Logging;
@@ -26,6 +24,7 @@ namespace NuGet.Services.SearchService
     public class Startup
     {
         private const string ConfigurationSectionName = "SearchService";
+        private const string FeatureFlagSectionName = "FeatureFlags";
 
         public Startup(IConfiguration configuration)
         {
@@ -56,6 +55,7 @@ namespace NuGet.Services.SearchService
 
             services.Configure<AzureSearchConfiguration>(Configuration.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(Configuration.GetSection(ConfigurationSectionName));
+            services.Configure<FeatureFlagConfiguration>(Configuration.GetSection(FeatureFlagSectionName));
 
             services.AddApplicationInsightsTelemetry(o =>
             {
@@ -76,6 +76,7 @@ namespace NuGet.Services.SearchService
 
             services.AddHostedService<AuxiliaryFileReloaderBackgroundService>();
             services.AddHostedService<SecretRefresherBackgroundService>();
+            services.AddHostedService<FeatureFlagBackgroundService>();
 
             services.AddAzureSearch(new Dictionary<string, string>());
 

--- a/src/NuGet.Services.SearchService.Core/Support/FeatureFlagBackgroundService.cs
+++ b/src/NuGet.Services.SearchService.Core/Support/FeatureFlagBackgroundService.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NuGet.Services.FeatureFlags;
+
+namespace NuGet.Services.SearchService
+{
+    public class FeatureFlagBackgroundService : BackgroundService
+    {
+        private readonly IFeatureFlagCacheService _flagsCache;
+
+        public FeatureFlagBackgroundService(IFeatureFlagCacheService flagsCache)
+        {
+            _flagsCache = flagsCache ?? throw new ArgumentNullException(nameof(flagsCache));
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            await _flagsCache.RunAsync(stoppingToken);
+        }
+    }
+}

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.Search.Models;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -28,6 +29,16 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Same(Parameters, actual.SearchParameters);
                 TextBuilder.Verify(x => x.Autocomplete(AutocompleteRequest), Times.Once);
                 ParametersBuilder.Verify(x => x.Autocomplete(AutocompleteRequest, It.IsAny<bool>()), Times.Once);
+            }
+
+            [Fact]
+            public void ReturnsEmptyQueryIfPastSkipLimit()
+            {
+                AutocompleteRequest.Skip = 100_001;
+
+                var actual = Build();
+
+                Assert.Equal(IndexOperationType.Empty, actual.Type);
             }
 
             [Fact]
@@ -68,6 +79,26 @@ namespace NuGet.Services.AzureSearch.SearchService
                 TextBuilder.Verify(x => x.ParseV3Search(V3SearchRequest), Times.Once);
                 TextBuilder.Verify(x => x.Build(ParsedQuery), Times.Once);
                 ParametersBuilder.Verify(x => x.V3Search(V3SearchRequest, It.IsAny<bool>()), Times.Once);
+            }
+
+            [Theory]
+            [InlineData(false, 3_001, IndexOperationType.Search)]
+            [InlineData(false, 100_001, IndexOperationType.Empty)]
+            [InlineData(true, 3_001, IndexOperationType.Empty)]
+            [InlineData(true, 100_001, IndexOperationType.Empty)]
+
+            public void ReturnsEmptyQueryIfPastSkipLimit(bool disableDeepPaging, int skip, IndexOperationType expectedType)
+            {
+                Config.V3DeepPagingLimit = 3_000;
+                V3SearchRequest.Skip = skip;
+
+                Features
+                    .Setup(f => f.IsDeepPagingDisabled())
+                    .Returns(disableDeepPaging);
+
+                var actual = Build();
+
+                Assert.Equal(expectedType, actual.Type);
             }
 
             [Fact]
@@ -119,6 +150,26 @@ namespace NuGet.Services.AzureSearch.SearchService
                 TextBuilder.Verify(x => x.ParseV2Search(V2SearchRequest), Times.Once);
                 TextBuilder.Verify(x => x.Build(ParsedQuery), Times.Once);
                 ParametersBuilder.Verify(x => x.V2Search(V2SearchRequest, It.IsAny<bool>()), Times.Once);
+            }
+
+            [Theory]
+            [InlineData(false, 30_001, IndexOperationType.Search)]
+            [InlineData(false, 100_001, IndexOperationType.Empty)]
+            [InlineData(true, 30_001, IndexOperationType.Empty)]
+            [InlineData(true, 100_001, IndexOperationType.Empty)]
+
+            public void ReturnsEmptyQueryIfPastSkipLimit(bool disableDeepPaging, int skip, IndexOperationType expectedType)
+            {
+                Config.V2DeepPagingLimit = 30_000;
+                V2SearchRequest.Skip = skip;
+
+                Features
+                    .Setup(f => f.IsDeepPagingDisabled())
+                    .Returns(disableDeepPaging);
+
+                var actual = Build();
+
+                Assert.Equal(expectedType, actual.Type);
             }
 
             [Fact]
@@ -508,6 +559,13 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 TextBuilder = new Mock<ISearchTextBuilder>();
                 ParametersBuilder = new Mock<ISearchParametersBuilder>();
+                Features = new Mock<IFeatureFlagService>();
+                Config = new SearchServiceConfiguration();
+
+                var options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
+                options
+                    .Setup(o => o.Value)
+                    .Returns(() => Config);
 
                 AutocompleteRequest = new AutocompleteRequest { Skip = 0, Take = 20 };
                 V2SearchRequest = new V2SearchRequest { Skip = 0, Take = 20 };
@@ -540,11 +598,15 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 Target = new IndexOperationBuilder(
                     TextBuilder.Object,
-                    ParametersBuilder.Object);
+                    ParametersBuilder.Object,
+                    Features.Object,
+                    options.Object);
             }
 
             public Mock<ISearchTextBuilder> TextBuilder { get; }
             public Mock<ISearchParametersBuilder> ParametersBuilder { get; }
+            public Mock<IFeatureFlagService> Features { get; }
+            public SearchServiceConfiguration Config { get; }
             public AutocompleteRequest AutocompleteRequest { get; }
             public V2SearchRequest V2SearchRequest { get; }
             public V3SearchRequest V3SearchRequest { get; }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/IndexOperationBuilderFacts.cs
@@ -82,8 +82,10 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
+            [InlineData(false, 3_000, IndexOperationType.Search)]
             [InlineData(false, 3_001, IndexOperationType.Search)]
             [InlineData(false, 100_001, IndexOperationType.Empty)]
+            [InlineData(true, 3_000, IndexOperationType.Search)]
             [InlineData(true, 3_001, IndexOperationType.Empty)]
             [InlineData(true, 100_001, IndexOperationType.Empty)]
 
@@ -153,8 +155,10 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
+            [InlineData(false, 30_000, IndexOperationType.Search)]
             [InlineData(false, 30_001, IndexOperationType.Search)]
             [InlineData(false, 100_001, IndexOperationType.Empty)]
+            [InlineData(true, 30_000, IndexOperationType.Search)]
             [InlineData(true, 30_001, IndexOperationType.Empty)]
             [InlineData(true, 100_001, IndexOperationType.Empty)]
 


### PR DESCRIPTION
## Background

Search request with high skip values are particularly expensive for Azure Search. This results in throttling of our resources, causing availability issues. This problem is referred to as "deep paging".

This change allows us to disable deep paging using nuget.org's feature flag system. 

## Relevant links

Relevant changes:

* Configuration changes: TODO
* Docs change: https://github.com/NuGet/docs.microsoft.com-nuget/pull/2442
* Announcement: TODO 

Part of: https://github.com/NuGet/Engineering/issues/3776

## Testing

* [x] Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4804587&view=results
* [x] DEV deployment: https://devdiv.visualstudio.com/DevDiv/_apps/hub/ms.vss-releaseManagement-web.cd-release-progress?releaseId=1048929&_a=release-pipeline-progress