### PR TITLE
Updating orchestrator configuration according to UVP spec.

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ConfigurationValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ConfigurationValidator.cs
@@ -167,7 +167,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     .Where(x => _validatorProvider.IsNuGetProcessor(x))
                     .ToList();
 
-                TopologicalSort.Validate(validationConfiguration.Value, processorNames);
+                TopologicalSort.Validate(validationConfiguration.Value, processorNames, validationConfiguration.Key);
             }
         }
     }

--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/TopologicalSort.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/TopologicalSort.cs
@@ -35,15 +35,16 @@ namespace NuGet.Services.Validation.Orchestrator
         /// </summary>
         /// <param name="validators">The validator configuration items.</param>
         /// <param name="cannotBeParallel">The names of validators that are also processors.</param>
+        /// <param name="contentType">Content type to mention in error messages.</param>
         /// <exception cref="ConfigurationErrorsException">
         /// Thrown if a cycle or parallel processor is found
         /// </exception>
-        public static void Validate(IReadOnlyList<ValidationConfigurationItem> validators, IReadOnlyList<string> cannotBeParallel)
+        public static void Validate(IReadOnlyList<ValidationConfigurationItem> validators, IReadOnlyList<string> cannotBeParallel, string contentType)
         {
             var allOrders = EnumerateAll(validators);
             if (!allOrders.Any())
             {
-                throw new ConfigurationErrorsException("No validation sequences were found. This indicates a cycle in the validation dependencies.");
+                throw new ConfigurationErrorsException($"No validation sequences were found for {contentType} content type. This indicates a cycle in the validation dependencies.");
             }
 
             // A dictionary mapping the name of the validator to its index in the first topological sort result. All
@@ -62,7 +63,7 @@ namespace NuGet.Services.Validation.Orchestrator
                     if (otherName != name)
                     {
                         throw new ConfigurationErrorsException(
-                            $"The processor {name} could run in parallel with {otherName}. Processors must not run " +
+                            $"The processor {name} for {contentType} content type could run in parallel with {otherName}. Processors must not run " +
                             $"in parallel with any other validators.");
                     }
                 }

