### PR TITLE
Switch from Logger Scope to LogInformation to reduce noise

### DIFF
--- a/src/StatusAggregator/Collector/Cursor.cs
+++ b/src/StatusAggregator/Collector/Cursor.cs
@@ -26,37 +26,31 @@ namespace StatusAggregator.Collector
         public async Task<DateTime> Get(string name)
         {
             name = name ?? throw new ArgumentNullException(nameof(name));
+            _logger.LogInformation("Fetching cursor with name {CursorName}.", name);
+            var cursor = await _table.RetrieveAsync<CursorEntity>(name);
 
-            using (_logger.Scope("Fetching cursor with name {CursorName}.", name))
+            DateTime value;
+            if (cursor == null)
             {
-                var cursor = await _table.RetrieveAsync<CursorEntity>(name);
-
-                DateTime value;
-                if (cursor == null)
-                {
-                    // If we can't find a cursor, the job is likely uninitialized, so start at the beginning of time.
-                    value = DateTime.MinValue;
-                    _logger.LogInformation("Could not fetch cursor, reinitializing cursor at {CursorValue}.", value);
-                }
-                else
-                {
-                    value = cursor.Value;
-                    _logger.LogInformation("Fetched cursor with value {CursorValue}.", value);
-                }
-
-                return value;
+                // If we can't find a cursor, the job is likely uninitialized, so start at the beginning of time.
+                value = DateTime.MinValue;
+                _logger.LogInformation("Could not fetch cursor, reinitializing cursor at {CursorValue}.", value);
             }
+            else
+            {
+                value = cursor.Value;
+                _logger.LogInformation("Fetched cursor with value {CursorValue}.", value);
+            }
+
+            return value;
         }
 
         public Task Set(string name, DateTime value)
         {
             name = name ?? throw new ArgumentNullException(nameof(name));
-
-            using (_logger.Scope("Updating cursor with name {CursorName} to {CursorValue}.", name, value))
-            {
-                var cursorEntity = new CursorEntity(name, value);
-                return _table.InsertOrReplaceAsync(cursorEntity);
-            }
+            _logger.LogInformation("Updating cursor with name {CursorName} to {CursorValue}.", name, value);
+            var cursorEntity = new CursorEntity(name, value);
+            return _table.InsertOrReplaceAsync(cursorEntity);
         }
     }
 }

