### PR TITLE
[Hotfix] [CDN Import] Improve error logs for parsing failures

### DIFF
--- a/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
+++ b/src/Stats.ImportAzureCdnStatistics/LogFileProcessor.cs
@@ -183,11 +183,11 @@ namespace Stats.ImportAzureCdnStatistics
                                 lineNumber,
                                 rawLogLine,
                                 (e, line) => _logger.LogError(
-                                    LogEvents.FailedToParseLogFileEntry,
                                     e,
-                                    LogMessages.ParseLogEntryLineFailed,
+                                    "Failed to parse W3C log entry in {LogFileName} at line {LineNumber}: {RawLogLine}",
                                     fileName,
-                                    line));
+                                    line,
+                                    rawLogLine));
 
                             if (logEntry != null)
                             {


### PR DESCRIPTION
The on-call needs to go and download an entire CDN logs blob to investigate a parsing failure, which is very work intensive. Instead, we can log the offending line. Note that all PII has been stripped from CDN logs by the time the blob reaches the ImportAzureCdnStatistics job. 

Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4895580&view=results
DEV release: https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1074117