### PR TITLE
[Roslyn Analyzer - 2] Import Roslyn Analyzer using the environment variable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,10 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.0.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
+      <Version>6.0.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-</Project> 
+  <Import Project="$(NuGetCodeAnalyzerExtensions)" Condition="'$(NuGetCodeAnalyzerExtensions)' != '' And Exists('$(NuGetCodeAnalyzerExtensions)')" />
+</Project>

--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,7 @@ param (
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch = 'zlocal',
     [string]$CommitSHA,
-    [string]$BuildBranchCommit = 'ade39b693d49b266ec5cac5d939edac7dda2fd92'
+    [string]$BuildBranchCommit = '4e43763650ef1d3d7eb532484cc7889ce8cdfd86'
 )
 
 # For TeamCity - If any issue occurs, this script fails the build. - By default, TeamCity returns an exit code of 0 for all powershell scripts, even if they fail
@@ -66,7 +66,7 @@ Invoke-BuildStep 'Clearing package cache' { Clear-PackageCache } `
     
 Invoke-BuildStep 'Clearing artifacts' { Clear-Artifacts } `
     -ev +BuildErrors
-    
+
 Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
         $versionMetadata =
             "src\Catalog\Properties\AssemblyInfo.g.cs",
@@ -121,6 +121,9 @@ Invoke-BuildStep 'Set version metadata in AssemblyInfo.cs' { `
 Invoke-BuildStep 'Restoring solution packages' { `
     Install-SolutionPackages -path (Join-Path $PSScriptRoot ".nuget\packages.config") -output (Join-Path $PSScriptRoot "packages") -ExcludeVersion } `
     -skip:$SkipRestore `
+    -ev +BuildErrors
+
+Invoke-BuildStep 'Removing .editorconfig file' { Remove-EditorconfigFile -Directory $PSScriptRoot } `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Building solution' { 

--- a/build.ps1
+++ b/build.ps1
@@ -9,7 +9,7 @@ param (
     [string]$SemanticVersion = '1.0.0-zlocal',
     [string]$Branch = 'zlocal',
     [string]$CommitSHA,
-    [string]$BuildBranchCommit = '4e43763650ef1d3d7eb532484cc7889ce8cdfd86'
+    [string]$BuildBranchCommit = '65e723253187442f5b8ea537f672bd9328ade5a7'
 )
 
 # For TeamCity - If any issue occurs, this script fails the build. - By default, TeamCity returns an exit code of 0 for all powershell scripts, even if they fail

--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
@@ -113,7 +113,7 @@
       <Version>1.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
-      <Version>1.0.5</Version>
+      <Version>3.6.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.2</Version>


### PR DESCRIPTION
Now we use the environment variable to import MSBuild project from NuGetBuild repo for Roslyn Analyzer and its configuration.

_Update $BuildBranchCommit before checking in_