--- a/src/StatusAggregator/Export/ComponentExporter.cs
+++ b/src/StatusAggregator/Export/ComponentExporter.cs
@@ -31,65 +31,63 @@ namespace StatusAggregator.Export
 
         public IComponent Export()
         {
-            using (_logger.Scope("Exporting active entities to component."))
+            _logger.LogInformation("Exporting active entities to component.");
+
+            var rootComponent = _factory.Create();
+
+            // Apply the active entities to the component tree.
+            var activeEvents = _table
+                .GetActiveEntities<EventEntity>()
+                .ToList()
+                .Where(e =>
+                    _table
+                        .GetChildEntities<MessageEntity, EventEntity>(e)
+                        .ToList()
+                        .Any())
+                .ToList();
+
+            _logger.LogInformation("Found {EventCount} active events with messages.", activeEvents.Count);
+
+            var activeIncidentGroups = activeEvents
+                .SelectMany(e =>
+                    _table
+                        .GetChildEntities<IncidentGroupEntity, EventEntity>(e)
+                        .Where(i => i.IsActive)
+                        .ToList())
+                .ToList();
+
+            _logger.LogInformation("Found {GroupCount} active incident groups linked to active events with messages.", activeIncidentGroups.Count);
+
+            var activeEntities = activeIncidentGroups
+                .Concat<IComponentAffectingEntity>(activeEvents)
+                // Only apply entities with a non-Up status.
+                .Where(e => e.AffectedComponentStatus != (int)ComponentStatus.Up)
+                // If multiple events are affecting a single region, the event with the highest severity should affect the component.
+                .GroupBy(e => e.AffectedComponentPath)
+                .Select(g => g.OrderByDescending(e => e.AffectedComponentStatus).First())
+                .ToList();
+
+            _logger.LogInformation("Active entities affect {PathCount} distinct subcomponents.", activeEntities.Count);
+            foreach (var activeEntity in activeEntities)
             {
-                var rootComponent = _factory.Create();
+                _logger.LogInformation("Applying active entity affecting {AffectedComponentPath} of severity {AffectedComponentStatus} at {StartTime} to root component",
+                    activeEntity.AffectedComponentPath, (ComponentStatus)activeEntity.AffectedComponentStatus, activeEntity.StartTime);
 
-                // Apply the active entities to the component tree.
-                var activeEvents = _table
-                    .GetActiveEntities<EventEntity>()
-                    .ToList()
-                    .Where(e => 
-                        _table
-                            .GetChildEntities<MessageEntity, EventEntity>(e)
-                            .ToList()
-                            .Any())
-                    .ToList();
+                var currentComponent = rootComponent.GetByPath(activeEntity.AffectedComponentPath);
 
-                _logger.LogInformation("Found {EventCount} active events with messages.", activeEvents.Count);
-
-                var activeIncidentGroups = activeEvents
-                    .SelectMany(e => 
-                        _table
-                            .GetChildEntities<IncidentGroupEntity, EventEntity>(e)
-                            .Where(i => i.IsActive)
-                            .ToList())
-                    .ToList();
-
-                _logger.LogInformation("Found {GroupCount} active incident groups linked to active events with messages.", activeIncidentGroups.Count);
-
-                var activeEntities = activeIncidentGroups
-                    .Concat<IComponentAffectingEntity>(activeEvents)
-                    // Only apply entities with a non-Up status.
-                    .Where(e => e.AffectedComponentStatus != (int)ComponentStatus.Up)
-                    // If multiple events are affecting a single region, the event with the highest severity should affect the component.
-                    .GroupBy(e => e.AffectedComponentPath)
-                    .Select(g => g.OrderByDescending(e => e.AffectedComponentStatus).First())
-                    .ToList();
-
-                _logger.LogInformation("Active entities affect {PathCount} distinct subcomponents.", activeEntities.Count);
-                foreach (var activeEntity in activeEntities)
+                if (currentComponent == null)
                 {
-                    using (_logger.Scope("Applying active entity affecting {AffectedComponentPath} of severity {AffectedComponentStatus} at {StartTime} to root component",
-                        activeEntity.AffectedComponentPath, (ComponentStatus)activeEntity.AffectedComponentStatus, activeEntity.StartTime))
-                    {
-                        var currentComponent = rootComponent.GetByPath(activeEntity.AffectedComponentPath);
+                    _logger.LogWarning(
+                        "Couldn't find component with path {AffectedComponentPath} corresponding to active entities. Ignoring entity.",
+                        activeEntity.AffectedComponentPath);
 
-                        if (currentComponent == null)
-                        {
-                            _logger.LogWarning(
-                                "Couldn't find component with path {AffectedComponentPath} corresponding to active entities. Ignoring entity.",
-                                activeEntity.AffectedComponentPath);
-
-                            continue;
-                        }
-
-                        currentComponent.Status = (ComponentStatus)activeEntity.AffectedComponentStatus;
-                    }
+                    continue;
                 }
 
-                return rootComponent;
+                currentComponent.Status = (ComponentStatus)activeEntity.AffectedComponentStatus;
             }
+
+            return rootComponent;
         }
     }
 }

