### PR TITLE
Allow downloads.v1.json to be configured by full URL for search jobs

### DIFF
--- a/src/Catalog/Downloads/DownloadByVersionData.cs
+++ b/src/Catalog/Downloads/DownloadByVersionData.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace NuGet.Services.AzureSearch.AuxiliaryFiles
+namespace NuGet.Services
 {
     public class DownloadByVersionData : IReadOnlyDictionary<string, long>
     {

--- a/src/Catalog/Downloads/DownloadData.cs
+++ b/src/Catalog/Downloads/DownloadData.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-namespace NuGet.Services.AzureSearch.AuxiliaryFiles
+namespace NuGet.Services
 {
     public class DownloadData : IReadOnlyDictionary<string, DownloadByVersionData>
     {

--- a/src/Catalog/Downloads/DownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/DownloadsV1JsonClient.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NuGet.Services.Metadata.Catalog.Helpers;
+
+namespace NuGet.Services.Metadata.Catalog
+{
+    public class DownloadsV1JsonClient : IDownloadsV1JsonClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<DownloadsV1JsonClient> _logger;
+
+        public DownloadsV1JsonClient(HttpClient httpClient, ILogger<DownloadsV1JsonClient> logger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<DownloadData> ReadAsync(string url)
+        {
+            var downloadData = new DownloadData();
+            await ReadAsync(url, downloadData.SetDownloadCount);
+            return downloadData;
+        }
+
+        public async Task ReadAsync(string url, Action<string, string, long> addCount)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var packageCount = 0;
+            
+            await Retry.IncrementalAsync(
+                async () =>
+                {
+                    _logger.LogInformation("Attempting to download {Url}", url);
+                    using (var response = await _httpClient.GetAsync(url))
+                    {
+                        response.EnsureSuccessStatusCode();
+                        using (var textReader = new StreamReader(await response.Content.ReadAsStreamAsync()))
+                        using (var jsonReader = new JsonTextReader(textReader))
+                        {
+                            DownloadsV1Reader.Load(jsonReader, (id, version, count) =>
+                            {
+                                packageCount++;
+                                addCount(id, version, count);
+                            });
+                        }
+                    }
+                },
+                ex => ex is HttpRequestException,
+                maxRetries: 5,
+                initialWaitInterval: TimeSpan.Zero,
+                waitIncrement: TimeSpan.FromSeconds(20));
+
+            stopwatch.Stop();
+
+            _logger.LogInformation("Got information about {RecordCount} packages from downloads.v1.json in {DurationSeconds} seconds",
+                packageCount,
+                stopwatch.Elapsed.TotalSeconds);
+        }
+    }
+}

--- a/src/Catalog/Downloads/DownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/DownloadsV1JsonClient.cs
@@ -33,7 +33,7 @@ namespace NuGet.Services.Metadata.Catalog
             return downloadData;
         }
 
-        public async Task ReadAsync(string url, Action<string, string, long> addCount)
+        public async Task ReadAsync(string url, AddDownloadCount addCount)
         {
             var stopwatch = Stopwatch.StartNew();
             var packageCount = 0;

--- a/src/Catalog/Downloads/DownloadsV1Reader.cs
+++ b/src/Catalog/Downloads/DownloadsV1Reader.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace NuGet.Services.AzureSearch.AuxiliaryFiles
+namespace NuGet.Services.Metadata.Catalog
 {
     public static class DownloadsV1Reader
     {

--- a/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault.Models;
+
+namespace NuGet.Services.Metadata.Catalog
+{
+    public interface IDownloadsV1JsonClient
+    {
+        Task<DownloadData> ReadAsync(string url);
+        Task ReadAsync(string url, Action<string, string, long> addCount);
+    }
+}

--- a/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
@@ -7,9 +7,11 @@ using Microsoft.Azure.KeyVault.Models;
 
 namespace NuGet.Services.Metadata.Catalog
 {
+    public delegate void AddDownloadCount(string packageId, string packageVersion, long downloadCount);
+
     public interface IDownloadsV1JsonClient
     {
         Task<DownloadData> ReadAsync(string url);
-        Task ReadAsync(string url, Action<string, string, long> addCount);
+        Task ReadAsync(string url, AddDownloadCount addCount);
     }
 }

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
@@ -13,6 +13,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
+        public string DownloadsV1JsonUrl { get; set; }
         public TimeSpan MinPushPeriod { get; set; }
         public int MaxDownloadCountDecreases { get; set; } = 15000;
     }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryDataStorageConfiguration.cs
@@ -9,5 +9,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         public string AuxiliaryDataStorageContainer { get; set; }
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
+        public string DownloadsV1JsonUrl { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryFileClient.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json;
+using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Helpers;
 using NuGetGallery;
 
@@ -18,6 +19,7 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
     public class AuxiliaryFileClient : IAuxiliaryFileClient
     {
         private readonly ICloudBlobClient _cloudBlobClient;
+        private readonly IDownloadsV1JsonClient _downloadsV1JsonClient;
         private readonly IOptionsSnapshot<AuxiliaryDataStorageConfiguration> _options;
         private readonly IAzureSearchTelemetryService _telemetryService;
         private readonly ILogger<AuxiliaryFileClient> _logger;
@@ -25,11 +27,13 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
         public AuxiliaryFileClient(
             ICloudBlobClient cloudBlobClient,
+            IDownloadsV1JsonClient downloadsV1JsonClient,
             IOptionsSnapshot<AuxiliaryDataStorageConfiguration> options,
             IAzureSearchTelemetryService telemetryService,
             ILogger<AuxiliaryFileClient> logger)
         {
             _cloudBlobClient = cloudBlobClient ?? throw new ArgumentNullException(nameof(cloudBlobClient));
+            _downloadsV1JsonClient = downloadsV1JsonClient ?? throw new ArgumentNullException(nameof(downloadsV1JsonClient));
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _telemetryService = telemetryService ?? throw new ArgumentNullException(nameof(telemetryService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -42,6 +46,11 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 
         public async Task<DownloadData> LoadDownloadDataAsync()
         {
+            if (_options.Value.DownloadsV1JsonUrl != null)
+            {
+                return await _downloadsV1JsonClient.ReadAsync(_options.Value.DownloadsV1JsonUrl);
+            }
+
             return await LoadAuxiliaryFileAsync(
                 _options.Value.AuxiliaryDataStorageDownloadsPath,
                 loadData: reader =>

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
@@ -9,5 +9,12 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
         string AuxiliaryDataStorageContainer { get; }
         string AuxiliaryDataStorageDownloadsPath { get; }
         string AuxiliaryDataStorageExcludedPackagesPath { get; }
+
+        /// <summary>
+        /// The URL to get downloads.v1.json. This property, if set, takes precedence over <see cref="AuxiliaryDataStorageDownloadsPath"/>.
+        /// This setting allows the downloads.v1.json report to be generated in a place different from
+        /// <see cref="AuxiliaryDataStorageExcludedPackagesPath"/>.
+        /// </summary>
+        string DownloadsV1JsonUrl { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
@@ -14,5 +14,6 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
+        public string DownloadsV1JsonUrl { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -20,6 +20,7 @@ using NuGet.Services.AzureSearch.Catalog2AzureSearch;
 using NuGet.Services.AzureSearch.Db2AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
 using NuGet.Services.AzureSearch.Wrappers;
+using NuGet.Services.Metadata.Catalog;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Services.V3;
 using NuGetGallery;
@@ -220,6 +221,7 @@ namespace NuGet.Services.AzureSearch
             containerBuilder
                 .Register<IAuxiliaryFileClient>(c => new AuxiliaryFileClient(
                     c.ResolveKeyed<ICloudBlobClient>(key),
+                    c.Resolve<IDownloadsV1JsonClient>(),
                     c.Resolve<IOptionsSnapshot<AuxiliaryDataStorageConfiguration>>(),
                     c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<AuxiliaryFileClient>>()));
@@ -256,6 +258,7 @@ namespace NuGet.Services.AzureSearch
                     return client;
                 });
 
+            services.AddTransient<IDownloadsV1JsonClient, DownloadsV1JsonClient>();
             services.AddSingleton<IAuxiliaryDataCache, AuxiliaryDataCache>();
             services.AddScoped(p => p.GetRequiredService<IAuxiliaryDataCache>().Get());
             services.AddSingleton<IAuxiliaryFileReloader, AuxiliaryFileReloader>();

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Integration/PopularityTransferIntegrationTests.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/Integration/PopularityTransferIntegrationTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Wrappers;
+using NuGet.Services.Metadata.Catalog;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,6 +26,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch.Integration
         private readonly Auxiliary2AzureSearchConfiguration _config;
         private readonly AzureSearchJobDevelopmentConfiguration _developmentConfig;
         private readonly Mock<IAzureSearchTelemetryService> _telemetry;
+        private readonly Mock<IDownloadsV1JsonClient> _downloadsV1JsonClient;
         private readonly UpdateDownloadsCommand _target;
 
         private readonly PopularityTransferData _newPopularityTransfers;
@@ -35,6 +37,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch.Integration
         {
             _featureFlags = new Mock<IFeatureFlagService>();
             _telemetry = new Mock<IAzureSearchTelemetryService>();
+            _downloadsV1JsonClient = new Mock<IDownloadsV1JsonClient>();
 
             _config = new Auxiliary2AzureSearchConfiguration
             {
@@ -76,6 +79,7 @@ namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch.Integration
 
             var auxiliaryFileClient = new AuxiliaryFileClient(
                 _blobClient,
+                _downloadsV1JsonClient.Object,
                 auxiliaryOptions.Object,
                 _telemetry.Object,
                 output.GetLogger<AuxiliaryFileClient>());


### PR DESCRIPTION
Depends on https://github.com/NuGet/NuGet.Jobs/pull/1017.
Resolves https://github.com/NuGet/Engineering/issues/4042.
Progress on https://github.com/NuGet/Engineering/issues/4146.

This PR does two things:

1. Move downloads.v1.json downloading logic to a shared `DownloadsV1JsonClient` (this is @agr's logic from https://github.com/NuGet/NuGet.Jobs/pull/1017)
1. Use this `DownloadsV1JsonClient` in the Azure Search subsystem, which affects two jobs:
   1. Db2AzureSearch - this job must initialize download counts in the index from the new Synapse downloads.v1.json
   1. Auxiliary2AzureSearch - this job incrementally updates download counts in the index also using this new downloads.v1.json

This change is backwards compatible in such a way that if we do not set the new `DownloadsV1JsonUrl` config the old behavior (old stats pipeline) is still used.

When we roll out the change in PROD, we may need to increase the `MaxDownloadCountDecreases` setting. It's expected that there is a small (<2%) variance in download counts. This job is sensitive to download count decreases per a past bug mitigation:
https://github.com/NuGet/NuGet.Jobs/blob/be3a837ea4add2d6376f16da562d67f83699cce0/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/DownloadSetComparer.cs#L71-L74