### PR TITLE
Additional location for totals report

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/Configuration/CreateAzureCdnWarehouseReportsConfiguration.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Configuration/CreateAzureCdnWarehouseReportsConfiguration.cs
@@ -13,9 +13,9 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
         public string DataContainerName { get; set; }
 
-        public string AdditionalGalleryTotalsAccount { get; set; }
+        public string AdditionalGalleryTotalsStorageAccount { get; set; }
 
-        public string AdditionalGalleryTotalsContainerName { get; set; }
+        public string AdditionalGalleryTotalsStorageContainerName { get; set; }
 
         public int? CommandTimeOut { get; set; }
 

--- a/src/Stats.CreateAzureCdnWarehouseReports/Configuration/CreateAzureCdnWarehouseReportsConfiguration.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Configuration/CreateAzureCdnWarehouseReportsConfiguration.cs
@@ -13,6 +13,10 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
         public string DataContainerName { get; set; }
 
+        public string AdditionalGalleryTotalsAccount { get; set; }
+
+        public string AdditionalGalleryTotalsContainerName { get; set; }
+
         public int? CommandTimeOut { get; set; }
 
         public int? PerPackageReportDegreeOfParallelism { get; set; }

--- a/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
@@ -208,6 +208,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 if (_additionalGalleryTotalsAccount != null && !string.IsNullOrWhiteSpace(_additionalGalleryTotalsContainerName))
                 {
                     targets.Add(new StorageContainerTarget(_additionalGalleryTotalsAccount, _additionalGalleryTotalsContainerName));
+                    Logger.LogInformation("Added additional target for stats totals report");
                 }
                 var galleryTotalsReport = new GalleryTotalsReport(
                     LoggerFactory.CreateLogger<GalleryTotalsReport>(),

--- a/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
@@ -27,9 +27,11 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
         private CloudStorageAccount _cloudStorageAccount;
         private CloudStorageAccount _dataStorageAccount;
+        private CloudStorageAccount _additionalGalleryTotalsAccount;
         private string _statisticsContainerName;
         private string _reportNameConfig;
         private string[] _dataContainerNames;
+        private string _additionalGalleryTotalsContainerName;
         private int _sqlCommandTimeoutSeconds = DefaultSqlCommandTimeoutSeconds;
         private int _perPackageReportDegreeOfParallelism = DefaultPerPackageReportDegreeOfParallelism;
         private ApplicationInsightsHelper _applicationInsightsHelper;
@@ -84,6 +86,16 @@ namespace Stats.CreateAzureCdnWarehouseReports
             }
 
             _dataContainerNames = containerNames;
+
+            if (!string.IsNullOrWhiteSpace(configuration.AdditionalGalleryTotalsAccount))
+            {
+                _additionalGalleryTotalsAccount = ValidateAzureCloudStorageAccount(
+                    configuration.AdditionalGalleryTotalsAccount,
+                    nameof(configuration.AdditionalGalleryTotalsAccount));
+
+                _additionalGalleryTotalsContainerName = configuration.AdditionalGalleryTotalsContainerName;
+            }
+
             _applicationInsightsHelper = new ApplicationInsightsHelper(ApplicationInsightsConfiguration.TelemetryConfiguration);
         }
 
@@ -192,6 +204,10 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
                 var targets = new List<StorageContainerTarget>();
                 targets.Add(new StorageContainerTarget(_cloudStorageAccount, _statisticsContainerName));