--- a/src/StatusAggregator/Export/EventExporter.cs
+++ b/src/StatusAggregator/Export/EventExporter.cs
@@ -26,29 +26,28 @@ namespace StatusAggregator.Export
 
         public Event Export(EventEntity eventEntity)
         {
-            using (_logger.Scope("Exporting event {EventRowKey}.", eventEntity.RowKey))
-            {
-                var messages = _table.GetChildEntities<MessageEntity, EventEntity>(eventEntity)
-                    .ToList()
-                    // Don't show empty messages.
-                    .Where(m => !string.IsNullOrEmpty(m.Contents))
-                    .ToList();
+            _logger.LogInformation("Exporting event {EventRowKey}.", eventEntity.RowKey);
 
-                _logger.LogInformation("Event has {MessageCount} messages that are not empty.", messages.Count);
-                
-                if (!messages.Any())
-                {
-                    return null;
-                }
-                
-                return new Event(
-                    eventEntity.AffectedComponentPath, 
-                    eventEntity.StartTime,
-                    eventEntity.EndTime, 
-                    messages
-                        .OrderBy(m => m.Time)
-                        .Select(m => new Message(m.Time, m.Contents)));
+            var messages = _table.GetChildEntities<MessageEntity, EventEntity>(eventEntity)
+                .ToList()
+                // Don't show empty messages.
+                .Where(m => !string.IsNullOrEmpty(m.Contents))
+                .ToList();
+
+            _logger.LogInformation("Event has {MessageCount} messages that are not empty.", messages.Count);
+
+            if (!messages.Any())
+            {
+                return null;
             }
+
+            return new Event(
+                eventEntity.AffectedComponentPath,
+                eventEntity.StartTime,
+                eventEntity.EndTime,
+                messages
+                    .OrderBy(m => m.Time)
+                    .Select(m => new Message(m.Time, m.Contents)));
         }
     }
 }

--- a/src/StatusAggregator/Export/StatusExporter.cs
+++ b/src/StatusAggregator/Export/StatusExporter.cs
@@ -35,14 +35,12 @@ namespace StatusAggregator.Export
 
         public async Task Export(DateTime cursor)
         {
-            using (_logger.Scope("Exporting service status."))
-            {
-                var rootComponent = _componentExporter.Export();
-                var recentEvents = _eventExporter.Export(cursor);
+            _logger.LogInformation("Exporting service status.");
+            var rootComponent = _componentExporter.Export();
+            var recentEvents = _eventExporter.Export(cursor);
 
-                var lastUpdated = await _cursor.Get(StatusUpdater.LastUpdatedCursorName);
-                await _serializer.Serialize(cursor, lastUpdated, rootComponent, recentEvents);
-            }
+            var lastUpdated = await _cursor.Get(StatusUpdater.LastUpdatedCursorName);
+            await _serializer.Serialize(cursor, lastUpdated, rootComponent, recentEvents);
         }
     }
 }

--- a/src/StatusAggregator/Export/StatusSerializer.cs
+++ b/src/StatusAggregator/Export/StatusSerializer.cs
@@ -40,16 +40,12 @@ namespace StatusAggregator.Export
         {
             ServiceStatus status;
             string statusJson;
-            using (_logger.Scope("Serializing service status."))
-            {
-                status = new ServiceStatus(lastBuilt, lastUpdated, rootComponent, recentEvents);
-                statusJson = JsonConvert.SerializeObject(status, Settings);
-            }
+            _logger.LogInformation("Serializing service status.");
+            status = new ServiceStatus(lastBuilt, lastUpdated, rootComponent, recentEvents);
+            statusJson = JsonConvert.SerializeObject(status, Settings);
 
-            using (_logger.Scope("Saving service status to blob storage."))
-            {
-                await _container.SaveBlobAsync(StatusBlobName, statusJson);
-            }
+            _logger.LogInformation("Saving service status to blob storage.");
+            await _container.SaveBlobAsync(StatusBlobName, statusJson);
         }
     }
 }

--- a/src/StatusAggregator/Factory/EventFactory.cs
+++ b/src/StatusAggregator/Factory/EventFactory.cs
@@ -31,13 +31,11 @@ namespace StatusAggregator.Factory
         public async Task<EventEntity> CreateAsync(ParsedIncident input)
         {
             var affectedPath = _pathProvider.Get(input);
-            using (_logger.Scope("Creating event for parsed incident with path {AffectedComponentPath}.", affectedPath))
-            {
-                var entity = new EventEntity(affectedPath, input.StartTime);
-                await _table.InsertOrReplaceAsync(entity);
+            _logger.LogInformation("Creating event for parsed incident with path {AffectedComponentPath}.", affectedPath);
+            var entity = new EventEntity(affectedPath, input.StartTime);
+            await _table.InsertOrReplaceAsync(entity);
 
-                return entity;
-            }
+            return entity;
         }
     }
 }

