### PR TITLE
Less fragile China log processing.

### DIFF
--- a/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
+++ b/src/Stats.CollectAzureChinaCDNLogs/ChinaStatsCollector.cs
@@ -40,8 +40,8 @@ namespace Stats.CollectAzureChinaCDNLogs
 
         public override OutputLogLine TransformRawLogLine(string line)
         {
-            if (string.IsNullOrWhiteSpace(line) || 
-                string.IsNullOrEmpty(line) || 
+            if (string.IsNullOrWhiteSpace(line) ||
+                string.IsNullOrEmpty(line) ||
                 line.Trim().StartsWith("c-ip", ignoreCase: true, culture: CultureInfo.InvariantCulture))
             {
                 // Ignore empty lines or the header
@@ -63,7 +63,11 @@ namespace Stats.CollectAzureChinaCDNLogs
             const string notAvailableInt = "0";
 
             string timestamp = segments[(int)ChinaLogHeaderFields.timestamp];
-            DateTime dt = DateTime.Parse(timestamp, CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
+            if (!DateTime.TryParse(timestamp, CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal, out var dt))
+            {
+                _logger.LogError("Skipping a line with malformed timestamp: {MalformedDate}", timestamp);
+                return null;
+            }
             string timeStamp2 = ToUnixTimeStamp(dt);
 
             // Global status code format: cache status + "/" + HTTP status code

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
@@ -137,7 +137,6 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
                 .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(header + data)));
 
             var destinationMock = new Mock<ILogDestination>();
-            //var outputBuffer = new byte[1024 * 1024];
             var outputStream = new MemoryStream();
             var writeSucceeded = false;
             destinationMock

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
@@ -180,7 +180,7 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
             Assert.True(writeSucceeded);
             Assert.NotEmpty(outputLines);
             Assert.Equal("#Fields: timestamp time-taken c-ip filesize s-ip s-port sc-status sc-bytes cs-method cs-uri-stem - rs-duration rs-bytes c-referrer c-user-agent customer-id x-ec_custom-1", outputLines[0]);
-            Assert.Equal(expectedOutputLines, outputLines.Length - 1); // excluding header
+            Assert.True(expectedOutputLines <= outputLines.Length - 1); // excluding header
         }
     }
 }

--- a/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
+++ b/tests/Tests.Stats.CollectAzureChinaCDNLogs/ChinaCollectorTests.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Stats.AzureCdnLogs.Common;
@@ -32,8 +37,8 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
                 Mock.Of<ILogDestination>(),
                 Mock.Of<ILogger<ChinaStatsCollector>>());
 
-            var tranformedinput = collector.TransformRawLogLine(input);
-            string output = tranformedinput == null ? null : tranformedinput.ToString();
+            var transformedInput = collector.TransformRawLogLine(input);
+            string output = transformedInput == null ? null : transformedInput.ToString();
             Assert.Equal(expectedOutput, output);
         }
 
@@ -48,16 +53,135 @@ namespace Tests.Stats.CollectAzureChinaCDNLogs
                 Mock.Of<ILogDestination>(),
                 Mock.Of<ILogger<ChinaStatsCollector>>());
 
-            var tranformedInput = collector.TransformRawLogLine(input);
-            if (tranformedInput == null)
+            var transformedInput = collector.TransformRawLogLine(input);
+            if (transformedInput == null)
             {
                 return;
             }
-            string output = tranformedInput.ToString();
+            string output = transformedInput.ToString();
             const int lineNumber = 1;
             var logEntry = CdnLogEntryParser.ParseLogEntryFromLine(lineNumber, output, onErrorAction: null);
