### PR TITLE
Add ignoreList  to GHIndexer

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace NuGet.Jobs.GitHubIndexer
 {
@@ -46,5 +47,10 @@ namespace NuGet.Jobs.GitHubIndexer
         /// How long to sleep after succeeding. If the job fails this setting will be ignored.
         /// </summary>
         public TimeSpan SleepAfterSuccess { get; set; }
+
+        /// <summary>
+        /// The list of repositories to be ignored by the indexing job. ("{repoOwner}/{repoName}")
+        /// </summary>
+        public HashSet<string> IgnoreList {  get; set; }
     }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
@@ -51,6 +51,6 @@ namespace NuGet.Jobs.GitHubIndexer
         /// <summary>
         /// The list of repositories to be ignored by the indexing job. ("{repoOwner}/{repoName}")
         /// </summary>
-        public HashSet<string> IgnoreList {  get; set; }
+        public HashSet<string> IgnoreList { get; set; }
     }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
@@ -135,10 +135,12 @@ namespace NuGet.Jobs.GitHubIndexer
                     }
 
                     // TODO: Block unwanted repos (https://github.com/NuGet/NuGetGallery/issues/7298)
-                    resultList.AddRange(response);
+                    var ignoreList = _configuration.Value.IgnoreList;
+                    var filteredRepoList = response.Where(x => !ignoreList.Contains(x.Id));
+                    resultList.AddRange(filteredRepoList);
                     page++;
 
-                    if (page == lastPage && response.First().Stars == response.Last().Stars)
+                    if (page == (int) lastPage && response.First().Stars == response.Last().Stars)
                     {
                         // GitHub throttles us after a certain number of results per query.
                         // We can only construct queries based on number of stars a repository has.

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
@@ -134,13 +134,20 @@ namespace NuGet.Jobs.GitHubIndexer
                         return resultList;
                     }
 
-                    // TODO: Block unwanted repos (https://github.com/NuGet/NuGetGallery/issues/7298)
                     var ignoreList = _configuration.Value.IgnoreList;
-                    var filteredRepoList = response.Where(x => !ignoreList.Contains(x.Id, StringComparer.OrdinalIgnoreCase));
+                    var filteredRepoList = response.Where(x =>
+                    {
+                        var isValidRepo = !ignoreList.Contains(x.Id, StringComparer.OrdinalIgnoreCase);
+                        if (!isValidRepo)
+                        {
+                            _logger.LogInformation("Found {RepoName} in the ignore list", x.Id);
+                        }
+                        return isValidRepo;
+                    });
                     resultList.AddRange(filteredRepoList);
                     page++;
 
-                    if (page == (int) lastPage && response.First().Stars == response.Last().Stars)
+                    if (page == (int)lastPage && response.First().Stars == response.Last().Stars)
                     {
                         // GitHub throttles us after a certain number of results per query.
                         // We can only construct queries based on number of stars a repository has.

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearcher.cs
@@ -136,7 +136,7 @@ namespace NuGet.Jobs.GitHubIndexer
 
                     // TODO: Block unwanted repos (https://github.com/NuGet/NuGetGallery/issues/7298)
                     var ignoreList = _configuration.Value.IgnoreList;
-                    var filteredRepoList = response.Where(x => !ignoreList.Contains(x.Id));
+                    var filteredRepoList = response.Where(x => !ignoreList.Contains(x.Id, StringComparer.OrdinalIgnoreCase));
                     resultList.AddRange(filteredRepoList);
                     page++;
 

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearcherFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/GitHubSearcherFacts.cs
@@ -165,7 +165,8 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                     // Add all the even numbered repos to the ignore list
                     if (i % 2 == 0)
                     {
-                        ignoreList.Add(repoName);
+                        // Mixing the naming case to test for case-insensitivity
+                        ignoreList.Add(i % 4 == 0 ? repoName.ToUpper() : repoName);
                     }
                 }
 
@@ -206,7 +207,7 @@ namespace NuGet.Jobs.GitHubIndexer.Tests
                   };
 
                 var res = await GetMockClient(mockTelemetry, mockGitHubSearch, _configuration).GetPopularRepositories();
-                var expectedFilteredResults = items.Where(x => !ignoreList.Contains(x.Id)).ToList();
+                var expectedFilteredResults = items.Where(x => !ignoreList.Contains(x.Id, StringComparer.OrdinalIgnoreCase)).ToList();
                 Assert.Equal(expectedFilteredResults.Count, res.Count);
 
                 for (int resIdx = 0; resIdx < res.Count; resIdx++)


### PR DESCRIPTION
This PR adds an ignore list to the github indexer job to be able to filter out unwanted repositories from being indexed.