--- a/src/StatusAggregator/Factory/IncidentGroupFactory.cs
+++ b/src/StatusAggregator/Factory/IncidentGroupFactory.cs
@@ -36,18 +36,17 @@ namespace StatusAggregator.Factory
         {
             var eventEntity = await _aggregationProvider.GetAsync(input);
             var affectedPath = _pathProvider.Get(input);
-            using (_logger.Scope("Creating incident for parsed incident with path {AffectedComponentPath}.", affectedPath))
-            {
-                var incidentGroupEntity = new IncidentGroupEntity(
-                    eventEntity,
-                    affectedPath,
-                    (ComponentStatus)input.AffectedComponentStatus,
-                    input.StartTime);
+            _logger.LogInformation("Creating incident for parsed incident with path {AffectedComponentPath}.", affectedPath);
 
-                await _table.InsertOrReplaceAsync(incidentGroupEntity);
+            var incidentGroupEntity = new IncidentGroupEntity(
+                eventEntity,
+                affectedPath,
+                (ComponentStatus)input.AffectedComponentStatus,
+                input.StartTime);
 
-                return incidentGroupEntity;
-            }
+            await _table.InsertOrReplaceAsync(incidentGroupEntity);
+
+            return incidentGroupEntity;
         }
     }
 }

--- a/src/StatusAggregator/Messages/MessageChangeEventProcessor.cs
+++ b/src/StatusAggregator/Messages/MessageChangeEventProcessor.cs
@@ -31,28 +31,28 @@ namespace StatusAggregator.Messages
             IComponent rootComponent, 
             ExistingStartMessageContext existingStartMessageContext)
         {
-            using (_logger.Scope("Processing change of type {StatusChangeType} at {StatusChangeTimestamp} affecting {StatusChangePath} with status {StatusChangeStatus}.",
-                change.Type, change.Timestamp, change.AffectedComponentPath, change.AffectedComponentStatus))
+            _logger.LogInformation(
+                "Processing change of type {StatusChangeType} at {StatusChangeTimestamp} affecting {StatusChangePath} with status {StatusChangeStatus}.",
+                change.Type, change.Timestamp, change.AffectedComponentPath, change.AffectedComponentStatus);
+
+            _logger.LogInformation("Getting component affected by change.");
+            var component = rootComponent.GetByPath(change.AffectedComponentPath);
+            if (component == null)
             {
-                _logger.LogInformation("Getting component affected by change.");
-                var component = rootComponent.GetByPath(change.AffectedComponentPath);
-                if (component == null)
-                {
-                    _logger.LogWarning("Affected path {change.AffectedComponentPath} does not exist in component tree.", nameof(change));
-                    return Task.FromResult(existingStartMessageContext);
-                }
+                _logger.LogWarning("Affected path {change.AffectedComponentPath} does not exist in component tree.", nameof(change));
+                return Task.FromResult(existingStartMessageContext);
+            }
 
-                switch (change.Type)
-                {
-                    case MessageType.Start:
-                        return ProcessStartMessageAsync(change, eventEntity, rootComponent, component, existingStartMessageContext);
+            switch (change.Type)
+            {
+                case MessageType.Start:
+                    return ProcessStartMessageAsync(change, eventEntity, rootComponent, component, existingStartMessageContext);
 
-                    case MessageType.End:
-                        return ProcessEndMessageAsync(change, eventEntity, rootComponent, component, existingStartMessageContext);
+                case MessageType.End:
+                    return ProcessEndMessageAsync(change, eventEntity, rootComponent, component, existingStartMessageContext);
 
-                    default:
-                        throw new ArgumentException($"Unexpected message type {change.Type}", nameof(change));
-                }
+                default:
+                    throw new ArgumentException($"Unexpected message type {change.Type}", nameof(change));
             }
         }
 