--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfiguration.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfiguration.cs
@@ -12,9 +12,11 @@ namespace NuGet.Services.Validation.Orchestrator
     public class ValidationConfiguration
     {
         /// <summary>
-        /// List of validations to run with their settings and dependencies
+        /// Dictionary of validation lists to run for each content type.
+        /// Key is content type, value is the list of validations to run with their respective settings.
+        /// "Classic" validation pipeline will use "NuGet" as key for its validations.
         /// </summary>
-        public List<ValidationConfigurationItem> Validations { get; set; }
+        public Dictionary<string, List<ValidationConfigurationItem>> ValidationSteps { get; set; }
 
         /// <summary>
         /// Connection string to storage account with packages to validate

--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationExtensions.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationExtensions.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationExtensions.cs
@@ -12,7 +12,8 @@ namespace NuGet.Services.Validation.Orchestrator
 
         public static List<ValidationConfigurationItem> GetClassicValidationConfiguration(this ValidationConfiguration validationConfiguration)
         {
-            if (validationConfiguration?.ValidationSteps?.TryGetValue(NuGetValidationStepContentType, out var nugetList) == true)
+            List<ValidationConfigurationItem> nugetList = null;
+            if (validationConfiguration?.ValidationSteps?.TryGetValue(NuGetValidationStepContentType, out nugetList) == true)
             {
                 return nugetList;
             }

--- a/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationExtensions.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Configuration/ValidationConfigurationExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Validation.Orchestrator
+{
+    internal static class ValidationConfigurationExtensions
+    {
+        private const string NuGetValidationStepContentType = "NuGet";
+
+        public static List<ValidationConfigurationItem> GetClassicValidationConfiguration(this ValidationConfiguration validationConfiguration)
+        {
+            if (validationConfiguration?.ValidationSteps?.TryGetValue(NuGetValidationStepContentType, out var nugetList) == true)
+            {
+                return nugetList;
+            }
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
+++ b/src/NuGet.Services.Validation.Orchestrator/NuGet.Services.Validation.Orchestrator.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Configuration\FlatContainerConfiguration.cs" />
     <Compile Include="Configuration\SasDefinitionConfiguration.cs" />
     <Compile Include="Configuration\TopologicalSort.cs" />
+    <Compile Include="Configuration\ValidationConfigurationExtensions.cs" />
     <Compile Include="ContainerBuilderExtensions.cs" />
     <Compile Include="Configuration\CoreMessageServiceConfiguration.cs" />
     <Compile Include="Configuration\EmailConfiguration.cs" />

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationOutcomeProcessor.cs
@@ -49,7 +49,7 @@ namespace NuGet.Services.Validation.Orchestrator
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            _validationConfigurationsByName = _validationConfiguration.Validations.ToDictionary(v => v.Name);
+            _validationConfigurationsByName = _validationConfiguration.GetClassicValidationConfiguration().ToDictionary(v => v.Name);
         }
 
         public async Task ProcessValidationOutcomeAsync(

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProcessor.cs
@@ -266,7 +266,7 @@ namespace NuGet.Services.Validation.Orchestrator
 
         private ValidationConfigurationItem GetValidationConfiguration(string validationName)
         {
-            return _validationConfiguration.Validations
+            return _validationConfiguration.GetClassicValidationConfiguration()
                 .FirstOrDefault(v => v.Name == validationName);
         }
 
@@ -306,7 +306,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 .Where(v => v.ValidationStatus == ValidationStatus.Succeeded)
                 .Select(v => v.Type));
             var requiredValidations = _validationConfiguration
-                .Validations
+                .GetClassicValidationConfiguration()
                 .Single(v => v.Name == packageValidation.Type).RequiredValidations;
 
             return completeValidations.IsSupersetOf(requiredValidations);

--- a/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/ValidationSetProvider.cs
@@ -162,7 +162,7 @@ namespace NuGet.Services.Validation.Orchestrator
             };
 
             var validationsToStart = _validationConfiguration
-                .Validations
+                .GetClassicValidationConfiguration()
                 .Where(v => v.ShouldStart);
 
             foreach (var validation in validationsToStart)

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
@@ -216,7 +216,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             var ex = Assert.Throws<ConfigurationErrorsException>(() => Validate(validatorProvider.Object, configuration));
 
             Assert.Contains(
-                "The processor Processor1 for ParallelProcessor could run in parallel with Validation2. Processors must not run in parallel with any other validators.",
+                "The processor Processor1 for ParallelProcessor content type could run in parallel with Validation2. Processors must not run in parallel with any other validators.",
                 ex.Message);
         }
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
@@ -18,19 +18,25 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation2" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
+                    { 
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation2" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            }
+                        }
                     }
                 }
             };
@@ -46,17 +52,23 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string validationName = "Validation1";
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = validationName,
-                        TrackAfter = TimeSpan.FromHours(1),
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = validationName,
-                        TrackAfter = TimeSpan.FromHours(1),
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = validationName,
+                                TrackAfter = TimeSpan.FromHours(1),
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = validationName,
+                                TrackAfter = TimeSpan.FromHours(1),
+                            }
+                        }
                     }
                 }
             };
@@ -74,14 +86,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string NonExistentValidationName = "SomeValidation";
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ NonExistentValidationName }
-                    },
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ NonExistentValidationName }
+                            },
+                        }
+                    }
                 }
             };
 
@@ -97,14 +115,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             var validationName = "Validation1";
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = validationName,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>(),
-                    },
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = validationName,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>(),
+                            },
+                        }
+                    }
                 }
             };
             var validatorProvider = new Mock<IValidatorProvider>();
@@ -123,26 +147,32 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             var processorName1 = "Processor1";
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = validationName1,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>(),
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = validationName2,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string> { validationName1 },
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = processorName1,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string> { validationName1 },
-                    },
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = validationName1,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>(),
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = validationName2,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string> { validationName1 },
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = processorName1,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string> { validationName1 },
+                            },
+                        }
+                    }
                 }
             };
 
@@ -172,26 +202,32 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             var processorName1 = "Processor1";
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = validationName1,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>(),
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = validationName2,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string> { validationName1 },
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = processorName1,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string> { validationName2 },
-                    },
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = validationName1,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>(),
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = validationName2,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string> { validationName1 },
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = processorName1,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string> { validationName2 },
+                            },
+                        }
+                    }
                 }
             };
 
@@ -216,19 +252,25 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation2"}
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation1"}
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation2" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation1" }
+                            }
+                        }
                     }
                 }
             };
