### PR TITLE
Updating ServerCommon to 2.94

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.90.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.94.0</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>5.9.1</NuGetClientPackageVersion>
     <NuGetGalleryPackageVersion>4.4.5-dev-5065749</NuGetGalleryPackageVersion>
   </PropertyGroup>

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -47,7 +47,7 @@ namespace Ng
             { Arguments.StorageServerTimeoutInSeconds, Arguments.StorageServerTimeoutInSeconds }
         };
 
-        public static IDictionary<string, string> GetArguments(string[] args, int start, out ISecretInjector secretInjector)
+        public static IDictionary<string, string> GetArguments(string[] args, int start, out ICachingSecretInjector secretInjector)
         {
             var unprocessedArguments = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -78,9 +78,9 @@ namespace Ng
             Trace.TraceError("Required argument \"{0}\" not provided", name);
         }
 
-        private static ISecretInjector GetSecretInjector(IDictionary<string, string> arguments)
+        private static ICachingSecretInjector GetSecretInjector(IDictionary<string, string> arguments)
         {
-            ISecretReader secretReader;
+            ICachingSecretReader secretReader;
 
             var vaultName = arguments.GetOrDefault<string>(Arguments.VaultName);
             if (string.IsNullOrEmpty(vaultName))

--- a/src/Ng/Jobs/NgJob.cs
+++ b/src/Ng/Jobs/NgJob.cs
@@ -15,7 +15,7 @@ namespace Ng.Jobs
 {
     public abstract class NgJob
     {
-        protected ISecretInjector SecretInjector { get; private set; }
+        protected ICachingSecretInjector SecretInjector { get; private set; }
 
         protected readonly IDictionary<string, string> GlobalTelemetryDimensions;
         protected readonly ITelemetryClient TelemetryClient;
@@ -61,7 +61,7 @@ namespace Ng.Jobs
             return GetUsageBase();
         }
 
-        public void SetSecretInjector(ISecretInjector secretInjector)
+        public void SetSecretInjector(ICachingSecretInjector secretInjector)
         {
             SecretInjector = secretInjector;
         }

--- a/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobConfigurationManager.cs
@@ -199,6 +199,7 @@ namespace NuGet.Jobs
             var secretInjector = secretReaderFactory.CreateSecretInjector(secretReader);
 
             serviceContainer.AddService(typeof(ISecretInjector), secretInjector);
+            serviceContainer.AddService(typeof(ICachingSecretInjector), secretInjector);
 
             return InjectSecrets(secretInjector, argsDictionary);
         }

--- a/src/NuGet.Jobs.Common/JobBase.cs
+++ b/src/NuGet.Jobs.Common/JobBase.cs
@@ -114,7 +114,7 @@ namespace NuGet.Jobs
                 throw new ArgumentNullException(nameof(services));
             }
 
-            var secretInjector = services.GetRequiredService<ISecretInjector>();
+            var secretInjector = services.GetRequiredService<ICachingSecretInjector>();
             var connectionString = services.GetRequiredService<IOptionsSnapshot<T>>().Value.ConnectionString;
 
             return RegisterDatabase(GetDatabaseKey<T>(), connectionString, testConnection, secretInjector);
@@ -145,7 +145,7 @@ namespace NuGet.Jobs
                 throw new ArgumentException("Argument cannot be null or empty.", nameof(connectionStringArgName));
             }
 
-            var secretInjector = (ISecretInjector)serviceContainer.GetService(typeof(ISecretInjector));
+            var secretInjector = serviceContainer.GetRequiredService<ICachingSecretInjector>();
             var connectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, connectionStringArgName);
 
             return RegisterDatabase(connectionStringArgName, connectionString, testConnection, secretInjector);
@@ -160,7 +160,7 @@ namespace NuGet.Jobs
             string name,
             string connectionString,
             bool testConnection,