--- a/src/StatusAggregator/Messages/MessageChangeEventProvider.cs
+++ b/src/StatusAggregator/Messages/MessageChangeEventProvider.cs
@@ -36,25 +36,23 @@ namespace StatusAggregator.Messages
             _logger.LogInformation("Event has {IncidentGroupsCount} linked incident groups.", linkedGroups.Count);
             foreach (var linkedGroup in linkedGroups)
             {
-                using (_logger.Scope("Getting status changes from incident group {IncidentGroupRowKey}.", linkedGroup.RowKey))
+                _logger.LogInformation("Getting status changes from incident group {IncidentGroupRowKey}.", linkedGroup.RowKey);
+                if (!_filter.CanPostMessages(linkedGroup, cursor))
                 {
-                    if (!_filter.CanPostMessages(linkedGroup, cursor))
-                    {
-                        _logger.LogInformation("Incident group did not pass filter. Cannot post messages about it.");
-                        continue;
-                    }
+                    _logger.LogInformation("Incident group did not pass filter. Cannot post messages about it.");
+                    continue;
+                }
 
-                    var path = linkedGroup.AffectedComponentPath;
-                    var status = (ComponentStatus)linkedGroup.AffectedComponentStatus;
-                    var startTime = linkedGroup.StartTime;
-                    _logger.LogInformation("Incident group started at {StartTime}.", startTime);
-                    events.Add(new MessageChangeEvent(startTime, path, status, MessageType.Start));
-                    if (!linkedGroup.IsActive)
-                    {
-                        var endTime = linkedGroup.EndTime.Value;
-                        _logger.LogInformation("Incident group ended at {EndTime}.", endTime);
-                        events.Add(new MessageChangeEvent(endTime, path, status, MessageType.End));
-                    }
+                var path = linkedGroup.AffectedComponentPath;
+                var status = (ComponentStatus)linkedGroup.AffectedComponentStatus;
+                var startTime = linkedGroup.StartTime;
+                _logger.LogInformation("Incident group started at {StartTime}.", startTime);
+                events.Add(new MessageChangeEvent(startTime, path, status, MessageType.Start));
+                if (!linkedGroup.IsActive)
+                {
+                    var endTime = linkedGroup.EndTime.Value;
+                    _logger.LogInformation("Incident group ended at {EndTime}.", endTime);
+                    events.Add(new MessageChangeEvent(endTime, path, status, MessageType.End));
                 }
             }
 

--- a/src/StatusAggregator/Messages/MessageContentBuilder.cs
+++ b/src/StatusAggregator/Messages/MessageContentBuilder.cs
@@ -41,30 +41,29 @@ namespace StatusAggregator.Messages
             string path,
             ComponentStatus status)
         {
-            using (_logger.Scope("Getting contents for message of type {MessageType} with path {ComponentPath} and status {ComponentStatus}.",
-                type, path, status))
+            _logger.LogInformation("Getting contents for message of type {MessageType} with path {ComponentPath} and status {ComponentStatus}.",
+                type, path, status);
+
+            if (!_messageTypeToMessageTemplate.TryGetValue(type, out string messageTemplate))
             {
-                if (!_messageTypeToMessageTemplate.TryGetValue(type, out string messageTemplate))
-                {
-                    throw new ArgumentException("Could not find a template for type.", nameof(type));
-                }
-
-                _logger.LogInformation("Using template {MessageTemplate}.", messageTemplate);
-
-                var nameString = GetName(path);
-                _logger.LogInformation("Using {ComponentName} for name of component.", nameString);
-
-                var actionDescription = GetActionDescriptionFromPath(path);
-                if (actionDescription == null)
-                {
-                    throw new ArgumentException("Could not find an action description for path.", nameof(path));
-                }
-
-                var statusString = status.ToString().ToLowerInvariant();
-                var contents = string.Format(messageTemplate, nameString, statusString, actionDescription);
-                _logger.LogInformation("Returned {Contents} for contents of message.", contents);
-                return contents;
+                throw new ArgumentException("Could not find a template for type.", nameof(type));
             }
+
+            _logger.LogInformation("Using template {MessageTemplate}.", messageTemplate);
+
+            var nameString = GetName(path);
+            _logger.LogInformation("Using {ComponentName} for name of component.", nameString);
+
+            var actionDescription = GetActionDescriptionFromPath(path);
+            if (actionDescription == null)
+            {
+                throw new ArgumentException("Could not find an action description for path.", nameof(path));
+            }
+
+            var statusString = status.ToString().ToLowerInvariant();
+            var contents = string.Format(messageTemplate, nameString, statusString, actionDescription);
+            _logger.LogInformation("Returned {Contents} for contents of message.", contents);
+            return contents;
         }
 
         private string GetName(string path)