@@ -244,14 +286,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation1" }
-                    },
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation1" }
+                            },
+                        }
+                    }
                 }
             };
 
@@ -266,19 +314,25 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation2" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation2" }
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation2" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation2" }
+                            }
+                        }
                     }
                 }
             };
@@ -294,12 +348,18 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "",
-                        TrackAfter = TimeSpan.FromHours(1)
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "",
+                                TrackAfter = TimeSpan.FromHours(1)
+                            }
+                        }
                     }
                 }
             };
@@ -315,12 +375,18 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "SomeValidation",
-                        TrackAfter = TimeSpan.Zero
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "SomeValidation",
+                                TrackAfter = TimeSpan.Zero
+                            }
+                        }
                     }
                 }
             };
@@ -347,31 +413,37 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation3", "Validation4" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation3", "Validation4" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation3",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation4",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation3", "Validation4" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation3", "Validation4" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation3",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation4",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            }
+                        }
                     }
                 }
             };
@@ -396,31 +468,37 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
              */
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation2", "Validation3" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation4" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation3",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation4" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation4",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation2", "Validation3" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation4" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation3",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation4" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation4",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            }
+                        }
                     }
                 }
             };
@@ -436,25 +514,31 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             // Validation3 ---> Validation1 ---> Validation2
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation2" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation3",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation1" }
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation2" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation3",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation1" }
+                            }
+                        }
                     }
                 }
             };
@@ -469,19 +553,25 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            }
+                        }
                     }
                 }
             };
@@ -501,25 +591,31 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
              */
             var configuration = new ValidationConfiguration()
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = "Validation1",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>()
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation2",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation3" }
-                    },
-                    new ValidationConfigurationItem
-                    {
-                        Name = "Validation3",
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>{ "Validation2" }
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation1",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>()
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation2",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation3" }
+                            },
+                            new ValidationConfigurationItem
+                            {
+                                Name = "Validation3",
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>{ "Validation2" }
+                            }
+                        }
                     }
                 }
             };
@@ -548,14 +644,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             const string lastValidationName = "LastValidation";
             var configuration = new ValidationConfiguration
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
-                    new ValidationConfigurationItem
                     {
-                        Name = firstValidationName,
-                        TrackAfter = TimeSpan.FromHours(1),
-                        RequiredValidations = new List<string>(),
-                        ShouldStart = false
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                            new ValidationConfigurationItem
+                            {
+                                Name = firstValidationName,
+                                TrackAfter = TimeSpan.FromHours(1),
+                                RequiredValidations = new List<string>(),
+                                ShouldStart = false
+                            }
+                        }
                     }
                 }
             };