-            ISecretInjector secretInjector)
+            ICachingSecretInjector secretInjector)
         {
             var connectionFactory = new AzureSqlConnectionFactory(connectionString, secretInjector, Logger);
             SqlConnectionFactories[name] = connectionFactory;

--- a/src/NuGet.Jobs.Common/SecretReader/ISecretReaderFactory.cs
+++ b/src/NuGet.Jobs.Common/SecretReader/ISecretReaderFactory.cs
@@ -8,8 +8,8 @@ namespace NuGet.Jobs
 {
     public interface ISecretReaderFactory
     {
-        ISecretReader CreateSecretReader(IDictionary<string, string> settings);
+        ICachingSecretReader CreateSecretReader(IDictionary<string, string> settings);
 
-        ISecretInjector CreateSecretInjector(ISecretReader secretReader);
+        ICachingSecretInjector CreateSecretInjector(ISecretReader secretReader);
     }
 }

--- a/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
@@ -10,7 +10,7 @@ namespace NuGet.Jobs
 {
     public class SecretReaderFactory : ISecretReaderFactory
     {
-        public ISecretReader CreateSecretReader(IDictionary<string, string> settings)
+        public ICachingSecretReader CreateSecretReader(IDictionary<string, string> settings)
         {
             if (JobConfigurationManager.TryGetArgument(settings, JobArgumentNames.VaultName) == null)
             {
@@ -49,7 +49,7 @@ namespace NuGet.Jobs
             return new CachingSecretReader(new KeyVaultReader(keyVaultConfiguration), refreshIntervalSec);
         }
 
-        public ISecretInjector CreateSecretInjector(ISecretReader secretReader)
+        public ICachingSecretInjector CreateSecretInjector(ISecretReader secretReader)
         {
             return new SecretInjector(secretReader);
         }

--- a/src/Stats.RefreshClientDimension/RefreshClientDimensionJob.cs
+++ b/src/Stats.RefreshClientDimension/RefreshClientDimensionJob.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NuGet.Jobs;
 using NuGet.Services.KeyVault;
@@ -24,7 +25,7 @@ namespace Stats.RefreshClientDimension
 
         public override void Init(IServiceContainer serviceContainer, IDictionary<string, string> jobArgsDictionary)
         {
-            var secretInjector = (ISecretInjector)serviceContainer.GetService(typeof(ISecretInjector));
+            var secretInjector = serviceContainer.GetRequiredService<ICachingSecretInjector>();
             var statisticsDbConnectionString = JobConfigurationManager.GetArgument(jobArgsDictionary, JobArgumentNames.StatisticsDatabase);
             _statisticsDbConnectionFactory = new AzureSqlConnectionFactory(statisticsDbConnectionString, secretInjector);
 

--- a/tests/NuGet.Jobs.Common.Tests/JobBaseFacts.cs
+++ b/tests/NuGet.Jobs.Common.Tests/JobBaseFacts.cs
@@ -93,7 +93,7 @@ namespace NuGet.Jobs.Common.Tests
 
             public TestJob()
             {
-                var mockSecretInjector = new Mock<ISecretInjector>();
+                var mockSecretInjector = new Mock<ICachingSecretInjector>();
 
                 var galleryOptionsSnapshot = CreateMockOptionsSnapshot(
                     new GalleryDbConfiguration {
@@ -112,7 +112,7 @@ namespace NuGet.Jobs.Common.Tests
                     .Setup(x => x.GetService(It.IsAny<Type>()))
                     .Returns<Type>(serviceType =>
                     {
-                        if (serviceType == typeof(ISecretInjector))
+                        if (serviceType == typeof(ICachingSecretInjector))
                         {
                             return mockSecretInjector.Object;
                         }

--- a/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateVerificationResultFacts.cs
+++ b/tests/Validation.PackageSigning.ValidateCertificate.Tests/CertificateVerificationResultFacts.cs
@@ -75,14 +75,17 @@ namespace Validation.PackageSigning.ValidateCertificate.Tests
         [InlineData(EndCertificateStatus.Unknown, X509ChainStatusFlags.OfflineRevocation)]
         public void CannotCreateNonRevokedResultWithRevocationDate(EndCertificateStatus status, X509ChainStatusFlags flags)
         {
-            var exception = Assert.Throws<ArgumentException>(
-                    () => CreateResult()
-                            .WithStatus(status)
-                            .WithStatusFlags(flags)
-                            .WithRevocationTime(new DateTime(2000, 1, 2))
-                            .Build());
+            var revocationTime = new DateTime(2000, 1, 2);
+            var exception = Assert.Throws<ArgumentException>(() =>
+            {
+                return CreateResult()
+                    .WithStatus(status)
+                    .WithStatusFlags(flags)
+                    .WithRevocationTime(revocationTime)
+                    .Build();
+            });
 
-            Assert.StartsWith("End certificate revoked at 1/2/2000", exception.Message);
+            Assert.StartsWith($"End certificate revoked at {revocationTime.ToShortDateString()}", exception.Message);
             Assert.Contains($"status is {status}", exception.Message);
         }
 


### PR DESCRIPTION
Recent update to server common messed up Azure SQL connection factory made it depend on `ICachingSecretInjector`.
Updating DI setup and tests to accommodate.

Also, unrelated change: fix to locale-sensitive test.

Tested the change with Orchestrator.