-            Assert.Contains(tranformedInput.XEc_Custom_1, logEntry.CustomField);
-            Assert.Contains(tranformedInput.CUserAgent, logEntry.UserAgent);
+            Assert.Contains(transformedInput.XEc_Custom_1, logEntry.CustomField);
+            Assert.Contains(transformedInput.CUserAgent, logEntry.UserAgent);
+        }
+
+        [Fact]
+        public void SkipsMalformedTimestamps()
+        {
+            const string data =
+                "1.2.3.4,malformed,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1";
+
+            var collector = new ChinaStatsCollector(
+                Mock.Of<ILogSource>(),
+                Mock.Of<ILogDestination>(),
+                Mock.Of<ILogger<ChinaStatsCollector>>());
+
+            OutputLogLine transformedInput = null;
+
+            var exception = Record.Exception(() => transformedInput = collector.TransformRawLogLine(data));
+            Assert.Null(exception);
+            Assert.Null(transformedInput);
+        }
+
+
+        // potential issues are with non-string columns as they are to be parsed for transformation, specifically:
+        // timestamp
+        // sc-status
+        // sc-bytes
+        // rs-duration(ms)
+        public static IEnumerable<object[]> LogsWithMalformedData => new object[][] {
+            new object[] {
+                // timestamp
+                "1.1.1.1,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1\n" +
+                "1.1.1.1,malformed,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1",
+                1
+            },
+            new object[] {
+                // sc-status
+                "1.1.1.2,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1\n" +
+                "1.1.1.2,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,malformed,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1",
+                1
+            },
+            new object[] {
+                // sc-bytes
+                "1.1.1.3,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1\n" +
+                "1.1.1.3,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,malformed,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1",
+                1
+            },
+            new object[] {
+                // rs-duration(ms)
+                "1.1.1.4,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",796,MISS,4.3.2.1\n" +
+                "1.1.1.4,4/6/2019 4:00:20 PM +00:00,GET,\"/v3-flatcontainer/microsoft.codeanalysis.common/1.2.2/microsoft.codeanalysis.common.1.2.2.nupkg\",HTTPS,200,2044843,\"NULL\",\"NuGet VS VSIX/4.7.0 (Microsoft Windows NT 10.0.17134.0, VS Enterprise/15.0)\",malformed,MISS,4.3.2.1",
+                1
+            },
+        };
+
+        [Theory]
+        [MemberData(nameof(LogsWithMalformedData))]
+        public async Task SkipsLinesWithMalformedColumns(string data, int expectedOutputLines)
+        {
+            const string header = "c-ip, timestamp, cs-method, cs-uri-stem, http-ver, sc-status, sc-bytes, c-referer, c-user-agent, rs-duration(ms), hit-miss, s-ip\n";
+            var sourceUri = new Uri("https://example.com/log1");
+
+            var sourceMock = new Mock<ILogSource>();
+            sourceMock
+                .Setup(s => s.GetFilesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<string>()))
+                .ReturnsAsync((IEnumerable<Uri>)new List<Uri> { sourceUri });
+
+            sourceMock
+                .Setup(s => s.TakeLockAsync(sourceUri, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AzureBlobLockResult(new Microsoft.WindowsAzure.Storage.Blob.CloudBlob(sourceUri), true, "foo", CancellationToken.None));
+
+            sourceMock
+                .Setup(s => s.OpenReadAsync(sourceUri, It.IsAny<ContentType>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(header + data)));
+
+            var destinationMock = new Mock<ILogDestination>();
+            //var outputBuffer = new byte[1024 * 1024];
+            var outputStream = new MemoryStream();
+            var writeSucceeded = false;
+            destinationMock
+                .Setup(d => d.TryWriteAsync(It.IsAny<Stream>(), It.IsAny<Action<Stream, Stream>>(), It.IsAny<string>(), It.IsAny<ContentType>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Stream inputStream, Action<Stream, Stream> writeAction, string destinationFileName, ContentType destinationContentType, CancellationToken token) =>
+                {
+                    try
+                    {
+                        writeAction(inputStream, outputStream);
+                        writeSucceeded = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        return new AsyncOperationResult(false, ex);
+                    }
+                    return new AsyncOperationResult(true, null);
+                });
+
+            var collector = new ChinaStatsCollector(
+                sourceMock.Object,
+                destinationMock.Object,
+                Mock.Of<ILogger<ChinaStatsCollector>>());
+
+            await collector.TryProcessAsync(
+                maxFileCount: 10,
+                fileNameTransform: s => s,
+                sourceContentType: ContentType.Text,
+                destinationContentType: ContentType.Text,
+                CancellationToken.None);
+
+            string[] outputLines = null;
+
+            // need to reopen closed stream
+            var outputBuffer = outputStream.ToArray();
+            outputStream = new MemoryStream(outputBuffer);
+            using (var streamReader = new StreamReader(outputStream))
+            {
+                outputLines = streamReader.ReadToEnd().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+
+            Assert.True(writeSucceeded);
+            Assert.NotEmpty(outputLines);
+            Assert.Equal("#Fields: timestamp time-taken c-ip filesize s-ip s-port sc-status sc-bytes cs-method cs-uri-stem - rs-duration rs-bytes c-referrer c-user-agent customer-id x-ec_custom-1", outputLines[0]);
+            Assert.Equal(expectedOutputLines, outputLines.Length - 1); // excluding header
         }
     }
 }


### PR DESCRIPTION
A naive-ish attempt at addressing https://github.com/NuGet/Engineering/issues/3557.

Removed one `Parse` call with `TryParse` and failure handling.
`CdnLogEntryParser.ParseLogEntryFromLine` is now called in a form that logs parse failures instead of throwing. Existing code already handles those failures.