@@ -564,7 +666,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             foreach (var intermediateValidationIndex in Enumerable.Range(1, numIntermediateValidations))
             {
                 var intermediateValidationName = $"Validation{intermediateValidationIndex}";
-                configuration.Validations.Add(new ValidationConfigurationItem
+                configuration.ValidationSteps[ValidationStepsContentType.NuGet].Add(new ValidationConfigurationItem
                 {
                     Name = intermediateValidationName,
                     TrackAfter = TimeSpan.FromHours(1),
@@ -575,7 +677,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 previousValidationName = intermediateValidationName;
             }
 
-            configuration.Validations.Add(new ValidationConfigurationItem
+            configuration.ValidationSteps[ValidationStepsContentType.NuGet].Add(new ValidationConfigurationItem
             {
                 Name = lastValidationName,
                 TrackAfter = TimeSpan.FromHours(1),
@@ -584,7 +686,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 FailureBehavior = lastValidationFailureBehavior
             });
 
-            configuration.Validations.Reverse();
+            configuration.ValidationSteps[ValidationStepsContentType.NuGet].Reverse();
 
             var ex = Record.Exception(() => Validate(configuration));
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ConfigurationValidatorFacts.cs
@@ -21,7 +21,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     { 
-                        ValidationStepsContentType.NuGet,
+                        "TestContentType",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -55,7 +55,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "FooBar",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -89,7 +89,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "SomeContentType",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -118,7 +118,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "TestContentType",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -150,7 +150,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "ParallelProcessor",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -205,7 +205,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "ParallelProcessor",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -255,7 +255,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "Loops",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -289,7 +289,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "SelfReference",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -317,7 +317,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "SelfReference",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -351,7 +351,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "EmptyValidationName",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -378,7 +378,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "ZeroTimeout",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -416,7 +416,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "Diamonds",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -471,7 +471,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "Diamonds",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -517,7 +517,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "Loops",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -556,7 +556,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "Unconnected",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -594,7 +594,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        "Loops",
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -642,12 +642,13 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
 
             const string firstValidationName = "FirstValidation";
             const string lastValidationName = "LastValidation";
+            const string contentType = "RequiredToRun";
             var configuration = new ValidationConfiguration
             {
                 ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
                     {
-                        ValidationStepsContentType.NuGet,
+                        contentType,
                         new List<ValidationConfigurationItem>
                         {
                             new ValidationConfigurationItem
@@ -666,7 +667,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             foreach (var intermediateValidationIndex in Enumerable.Range(1, numIntermediateValidations))
             {
                 var intermediateValidationName = $"Validation{intermediateValidationIndex}";
-                configuration.ValidationSteps[ValidationStepsContentType.NuGet].Add(new ValidationConfigurationItem
+                configuration.ValidationSteps[contentType].Add(new ValidationConfigurationItem
                 {
                     Name = intermediateValidationName,
                     TrackAfter = TimeSpan.FromHours(1),
@@ -677,7 +678,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 previousValidationName = intermediateValidationName;
             }
 
-            configuration.ValidationSteps[ValidationStepsContentType.NuGet].Add(new ValidationConfigurationItem
+            configuration.ValidationSteps[contentType].Add(new ValidationConfigurationItem
             {
                 Name = lastValidationName,
                 TrackAfter = TimeSpan.FromHours(1),
@@ -686,7 +687,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 FailureBehavior = lastValidationFailureBehavior
             });
 
-            configuration.ValidationSteps[ValidationStepsContentType.NuGet].Reverse();
+            configuration.ValidationSteps[contentType].Reverse();
 
             var ex = Record.Exception(() => Validate(configuration));
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/TopologicalSortFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/TopologicalSortFacts.cs
@@ -284,7 +284,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             {
                 try
                 {
-                    TopologicalSort.Validate(validators, cannotBeParallel);
+                    TopologicalSort.Validate(validators, cannotBeParallel, "TestContentType");
                     return null;
                 }
                 catch (ConfigurationErrorsException e)

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/TopologicalSortFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/TopologicalSortFacts.cs
@@ -12,7 +12,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
     {
         public class Validate
         {
-            private const string CycleError = "No validation sequences were found. This indicates a cycle in the validation dependencies.";
+            private const string TestContentType = "TestContentType";
+            private const string CycleError = "No validation sequences were found for " + TestContentType + " content type. This indicates a cycle in the validation dependencies.";
             private const string ParallelProcessorError = "Processors must not run in parallel with any other validators.";
 
             [Fact]
@@ -284,7 +285,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             {
                 try
                 {
-                    TopologicalSort.Validate(validators, cannotBeParallel, "TestContentType");
+                    TopologicalSort.Validate(validators, cannotBeParallel, TestContentType);
                     return null;
                 }
                 catch (ConfigurationErrorsException e)

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ValidationStepsContentType.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ValidationStepsContentType.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ValidationStepsContentType.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Configuration/ValidationStepsContentType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.Validation.Orchestrator.Tests
+{
+    internal static class ValidationStepsContentType
+    {
+        public static string NuGet = "NuGet";
+    }
+}

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/NuGet.Services.Validation.Orchestrator.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Configuration\ConfigurationValidatorFacts.cs" />
     <Compile Include="Configuration\CoreMessageServiceConfigurationFacts.cs" />
     <Compile Include="Configuration\TopologicalSortFacts.cs" />
+    <Compile Include="Configuration\ValidationStepsContentType.cs" />
     <Compile Include="Services\SymbolsMessageServiceFacts.cs" />
     <Compile Include="Services\MessageServiceFacts.cs" />
     <Compile Include="OrchestrationRunnerFacts.cs" />

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationOutcomeProcessorFacts.cs
@@ -644,7 +644,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             for (int cfgValidatorIndex = 0; cfgValidatorIndex < numConfiguredValidators; ++cfgValidatorIndex)
             {
-                Configuration.Validations.Add(new ValidationConfigurationItem
+                Configuration.ValidationSteps[ValidationStepsContentType.NuGet].Add(new ValidationConfigurationItem
                 {
                     Name = "validation" + cfgValidatorIndex,
                     TrackAfter = TimeSpan.FromDays(1),
@@ -718,7 +718,8 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             LoggerMock = new Mock<ILogger<ValidationOutcomeProcessor<Package>>>();
 
             Configuration = new ValidationConfiguration();
-            Configuration.Validations = new List<ValidationConfigurationItem>();
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>();
+            Configuration.ValidationSteps.Add(ValidationStepsContentType.NuGet, new List<ValidationConfigurationItem>());
             Package = new Package
             {
                 PackageRegistration = new PackageRegistration { Id = "package" },
@@ -791,7 +792,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ValidationStatus = validationStatus,
                 PackageValidationIssues = new List<PackageValidationIssue> { },
             });
-            Configuration.Validations.Add(new ValidationConfigurationItem
+            Configuration.ValidationSteps[ValidationStepsContentType.NuGet].Add(new ValidationConfigurationItem
             {
                 Name = validationName,
                 TrackAfter = trackAfter ?? TimeSpan.FromDays(1),

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProcessorFacts.cs
@@ -442,8 +442,14 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             TelemetryServiceMock = new Mock<ITelemetryService>(telemetryServiceMockBehavior);
             Configuration = new ValidationConfiguration
             {
-                Validations = new List<ValidationConfigurationItem>
+                ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
                 {
+                    {
+                        ValidationStepsContentType.NuGet,
+                        new List<ValidationConfigurationItem>
+                        {
+                        }
+                    }
                 },
                 TimeoutValidationSetAfter = TimeSpan.FromDays(5),
             };
@@ -523,7 +529,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ShouldStart = shouldStart,
                 FailureBehavior = failureBehavior
             };
-            Configuration.Validations.Add(validation);
+            Configuration.ValidationSteps[ValidationStepsContentType.NuGet].Add(validation);
             return validation;
         }
 

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
@@ -140,7 +140,12 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     ValidationStepsContentType.NuGet,
                     new List<ValidationConfigurationItem>
                     {
-                        new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                        new ValidationConfigurationItem()
+                        {
+                            Name = validation1,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>()
+                        }
                     }
                 }
             };
@@ -532,7 +537,12 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                     ValidationStepsContentType.NuGet,
                     new List<ValidationConfigurationItem>
                     {
-                        new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                        new ValidationConfigurationItem
+                        {
+                            Name = validation1,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>()
+                        }
                     }
                 }
             };

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationSetProviderFacts.cs
@@ -65,14 +65,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         public async Task CopiesToValidationSetContainerBeforeAddingDbRecord()
         {
             const string validation1 = "validation1";
-            Configuration.Validations = new List<ValidationConfigurationItem>
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
             {
-                new ValidationConfigurationItem
                 {
-                    Name = validation1,
-                    TrackAfter = TimeSpan.FromDays(1),
-                    RequiredValidations = new List<string>(),
-                    ShouldStart = true,
+                    ValidationStepsContentType.NuGet,
+                    new List<ValidationConfigurationItem>
+                    {
+                        new ValidationConfigurationItem
+                        {
+                            Name = validation1,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>(),
+                            ShouldStart = true,
+                        }
+                    }
                 }
             };
 
@@ -128,9 +134,15 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         public async Task DoesNotBackUpThePackageWhenThereAreNoValidators()
         {
             const string validation1 = "validation1";
-            Configuration.Validations = new List<ValidationConfigurationItem>
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
             {
-                new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                {
+                    ValidationStepsContentType.NuGet,
+                    new List<ValidationConfigurationItem>
+                    {
+                        new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                    }
+                }
             };
 
             ValidatorProvider
@@ -177,14 +189,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         public async Task CopiesPackageFromPackagesContainerWhenAvailable()
         {
             const string validation1 = "validation1";
-            Configuration.Validations = new List<ValidationConfigurationItem>
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
             {
-                new ValidationConfigurationItem
                 {
-                    Name = validation1,
-                    TrackAfter = TimeSpan.FromDays(1),
-                    RequiredValidations = new List<string>(),
-                    ShouldStart = true,
+                    ValidationStepsContentType.NuGet,
+                    new List<ValidationConfigurationItem>
+                    {
+                        new ValidationConfigurationItem
+                        {
+                            Name = validation1,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>(),
+                            ShouldStart = true,
+                        }
+                    }
                 }
             };
 
@@ -234,14 +252,20 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         public async Task CopiesPackageFromValidationContainerWhenNotAvailable(PackageStatus packageStatus)
         {
             const string validation1 = "validation1";
-            Configuration.Validations = new List<ValidationConfigurationItem>
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
             {
-                new ValidationConfigurationItem()
                 {
-                    Name = validation1,
-                    TrackAfter = TimeSpan.FromDays(1),
-                    RequiredValidations = new List<string>(),
-                    ShouldStart = true,
+                    ValidationStepsContentType.NuGet,
+                    new List<ValidationConfigurationItem>
+                    {
+                        new ValidationConfigurationItem()
+                        {
+                            Name = validation1,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>(),
+                            ShouldStart = true,
+                        }
+                    }
                 }
             };
 
@@ -307,21 +331,27 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             const string validation1 = "validation1";
             const string validation2 = "validation2";
-            Configuration.Validations = new List<ValidationConfigurationItem>
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
             {
-                new ValidationConfigurationItem()
                 {
-                    Name = validation1,
-                    TrackAfter = TimeSpan.FromDays(1),
-                    RequiredValidations = new List<string>{ validation2 },
-                    ShouldStart = true,
-                },
-                new ValidationConfigurationItem()
-                {
-                    Name = validation2,
-                    TrackAfter = TimeSpan.FromDays(1),
-                    RequiredValidations = new List<string>(),
-                    ShouldStart = true,
+                    ValidationStepsContentType.NuGet,
+                    new List<ValidationConfigurationItem>
+                    {
+                        new ValidationConfigurationItem()
+                        {
+                            Name = validation1,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>{ validation2 },
+                            ShouldStart = true,
+                        },
+                        new ValidationConfigurationItem()
+                        {
+                            Name = validation2,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>(),
+                            ShouldStart = true,
+                        }
+                    }
                 }
             };
 
@@ -399,21 +429,27 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         {
             const string validation1 = "validation1";
             const string validation2 = "validation2";
-            Configuration.Validations = new List<ValidationConfigurationItem>
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
             {
-                new ValidationConfigurationItem()
                 {
-                    Name = validation1,
-                    TrackAfter = TimeSpan.FromDays(1),
-                    RequiredValidations = new List<string>(),
-                    ShouldStart = true,
-                },
-                new ValidationConfigurationItem()
-                {
-                    Name = validation2,
-                    TrackAfter = TimeSpan.FromDays(1),
-                    RequiredValidations = new List<string>(),
-                    ShouldStart = false,
+                    ValidationStepsContentType.NuGet,
+                    new List<ValidationConfigurationItem>
+                    {
+                        new ValidationConfigurationItem()
+                        {
+                            Name = validation1,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>(),
+                            ShouldStart = true,
+                        },
+                        new ValidationConfigurationItem()
+                        {
+                            Name = validation2,
+                            TrackAfter = TimeSpan.FromDays(1),
+                            RequiredValidations = new List<string>(),
+                            ShouldStart = false,
+                        }
+                    }
                 }
             };
 
@@ -490,9 +526,15 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         public async Task DoesNotEmitTelemetryIfMultipleValidationSetsExist()
         {
             const string validation1 = "validation1";
-            Configuration.Validations = new List<ValidationConfigurationItem>
+            Configuration.ValidationSteps = new Dictionary<string, List<ValidationConfigurationItem>>
             {
-                new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                {
+                    ValidationStepsContentType.NuGet,
+                    new List<ValidationConfigurationItem>
+                    {
+                        new ValidationConfigurationItem(){ Name = validation1, TrackAfter = TimeSpan.FromDays(1), RequiredValidations = new List<string>{ } }
+                    }
+                }
             };
 
             Guid validationTrackingId = Guid.NewGuid();


### PR DESCRIPTION
Replaced the `Validations` property with `ValidationSteps` following the [specification](https://github.com/NuGet/Engineering/blob/main/Server.Specs/OrchestratorUnifiedValidations.md), added some initial workarounds in the code to accommodate for the shape change.
Added an extension to be called instead of accessing `Validations` property. Updated the calls accordingly.
Tests had to be updated to use `ValidationSteps` directly as they need write access.