+                if (_additionalGalleryTotalsAccount != null && !string.IsNullOrWhiteSpace(_additionalGalleryTotalsContainerName))
+                {
+                    targets.Add(new StorageContainerTarget(_additionalGalleryTotalsAccount, _additionalGalleryTotalsContainerName));
+                }
                 var galleryTotalsReport = new GalleryTotalsReport(
                     LoggerFactory.CreateLogger<GalleryTotalsReport>(),
                     targets,

--- a/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
@@ -190,10 +190,11 @@ namespace Stats.CreateAzureCdnWarehouseReports
             {
                 stopwatch = Stopwatch.StartNew();
 
+                var targets = new List<StorageContainerTarget>();
+                targets.Add(new StorageContainerTarget(_cloudStorageAccount, _statisticsContainerName));
                 var galleryTotalsReport = new GalleryTotalsReport(
                     LoggerFactory.CreateLogger<GalleryTotalsReport>(),
-                    _cloudStorageAccount,
-                    _statisticsContainerName,
+                    targets,
                     OpenSqlConnectionAsync<StatisticsDbConfiguration>,
                     OpenSqlConnectionAsync<GalleryDbConfiguration>,
                     commandTimeoutSeconds: _sqlCommandTimeoutSeconds);

--- a/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
@@ -87,14 +87,14 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
             _dataContainerNames = containerNames;
 
-            if (!string.IsNullOrWhiteSpace(configuration.AdditionalGalleryTotalsAccount))
+            if (!string.IsNullOrWhiteSpace(configuration.AdditionalGalleryTotalsStorageAccount))
             {
                 _additionalGalleryTotalsAccount = ValidateAzureCloudStorageAccount(
-                    configuration.AdditionalGalleryTotalsAccount,
-                    nameof(configuration.AdditionalGalleryTotalsAccount));
+                    configuration.AdditionalGalleryTotalsStorageAccount,
+                    nameof(configuration.AdditionalGalleryTotalsStorageAccount));
                 Logger.LogInformation("Additional totals account found {BlobEndpoint}", _additionalGalleryTotalsAccount.BlobEndpoint);
 
-                _additionalGalleryTotalsContainerName = configuration.AdditionalGalleryTotalsContainerName;
+                _additionalGalleryTotalsContainerName = configuration.AdditionalGalleryTotalsStorageContainerName;
             }
 
             _applicationInsightsHelper = new ApplicationInsightsHelper(ApplicationInsightsConfiguration.TelemetryConfiguration);
@@ -208,7 +208,9 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 if (_additionalGalleryTotalsAccount != null && !string.IsNullOrWhiteSpace(_additionalGalleryTotalsContainerName))
                 {
                     targets.Add(new StorageContainerTarget(_additionalGalleryTotalsAccount, _additionalGalleryTotalsContainerName));
-                    Logger.LogInformation("Added additional target for stats totals report");
+                    Logger.LogInformation("Added additional target for stats totals report {BlobEndpoint}/{Container}",
+                        _additionalGalleryTotalsAccount.BlobEndpoint,
+                        _additionalGalleryTotalsContainerName);
                 }
                 var galleryTotalsReport = new GalleryTotalsReport(
                     LoggerFactory.CreateLogger<GalleryTotalsReport>(),

--- a/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
@@ -92,6 +92,7 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 _additionalGalleryTotalsAccount = ValidateAzureCloudStorageAccount(
                     configuration.AdditionalGalleryTotalsAccount,
                     nameof(configuration.AdditionalGalleryTotalsAccount));
+                Logger.LogInformation("Additional totals account found {BlobEndpoint}", _additionalGalleryTotalsAccount.BlobEndpoint);
 
                 _additionalGalleryTotalsContainerName = configuration.AdditionalGalleryTotalsContainerName;
             }

--- a/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
@@ -23,12 +24,11 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
         public GalleryTotalsReport(
             ILogger<GalleryTotalsReport> logger,
-            CloudStorageAccount cloudStorageAccount,
-            string statisticsContainerName,
+            ICollection<StorageContainerTarget> targets,
             Func<Task<SqlConnection>> openStatisticsSqlConnectionAsync,
             Func<Task<SqlConnection>> openGallerySqlConnectionAsync,
             int commandTimeoutSeconds)
-            : base(logger, new[] { new StorageContainerTarget(cloudStorageAccount, statisticsContainerName) },
+            : base(logger, targets,
                   openStatisticsSqlConnectionAsync, openGallerySqlConnectionAsync, commandTimeoutSeconds)
         {
         }

--- a/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
@@ -72,6 +72,8 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
             var reportText = JsonConvert.SerializeObject(totalsData);
 
+            _logger.LogInformation("num report targets: {NumStatsTotalsTargets}", Targets.Count);
+
             foreach (var storageContainerTarget in Targets)
             {
                 try

--- a/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/GalleryTotalsReport.cs
@@ -72,8 +72,6 @@ namespace Stats.CreateAzureCdnWarehouseReports
 
             var reportText = JsonConvert.SerializeObject(totalsData);
 
-            _logger.LogInformation("num report targets: {NumStatsTotalsTargets}", Targets.Count);
-
             foreach (var storageContainerTarget in Targets)
             {
                 try


### PR DESCRIPTION
Synapse pipeline currently has no way to access Gallery DB to get the data required for this report, so as a workaround we'll have this job to save a copy of the report to an additional location.

The change utilizes an existing multi-target functionality in `ReportBase` class and just passes an additional save target to it.