### PR TITLE
[Hotfix] [Search] Fix CORS

### DIFF
--- a/src/Microsoft.PackageManagement.Search.Web/StartupHelper.cs
+++ b/src/Microsoft.PackageManagement.Search.Web/StartupHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -57,7 +58,10 @@ namespace Microsoft.PackageManagement.Search.Web
             };
         }
 
-        public static void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public static void Configure(
+            IApplicationBuilder app,
+            IWebHostEnvironment env,
+            Action<CorsPolicyBuilder> configureCors = null)
         {
             if (env.IsDevelopment())
             {
@@ -65,6 +69,11 @@ namespace Microsoft.PackageManagement.Search.Web
             }
 
             app.UseRouting();
+
+            if (configureCors != null)
+            {
+                app.UseCors(configureCors);
+            }
 
             app.UseHsts();
 

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -11,10 +10,8 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.PackageManagement.Search.Web;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
@@ -97,13 +94,14 @@ namespace NuGet.Services.SearchService
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            StartupHelper.Configure(app, env);
-
-            app.UseCors(cors => cors
-                .AllowAnyOrigin()
-                .WithHeaders("Content-Type", "If-Match", "If-Modified-Since", "If-None-Match", "If-Unmodified-Since", "Accept-Encoding")
-                .WithMethods("GET", "HEAD", "OPTIONS")
-                .WithExposedHeaders("Content-Type", "Content-Length", "Last-Modified", "Transfer-Encoding", "ETag", "Date", "Vary", "Server", "X-Hit", "X-CorrelationId"));
+            StartupHelper.Configure(
+                app,
+                env,
+                cors => cors
+                    .AllowAnyOrigin()
+                    .WithHeaders("Content-Type", "If-Match", "If-Modified-Since", "If-None-Match", "If-Unmodified-Since", "Accept-Encoding")
+                    .WithMethods("GET", "HEAD", "OPTIONS")
+                    .WithExposedHeaders("Content-Type", "Content-Length", "Last-Modified", "Transfer-Encoding", "ETag", "Date", "Vary", "Server", "X-Hit", "X-CorrelationId"));
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
@@ -130,7 +130,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
 
             // The result count should be different for included prerelease results, 
             // else it means the search term responded with same results i.e. no results have prerelease versions
-            Assert.True(resultsWithPrerelease.TotalHits > resultsWithoutPrerelease.TotalHits, 
+            Assert.True(resultsWithPrerelease.TotalHits > resultsWithoutPrerelease.TotalHits,
                 $"The search term {searchTerm} does not seem to have any prerelease versions in the search index.");
 
             var hasPrereleaseVersions = resultsWithPrerelease
@@ -427,6 +427,27 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
             {
                 return Enumerable.Range(1, 10).Select(i => new object[] { i });
             }
+        }
+
+        [Fact]
+        public async Task EnablesCors()
+        {
+            // Arrange
+            Client.DefaultRequestHeaders.Add("Origin", "https://foo.test");
+
+            // Act
+            var response = await Client.GetAsync("/query");
+
+            // Assert
+            Assert.True(response.Headers.Contains("Access-Control-Allow-Origin"));
+            var allowedOrigin = Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin"));
+            Assert.Equal("*", allowedOrigin);
+
+            Assert.True(response.Headers.Contains("Access-Control-Expose-Headers"));
+            var exposedHeaders = Assert.Single(response.Headers.GetValues("Access-Control-Expose-Headers"));
+            Assert.Equal(
+                "Content-Type,Content-Length,Last-Modified,Transfer-Encoding,ETag,Date,Vary,Server,X-Hit,X-CorrelationId",
+                exposedHeaders);
         }
     }
 }


### PR DESCRIPTION
# Background

In https://github.com/NuGet/NuGet.Jobs/pull/979 we refactored nuget.org's search service to share code with the Visual Studio Marketplace. This change incorrectly moved the CORS middleware to the end of the HTTP pipeline, after the terminal `UseEndpoints` middleware is added. As a result, CORS headers were no longer added to our responses. For more information, see: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-5.0#middleware-order 

This bug was caught by @clairernovotny. See: https://github.com/nuget/engineering/issues/3914

# Test

Added a new functional test to verify CORS headers, and deployed to DEV.

Build:  https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4863162&view=results
Release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1065543