--- a/src/StatusAggregator/Parse/AggregateIncidentParser.cs
+++ b/src/StatusAggregator/Parse/AggregateIncidentParser.cs
@@ -28,19 +28,17 @@ namespace StatusAggregator.Parse
 
         public IEnumerable<ParsedIncident> ParseIncident(Incident incident)
         {
-            using (_logger.Scope("Parsing incident {IncidentId}", incident.Id))
+            _logger.LogInformation("Parsing incident {IncidentId}", incident.Id);
+            var parsedIncidents = new List<ParsedIncident>();
+            foreach (var incidentParser in _incidentParsers)
             {
-                var parsedIncidents = new List<ParsedIncident>();
-                foreach (var incidentParser in _incidentParsers)
+                if (incidentParser.TryParseIncident(incident, out var parsedIncident))
                 {
-                    if (incidentParser.TryParseIncident(incident, out var parsedIncident))
-                    {
-                        parsedIncidents.Add(parsedIncident);
-                    }
+                    parsedIncidents.Add(parsedIncident);
                 }
-
-                return parsedIncidents;
             }
+
+            return parsedIncidents;
         }
     }
 }

--- a/src/StatusAggregator/Update/ActiveEventEntityUpdater.cs
+++ b/src/StatusAggregator/Update/ActiveEventEntityUpdater.cs
@@ -30,14 +30,12 @@ namespace StatusAggregator.Update
 
         public async Task UpdateAllAsync(DateTime cursor)
         {
-            using (_logger.Scope("Updating active events."))
+            _logger.LogInformation("Updating active events.");
+            var activeEvents = _table.GetActiveEntities<EventEntity>().ToList();
+            _logger.LogInformation("Updating {ActiveEventsCount} active events.", activeEvents.Count());
+            foreach (var activeEvent in activeEvents)
             {
-                var activeEvents = _table.GetActiveEntities<EventEntity>().ToList();
-                _logger.LogInformation("Updating {ActiveEventsCount} active events.", activeEvents.Count());
-                foreach (var activeEvent in activeEvents)
-                {
-                    await _updater.UpdateAsync(activeEvent, cursor);
-                }
+                await _updater.UpdateAsync(activeEvent, cursor);
             }
         }
     }

--- a/src/StatusAggregator/Update/EventMessagingUpdater.cs
+++ b/src/StatusAggregator/Update/EventMessagingUpdater.cs
@@ -29,11 +29,9 @@ namespace StatusAggregator.Update
 
         public Task UpdateAsync(EventEntity eventEntity, DateTime cursor)
         {
-            using (_logger.Scope("Updating messages for event {EventRowKey} at {Cursor}.", eventEntity.RowKey, cursor))
-            {
-                var changes = _provider.Get(eventEntity, cursor);
-                return _iterator.IterateAsync(changes, eventEntity);
-            }
+            _logger.LogInformation("Updating messages for event {EventRowKey} at {Cursor}.", eventEntity.RowKey, cursor);
+            var changes = _provider.Get(eventEntity, cursor);
+            return _iterator.IterateAsync(changes, eventEntity);
         }
     }
 }

