### PR TITLE
Disposing of DI container on job restart

### DIFF
--- a/src/NuGet.Jobs.Common/Configuration/FeatureFlagConfiguration.cs
+++ b/src/NuGet.Jobs.Common/Configuration/FeatureFlagConfiguration.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace NuGet.Jobs.Validation
+namespace NuGet.Jobs.Configuration
 {
     public class FeatureFlagConfiguration
     {

--- a/src/NuGet.Jobs.Common/FeatureFlags/FeatureFlagRefresher.cs
+++ b/src/NuGet.Jobs.Common/FeatureFlags/FeatureFlagRefresher.cs
@@ -6,9 +6,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NuGet.Jobs.Configuration;
 using NuGet.Services.FeatureFlags;
 
-namespace NuGet.Jobs.Validation
+namespace NuGet.Jobs
 {
     public class FeatureFlagRefresher : IFeatureFlagRefresher
     {

--- a/src/NuGet.Jobs.Common/FeatureFlags/FeatureFlagTelemetryService.cs
+++ b/src/NuGet.Jobs.Common/FeatureFlags/FeatureFlagTelemetryService.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Services.FeatureFlags;
+using NuGet.Services.Logging;
+
+namespace NuGet.Jobs
+{
+    public class FeatureFlagTelemetryService : IFeatureFlagTelemetryService
+    {
+        private const string FeatureFlagStalenessSeconds = "FeatureFlagStalenessSeconds";
+
+        protected readonly ITelemetryClient _telemetryClient;
+
+        public FeatureFlagTelemetryService(ITelemetryClient telemetryClient)
+        {
+            _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        }
+
+        public void TrackFeatureFlagStaleness(TimeSpan staleness)
+        {
+            _telemetryClient.TrackMetric(
+                FeatureFlagStalenessSeconds,
+                staleness.TotalSeconds);
+        }
+    }
+}

--- a/src/NuGet.Jobs.Common/FeatureFlags/IFeatureFlagRefresher.cs
+++ b/src/NuGet.Jobs.Common/FeatureFlags/IFeatureFlagRefresher.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace NuGet.Jobs.Validation
+namespace NuGet.Jobs
 {
     /// <summary>
     /// The interface for starting and stopping a background task which refreshes the cached feature flag state

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -143,11 +143,14 @@ namespace NuGet.Jobs
             containerBuilder.Populate(services);
             containerBuilder.RegisterAssemblyModules(GetType().Assembly);
 
-            // TelemetryConfiguration implements IDisposable, so we'll tell Autofac
+            // Classes below implement IDisposable, so we'll tell Autofac
             // not to dispose of it when container is disposed of. Otherwise, on second and
-            // subsequent job runs we'll end up without telemetry configuration.
+            // subsequent job runs we'll end up with them disposed.
             containerBuilder
                 .RegisterInstance(ApplicationInsightsConfiguration.TelemetryConfiguration)
+                .ExternallyOwned();
+            containerBuilder
+                .RegisterInstance(LoggerFactory)
                 .ExternallyOwned();
 
             ConfigureDefaultAutofacServices(containerBuilder, configurationRoot);
@@ -255,7 +258,6 @@ namespace NuGet.Jobs
         {
             // Use the custom NonCachingOptionsSnapshot so that KeyVault secret injection works properly.
             services.Add(ServiceDescriptor.Scoped(typeof(IOptionsSnapshot<>), typeof(NonCachingOptionsSnapshot<>)));
-            services.AddSingleton(LoggerFactory);
             services.AddLogging();
         }
 

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -13,10 +13,16 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using NuGet.Jobs.Configuration;
 using NuGet.Services.Configuration;
+using NuGet.Services.FeatureFlags;
 using NuGet.Services.KeyVault;
 using NuGet.Services.Logging;
+using NuGetGallery;
+using NuGetGallery.Diagnostics;
+using NuGetGallery.Features;
 
 namespace NuGet.Jobs
 {
@@ -29,6 +35,9 @@ namespace NuGet.Jobs
         private const string ValidationDbConfigurationSectionName = "ValidationDb";
         private const string ServiceBusConfigurationSectionName = "ServiceBus";
         private const string ValidationStorageConfigurationSectionName = "ValidationStorage";
+        private const string FeatureFlagConfigurationSectionName = "FeatureFlags";
+
+        private const string FeatureFlagBindingKey = nameof(FeatureFlagBindingKey);
 
         private bool testDatabaseConnections = true;
 
@@ -69,6 +78,10 @@ namespace NuGet.Jobs
             var configurationFilename = JobConfigurationManager.GetArgument(jobArgsDictionary, ConfigurationArgument);
             var configurationRoot = GetConfigurationRoot(configurationFilename, out var secretInjector, out var secretReader);
 
+            if (_serviceProvider != null && _serviceProvider is IDisposable disposableProvider)
+            {
+                disposableProvider.Dispose();
+            }
             _serviceProvider = GetServiceProvider(configurationRoot, secretInjector, secretReader);
 
             if (!_validateOnly)
@@ -148,6 +161,8 @@ namespace NuGet.Jobs
 
             services.AddSingleton(new TelemetryClient(ApplicationInsightsConfiguration.TelemetryConfiguration));
             services.AddTransient<ITelemetryClient, TelemetryClientWrapper>();
+            services.AddTransient<IDiagnosticsService, LoggerDiagnosticsService>();
+            services.AddTransient<ICloudBlobContainerInformationProvider, GalleryCloudBlobContainerInformationProvider>();
 
             AddScopedSqlConnectionFactory<GalleryDbConfiguration>(services);
             AddScopedSqlConnectionFactory<StatisticsDbConfiguration>(services);
@@ -168,6 +183,66 @@ namespace NuGet.Jobs
                     CreateSqlConnectionAsync<TDbConfiguration>,
                     p.GetRequiredService<ILogger<DelegateSqlConnectionFactory<TDbConfiguration>>>());
             });
+        }
+
+        public static void ConfigureFeatureFlagAutofacServices(ContainerBuilder containerBuilder)
+        {
+            containerBuilder
+                .Register(c =>
+                {
+                    var options = c.Resolve<IOptionsSnapshot<FeatureFlagConfiguration>>();
+                    return new CloudBlobClientWrapper(
+                        options.Value.ConnectionString,
+                        GetFeatureFlagBlobRequestOptions());
+                })
+                .Keyed<ICloudBlobClient>(FeatureFlagBindingKey);
+
+            containerBuilder
+                .Register(c => new CloudBlobCoreFileStorageService(
+                    c.ResolveKeyed<ICloudBlobClient>(FeatureFlagBindingKey),
+                    c.Resolve<IDiagnosticsService>(),
+                    c.Resolve<ICloudBlobContainerInformationProvider>()))
+                .Keyed<ICoreFileStorageService>(FeatureFlagBindingKey);
+
+            containerBuilder
+                .Register(c => new FeatureFlagFileStorageService(
+                    c.ResolveKeyed<ICoreFileStorageService>(FeatureFlagBindingKey)))
+                .As<IFeatureFlagStorageService>();
+        }
+
+        public static void ConfigureFeatureFlagServices(IServiceCollection services, IConfigurationRoot configurationRoot = null)
+        {
+            if (configurationRoot != null)
+            {
+                services.Configure<FeatureFlagConfiguration>(configurationRoot.GetSection(FeatureFlagConfigurationSectionName));
+            }
+
+            services
+                .AddTransient(p =>
+                {
+                    var options = p.GetRequiredService<IOptionsSnapshot<FeatureFlagConfiguration>>();
+                    return new FeatureFlagOptions
+                    {
+                        RefreshInterval = options.Value.RefreshInternal,
+                    };
+                });
+
+            services.AddTransient<IFeatureFlagClient, FeatureFlagClient>();
+            services.AddTransient<IFeatureFlagTelemetryService, FeatureFlagTelemetryService>();
+
+            services.AddSingleton<IFeatureFlagCacheService, FeatureFlagCacheService>();
+            services.AddSingleton<IFeatureFlagRefresher, FeatureFlagRefresher>();
+        }
+
+        private static BlobRequestOptions GetFeatureFlagBlobRequestOptions()
+        {
+            return new BlobRequestOptions
+            {
+                ServerTimeout = TimeSpan.FromMinutes(2),
+                MaximumExecutionTime = TimeSpan.FromMinutes(10),
+                LocationMode = LocationMode.PrimaryThenSecondary,
+                RetryPolicy = new ExponentialRetry(),
+            };
         }
 
         private void ConfigureLibraries(IServiceCollection services)

--- a/src/NuGet.Jobs.Common/LoggerDiagnosticsService.cs
+++ b/src/NuGet.Jobs.Common/LoggerDiagnosticsService.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Services.Logging;
 using NuGetGallery.Diagnostics;
 
-namespace NuGet.Jobs.Validation
+namespace NuGet.Jobs
 {
     public class LoggerDiagnosticsService : IDiagnosticsService
     {

--- a/src/NuGet.Jobs.Common/LoggerDiagnosticsSource.cs
+++ b/src/NuGet.Jobs.Common/LoggerDiagnosticsSource.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using NuGet.Services.Logging;
 using NuGetGallery.Diagnostics;
 
-namespace NuGet.Jobs.Validation
+namespace NuGet.Jobs
 {
     public class LoggerDiagnosticsSource : IDiagnosticsSource
     {

--- a/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
+++ b/src/NuGet.Jobs.Common/NuGet.Jobs.Common.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
     <RootNamespace>NuGet.Jobs</RootNamespace>
     <Description>Common infrastructure for running the NuGetGallery back-end jobs.</Description>
   </PropertyGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <Compile Remove="Configuration\MessageServiceConfiguration.cs" />
   </ItemGroup>
 
@@ -33,6 +33,12 @@
     </PackageReference>
     <PackageReference Include="NuGet.Services.Sql">
       <Version>$(ServerCommonPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.Services.FeatureFlags">
+      <Version>$(ServerCommonPackageVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="NuGetGallery.Core">
+      <Version>$(NuGetGalleryPackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/src/NuGet.Services.AzureSearch/AzureSearchJob.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchJob.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Rest;
 using NuGet.Jobs;
-using NuGet.Jobs.Validation;
+using NuGet.Jobs.Configuration;
 
 namespace NuGet.Services.AzureSearch
 {

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -14,7 +14,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.PackageManagement.Search.Web;
-using NuGet.Jobs.Validation;
+using NuGet.Jobs.Configuration;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.Logging;

--- a/src/NuGet.Services.V3/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.V3/DependencyInjectionExtensions.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Microsoft.WindowsAzure.Storage.RetryPolicies;
+using NuGet.Jobs;
+using NuGet.Jobs.Configuration;
 using NuGet.Jobs.Validation;
 using NuGet.Protocol.Catalog;
 using NuGet.Protocol.Registration;
@@ -99,22 +101,10 @@ namespace NuGet.Services.V3
 
         public static IServiceCollection AddFeatureFlags(this IServiceCollection services)
         {
-	        services
-                .AddTransient(p =>
-                {
-                    var options = p.GetRequiredService<IOptionsSnapshot<FeatureFlagConfiguration>>();
-                    return new FeatureFlagOptions
-                    {
-                        RefreshInterval = options.Value.RefreshInternal,
-                    };
-                });
+            JsonConfigurationJob.ConfigureFeatureFlagServices(services);
 
-            services.AddTransient<IFeatureFlagClient, FeatureFlagClient>();
             services.AddTransient<IFeatureFlagTelemetryService, V3TelemetryService>();
             services.AddTransient<ICloudBlobContainerInformationProvider, GalleryCloudBlobContainerInformationProvider>();
-
-            services.AddSingleton<IFeatureFlagCacheService, FeatureFlagCacheService>();
-            services.AddSingleton<IFeatureFlagRefresher, FeatureFlagRefresher>();
 
             return services;
         }

--- a/src/NuGet.Services.V3/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.V3/DependencyInjectionExtensions.cs
@@ -104,7 +104,6 @@ namespace NuGet.Services.V3
             JsonConfigurationJob.ConfigureFeatureFlagServices(services);
 
             services.AddTransient<IFeatureFlagTelemetryService, V3TelemetryService>();
-            services.AddTransient<ICloudBlobContainerInformationProvider, GalleryCloudBlobContainerInformationProvider>();
 
             return services;
         }

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -227,13 +227,9 @@ namespace NuGet.Services.Validation.Orchestrator
             });
             services.AddTransient<ISharedAccessSignatureService, SharedAccessSignatureService>();
 
-            /// See <see cref="SubscriptionProcessorJob{T}.ConfigureDefaultJobServices(IServiceCollection, IConfigurationRoot)"/>
-            /// for reasoning on why this is registered here.
-            services.AddSingleton<IFeatureFlagRefresher, FeatureFlagRefresher>();
-
             ConfigureFileServices(services, configurationRoot);
             ConfigureOrchestratorSymbolTypes(services);
-            ValidationJobBase.ConfigureFeatureFlagServices(services, configurationRoot);
+            JsonConfigurationJob.ConfigureFeatureFlagServices(services, configurationRoot);
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder, IConfigurationRoot configurationRoot)
@@ -305,7 +301,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     throw new NotImplementedException($"Unknown type: {validatingType}");
             }
 
-            ValidationJobBase.ConfigureFeatureFlagAutofacServices(containerBuilder);
+            JsonConfigurationJob.ConfigureFeatureFlagAutofacServices(containerBuilder);
             ConfigureLeaseService(containerBuilder);
         }
 

--- a/src/NuGet.Services.Validation.Orchestrator/Job.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Job.cs
@@ -229,7 +229,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
             ConfigureFileServices(services, configurationRoot);
             ConfigureOrchestratorSymbolTypes(services);
-            JsonConfigurationJob.ConfigureFeatureFlagServices(services, configurationRoot);
+            ValidationJobBase.ConfigureFeatureFlagServices(services, configurationRoot);
         }
 
         protected override void ConfigureAutofacServices(ContainerBuilder containerBuilder, IConfigurationRoot configurationRoot)

--- a/src/Validation.Common.Job/CommonTelemetryService.cs
+++ b/src/Validation.Common.Job/CommonTelemetryService.cs
@@ -8,7 +8,7 @@ using NuGet.Services.Logging;
 
 namespace NuGet.Jobs.Validation
 {
-    public class CommonTelemetryService : ICommonTelemetryService, IFeatureFlagTelemetryService
+    public class CommonTelemetryService : ICommonTelemetryService
     {
         private const string FileDownloadedSeconds = "FileDownloadedSeconds";
         private const string FileDownloadSpeed = "FileDownloadSpeedBytesPerSec";
@@ -16,20 +16,11 @@ namespace NuGet.Jobs.Validation
         private const string FileSize = "FileSize";
         private const double DefaultDownloadSpeed = 1;
 
-        private const string FeatureFlagStalenessSeconds = "FeatureFlagStalenessSeconds";
-
-        private readonly ITelemetryClient _telemetryClient;
+        protected readonly ITelemetryClient _telemetryClient;
 
         public CommonTelemetryService(ITelemetryClient telemetryClient)
         {
             _telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
-        }
-
-        public void TrackFeatureFlagStaleness(TimeSpan staleness)
-        {
-            _telemetryClient.TrackMetric(
-                FeatureFlagStalenessSeconds,
-                staleness.TotalSeconds);
         }
 
         public void TrackFileDownloaded(Uri fileUri, TimeSpan duration, long size)

--- a/src/Validation.Common.Job/SubscriptionProcessorJob.cs
+++ b/src/Validation.Common.Job/SubscriptionProcessorJob.cs
@@ -61,18 +61,6 @@ namespace NuGet.Jobs.Validation
         protected override void ConfigureDefaultJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
             base.ConfigureDefaultJobServices(services, configurationRoot);
-
-            // This service is registered at this level instead of a lower level (e.g. ValidationJobBase) because in
-            // general it is not clear what the lifetime of the singleton FeatureFlagRefresher should be per job. Since
-            // non-subscription processor jobs typically have their processes live forever but reinitialized their
-            // dependency injection container every job loop, managing the lifetime of a class like this is tricky.
-            //
-            // In the subscription processor job case, the job runs for one day then ends the process. The job runner
-            // only initializes the dependency container once so there is no concern of multiple feature flag
-            // refreshers running in parallel due to multiple instances from multiple containers.
-            //
-            // Once we fix https://github.com/NuGet/NuGetGallery/issues/7441, we can move this down to a lower level.
-            services.AddSingleton<IFeatureFlagRefresher, FeatureFlagRefresher>();
         }
 
         protected static void ConfigureDefaultSubscriptionProcessor(ContainerBuilder containerBuilder)

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -37,9 +37,6 @@
     <PackageReference Include="NuGet.Packaging">
       <Version>$(NuGetClientPackageVersion)</Version>
     </PackageReference>
-    <PackageReference Include="NuGetGallery.Core">
-      <Version>$(NuGetGalleryPackageVersion)</Version>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Validation.Common.Job/ValidationJobBase.cs
+++ b/src/Validation.Common.Job/ValidationJobBase.cs
@@ -44,7 +44,6 @@ namespace NuGet.Jobs.Validation
             base.ConfigureDefaultJobServices(services, configurationRoot);
 
             ConfigureFeatureFlagServices(services, configurationRoot);
-            services.AddTransient<IFeatureFlagService, FeatureFlagService>();
             ConfigureDatabaseServices(services);
 
             services.AddTransient<ICommonTelemetryService, CommonTelemetryService>();
@@ -113,6 +112,12 @@ namespace NuGet.Jobs.Validation
                     (pi, ctx) => pi.ParameterType == typeof(ITopicClient),
                     (pi, ctx) => ctx.ResolveKeyed<TopicClientWrapper>(PackageValidationServiceBusBindingKey)))
                 .As<IPackageValidationEnqueuer>();
+        }
+
+        public static new void ConfigureFeatureFlagServices(IServiceCollection services, IConfigurationRoot configurationRoot = null)
+        {
+            JsonConfigurationJob.ConfigureFeatureFlagServices(services, configurationRoot);
+            services.AddTransient<IFeatureFlagService, FeatureFlagService>();
         }
 
         private void ConfigureDatabaseServices(IServiceCollection services)

--- a/tests/NuGet.Jobs.Common.Tests/FeatureFlags/FeatureFlagRefresherFacts.cs
+++ b/tests/NuGet.Jobs.Common.Tests/FeatureFlags/FeatureFlagRefresherFacts.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
@@ -6,12 +9,12 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
-using NuGet.Jobs.Validation;
+using NuGet.Jobs.Configuration;
 using NuGet.Services.FeatureFlags;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Validation.Common.Job.Tests.FeatureFlags
+namespace NuGet.Jobs.Common.Tests.FeatureFlags
 {
     public class FeatureFlagRefresherFacts
     {

--- a/tests/NuGet.Jobs.Common.Tests/LoggerDiagnosticSourceFacts.cs
+++ b/tests/NuGet.Jobs.Common.Tests/LoggerDiagnosticSourceFacts.cs
@@ -7,13 +7,12 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NuGet.Jobs.Validation;
 using NuGet.Services.Logging;
 using Validation.PackageSigning.Core.Tests.Support;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Validation.Common.Job.Tests
+namespace NuGet.Jobs.Common.Tests
 {
     public class LoggerDiagnosticSourceFacts
     {

--- a/tests/NuGet.Jobs.Common.Tests/NuGet.Jobs.Common.Tests.csproj
+++ b/tests/NuGet.Jobs.Common.Tests/NuGet.Jobs.Common.Tests.csproj
@@ -41,7 +41,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configuration\MessageServiceConfigurationFacts.cs" />
+    <Compile Include="FeatureFlags\FeatureFlagRefresherFacts.cs" />
     <Compile Include="JobBaseFacts.cs" />
+    <Compile Include="LoggerDiagnosticSourceFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -61,6 +63,10 @@
     <ProjectReference Include="..\..\src\NuGet.Jobs.Common\NuGet.Jobs.Common.csproj">
       <Project>{4b4b1efb-8f33-42e6-b79f-54e7f3293d31}</Project>
       <Name>NuGet.Jobs.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\TestUtil\TestUtil.csproj">
+      <Project>{c3f84bad-acfa-4ae3-8286-d12f5a5bbc62}</Project>
+      <Name>TestUtil</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
+++ b/tests/Validation.Common.Job.Tests/Validation.Common.Job.Tests.csproj
@@ -42,13 +42,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommonTelemetryServiceFacts.cs" />
-    <Compile Include="FeatureFlags\FeatureFlagRefresherFacts.cs" />
     <Compile Include="FileStreamUtilityFacts.cs" />
     <Compile Include="Leases\BlobStorageCollection.cs" />
     <Compile Include="Leases\BlobStorageFact.cs" />
     <Compile Include="Leases\BlobStorageFixture.cs" />
     <Compile Include="Leases\CloudBlobLeaseServiceIntegrationTests.cs" />
-    <Compile Include="LoggerDiagnosticSourceFacts.cs" />
     <Compile Include="FileDownloaderFacts.cs" />
     <Compile Include="PathUtilityFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Addresses https://github.com/NuGet/NuGetGallery/issues/7441 (the initial proposition).
Feature flags setup method and related classes were moved down from `ValidationJobBase` to `JsonConfigurationJob` and `DependencyInjectionExtensions` implementation was updated to reuse some of that code.
Needed to bring Feature flags to non-validation jobs without too much copy-pasting.

The main change is in `JsonConfigurationJob.Init` where `Dispose` call has been added.
To move all related code to `JsonConfigurationJob`, I had to move `NuGetGallery.Core` reference to `NuGet.Jobs.Common` as feature flags need blob storage access and existing implementation utilized `NuGetGallery.Core`. That in turn required to bump target framework to `netstandard2.1` from `netstandard2.0`. Not sure if there are consequences of that outside of this repo.
`IFeatureFlagTelemetryService` of `CommonTelemetryService` was extracted to a class of its own and also moved to `NuGet.Jobs.Common`.

Although the code was made available in `JsonConfigurationJob`, it is not called automatically and it is still individual job responsibility to call it, if it needs it (since it requires presence of feature flag confuguration, most non-`ValidationJobBase` jobs are not configured appropriately).

Some DI changes were required for objects added to a DI container that supposed to outlive it (`TelemetryConfiguration` and `LoggerFactory`).

Orchestrator, Catalog2AzureSearch, Auxiliary2AzureSearch, AzureSearchService and Db2AzureSearch were affected directly by the change, so all of them except Db2AzureSearch were tested in dev to make sure they continue working (deploys fine, E2E tests pass).