### PR TITLE
Add owners property to V3 search and wrap in feature flag

### DIFF
--- a/src/NuGet.Services.AzureSearch/FeatureFlagService.cs
+++ b/src/NuGet.Services.AzureSearch/FeatureFlagService.cs
@@ -26,5 +26,10 @@ namespace NuGet.Services.AzureSearch
         {
             return _features.IsEnabled(SearchPrefix + "DisableDeepPaging", defaultValue: false);
         }
+
+        public bool IsV3OwnersPropertyEnabled()
+        {
+            return _features.IsEnabled(SearchPrefix + "V3Owners", defaultValue: false);
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/IFeatureFlagService.cs
+++ b/src/NuGet.Services.AzureSearch/IFeatureFlagService.cs
@@ -8,5 +8,7 @@ namespace NuGet.Services.AzureSearch
         bool IsPopularityTransferEnabled();
 
         bool IsDeepPagingDisabled();
+
+        bool IsV3OwnersPropertyEnabled();
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
@@ -64,6 +64,10 @@ namespace NuGet.Services.AzureSearch.SearchService
         [JsonPropertyName("authors")]
         public string[] Authors { get; set; }
 
+        [JsonProperty("owners")]
+        [JsonPropertyName("owners")]
+        public string[] Owners { get; set; }
+
         [JsonProperty("totalDownloads")]
         [JsonPropertyName("totalDownloads")]
         public long TotalDownloads { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -377,6 +377,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 ProjectUrl = result.ProjectUrl,
                 Tags = result.Tags ?? Array.Empty<string>(),
                 Authors = new[] { result.Authors ?? string.Empty },
+                Owners = result.Owners ?? Array.Empty<string>(),
                 TotalDownloads = AuxiliaryData.GetTotalDownloadCount(result.PackageId),
                 Verified = AuxiliaryData.IsVerified(result.PackageId),
                 PackageTypes = GetV3SearchPackageTypes(result),

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -682,6 +682,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 doc.Summary = null;
                 doc.Tags = null;
                 doc.Authors = null;
+                doc.Owners = null;
 
                 var response = Target.V3FromSearch(
                     _v3Request,
@@ -695,6 +696,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(string.Empty, result.Summary);
                 Assert.Empty(result.Tags);
                 Assert.Equal(string.Empty, Assert.Single(result.Authors));
+                Assert.Empty(result.Owners);
             }
 
             [Fact]
@@ -884,6 +886,10 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""authors"": [
         ""Microsoft""
       ],
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
+      ],
       ""totalDownloads"": 1001,
       ""verified"": true,
       ""packageTypes"": [
@@ -1057,6 +1063,10 @@ namespace NuGet.Services.AzureSearch.SearchService
       ],
       ""authors"": [
         ""Microsoft""
+      ],
+      ""owners"": [
+        ""Microsoft"",
+        ""azure-sdk""
       ],
       ""totalDownloads"": 1001,
       ""verified"": true,

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -675,6 +675,22 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Fact]
+            public void DoesNotIncludeOwnersWhenFeatureIsOff()
+            {
+                _featureFlagService.Setup(x => x.IsV3OwnersPropertyEnabled()).Returns(false);
+                var doc = _searchResult.Results[0].Document;
+
+                var response = Target.V3FromSearch(
+                    _v3Request,
+                    _text,
+                    _searchParameters,
+                    _searchResult,
+                    _duration);
+
+                Assert.Null(response.Data[0].Owners);
+            }
+
+            [Fact]
             public void CoalescesSomeNullFields()
             {
                 var doc = _searchResult.Results[0].Document;
@@ -1118,6 +1134,21 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Fact]
+            public void DoesNotIncludeOwnersWhenFeatureIsOff()
+            {
+                _featureFlagService.Setup(x => x.IsV3OwnersPropertyEnabled()).Returns(false);
+                var doc = _searchResult.Results[0].Document;
+
+                var response = Target.V3FromSearchDocument(
+                    _v3Request,
+                    doc.Key,
+                    doc,
+                    _duration);
+
+                Assert.Null(response.Data[0].Owners);
+            }
+
+            [Fact]
             public void LeavesNullIconUrlWithFlatContainerIconsButNullOriginalIconUrl()
             {
                 _config.AllIconsInFlatContainer = true;
@@ -1385,6 +1416,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public abstract class BaseFacts
         {
             protected readonly Mock<IAuxiliaryData> _auxiliaryData;
+            protected readonly Mock<IFeatureFlagService> _featureFlagService;
             protected readonly SearchServiceConfiguration _config;
             protected readonly Mock<IOptionsSnapshot<SearchServiceConfiguration>> _options;
             protected readonly V2SearchRequest _v2Request;
@@ -1402,6 +1434,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             public SearchResponseBuilder Target => new SearchResponseBuilder(
                 new Lazy<IAuxiliaryData>(() => _auxiliaryData.Object),
+                _featureFlagService.Object,
                 _options.Object);
 
             public static IEnumerable<object[]> MissingTitles = new[]
@@ -1415,6 +1448,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             public BaseFacts()
             {
                 _auxiliaryData = new Mock<IAuxiliaryData>();
+                _featureFlagService = new Mock<IFeatureFlagService>();
                 _config = new SearchServiceConfiguration();
                 _options = new Mock<IOptionsSnapshot<SearchServiceConfiguration>>();
                 _options.Setup(x => x.Value).Returns(() => _config);
@@ -1458,6 +1492,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 _auxiliaryData
                     .Setup(x => x.GetPopularityTransfers(It.IsAny<string>()))
                     .Returns(() => new[] { "transfer1", "transfer2" });
+                _featureFlagService.SetReturnsDefault<bool>(true);
 
                 _v2Request = new V2SearchRequest
                 {


### PR DESCRIPTION
Adds a feature flag to https://github.com/NuGet/NuGet.Jobs/pull/980 and brings the change into `dev`.

Address https://github.com/NuGet/NuGetGallery/issues/5647.

Allows client software to know the package owners which is a secured property, whereas `authors` is spoofable.