--- a/src/StatusAggregator/Update/IncidentUpdater.cs
+++ b/src/StatusAggregator/Update/IncidentUpdater.cs
@@ -29,22 +29,20 @@ namespace StatusAggregator.Update
 
         public async Task UpdateAsync(IncidentEntity entity, DateTime cursor)
         {
-            using (_logger.Scope("Updating incident with ID {IncidentApiId}.", entity.IncidentApiId))
+            _logger.LogInformation("Updating incident with ID {IncidentApiId}.", entity.IncidentApiId);
+            if (!entity.IsActive)
             {
-                if (!entity.IsActive)
-                {
-                    return;
-                }
+                return;
+            }
 
-                var activeIncident = await _incidentApiClient.GetIncident(entity.IncidentApiId);
-                var endTime = activeIncident.MitigationData?.Date;
+            var activeIncident = await _incidentApiClient.GetIncident(entity.IncidentApiId);
+            var endTime = activeIncident.MitigationData?.Date;
 
-                if (endTime != null)
-                {
-                    entity.EndTime = endTime;
-                    _logger.LogInformation("Updated mitigation time of active incident to {MitigationTime}.", entity.EndTime);
-                    await _table.ReplaceAsync(entity);
-                }
+            if (endTime != null)
+            {
+                entity.EndTime = endTime;
+                _logger.LogInformation("Updated mitigation time of active incident to {MitigationTime}.", entity.EndTime);
+                await _table.ReplaceAsync(entity);
             }
         }
     }

--- a/src/StatusAggregator/Update/StatusUpdater.cs
+++ b/src/StatusAggregator/Update/StatusUpdater.cs
@@ -42,24 +42,23 @@ namespace StatusAggregator.Update
 
         public async Task Update(DateTime cursor)
         {
-            using (_logger.Scope("Updating service status."))
+            _logger.LogInformation("Updating service status.");
+
+            foreach (var manualStatusChangeCollector in _manualStatusChangeCollectors)
             {
-                foreach (var manualStatusChangeCollector in _manualStatusChangeCollectors)
-                {
-                    await manualStatusChangeCollector.FetchLatest();
-                }
+                await manualStatusChangeCollector.FetchLatest();
+            }
 
-                try
-                {
-                    await _incidentCollector.FetchLatest();
-                    await _activeEventUpdater.UpdateAllAsync(cursor);
+            try
+            {
+                await _incidentCollector.FetchLatest();
+                await _activeEventUpdater.UpdateAllAsync(cursor);
 
-                    await _cursor.Set(LastUpdatedCursorName, cursor);
-                }
-                catch (Exception e)
-                {
-                    _logger.LogError(LogEvents.IncidentIngestionFailure, e, "Failed to update incident API data.");
-                }
+                await _cursor.Set(LastUpdatedCursorName, cursor);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(LogEvents.IncidentIngestionFailure, e, "Failed to update incident API data.");
             }
         }
 

--- a/src/Validation.Common.Job/FileDownloader.cs
+++ b/src/Validation.Common.Job/FileDownloader.cs
@@ -62,7 +62,7 @@ namespace NuGet.Jobs.Validation
                 throw new ArgumentNullException(nameof(cancellationToken));
             }
 
-            _logger.LogInformation("Attempting to download file from {FileUri}...", fileUri);
+            _logger.LogDebug("Attempting to download file from {FileUri}...", fileUri);
 
             Stream fileStream = null;
             var stopwatch = Stopwatch.StartNew();
@@ -127,7 +127,7 @@ namespace NuGet.Jobs.Validation
 
                 stopwatch.Stop();
 
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "Downloaded {FileSizeInBytes} bytes in {DownloadElapsedTime} seconds for request {FileUri}",
                     fileStream.Length,
                     stopwatch.Elapsed.TotalSeconds,


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4176

Looks like the StatusAggregator job uses Scopes extensively. This leads to a compounding effect each `_logger.Scope(...)` emits a "start" and "end" trace as well as includes the scope message on all log messages emitted in the scope.
![image](https://user-images.githubusercontent.com/94054/147496079-5e9389ea-aa02-4b33-a761-ebdd80617ed1.png)

This is too much for a job that has proven to be reliable. I switched from `_logger.Scope` to `_logger.Information`. The "scope" concept is great for jobs with high degrees or parallelism (e.g. validation jobs, Service Bus message processors) but StatusAggregator should not need that for debugging.

Also reduced the verbosity some `FileDownloader` messages which should help our package integrity job.

Best viewed by [hiding whitespace in the diff](https://github.com/NuGet/NuGet.Jobs/pull/1022/files?diff=split&w=1).