### PR TITLE
Fix feature flag DI issue in Search Service, clean up duplicated code

### DIFF
--- a/src/Ng/Jobs/LightningJob.cs
+++ b/src/Ng/Jobs/LightningJob.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -540,7 +541,9 @@ namespace Ng.Jobs
                 config.EnsureSingleSnapshot = true;
             });
 
-            services.AddCatalog2Registration(GlobalTelemetryDimensions);
+            services.AddCatalog2Registration(
+                GlobalTelemetryDimensions,
+                new ConfigurationRoot(new List<Microsoft.Extensions.Configuration.IConfigurationProvider>()));
 
             var containerBuilder = new ContainerBuilder();
             containerBuilder.AddCatalog2Registration();

--- a/src/NuGet.Jobs.Catalog2Registration/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/DependencyInjectionExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Autofac;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -22,6 +23,8 @@ namespace NuGet.Jobs.Catalog2Registration
 
         public static ContainerBuilder AddCatalog2Registration(this ContainerBuilder containerBuilder)
         {
+            containerBuilder.AddV3();
+
             RegisterCursorStorage(containerBuilder);
 
             containerBuilder
@@ -79,9 +82,10 @@ namespace NuGet.Jobs.Catalog2Registration
 
         public static IServiceCollection AddCatalog2Registration(
             this IServiceCollection services,
-            IDictionary<string, string> telemetryGlobalDimensions)
+            IDictionary<string, string> telemetryGlobalDimensions,
+            IConfigurationRoot configurationRoot)
         {
-            services.AddV3(telemetryGlobalDimensions);
+            services.AddV3(telemetryGlobalDimensions, configurationRoot);
 
             services.AddTransient<ICommitCollectorLogic, RegistrationCollectorLogic>();
             services.AddTransient<IHiveMerger, HiveMerger>();

--- a/src/NuGet.Jobs.Catalog2Registration/Job.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Job.cs
@@ -30,7 +30,7 @@ namespace NuGet.Jobs
 
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
-            services.AddCatalog2Registration(GlobalTelemetryDimensions);
+            services.AddCatalog2Registration(GlobalTelemetryDimensions, configurationRoot);
 
             services.Configure<Catalog2RegistrationConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<CommitCollectorConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));

--- a/src/NuGet.Jobs.Catalog2Registration/Schema/EntityBuilder.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Schema/EntityBuilder.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using Microsoft.Extensions.Options;
 using NuGet.Protocol.Catalog;
 using NuGet.Protocol.Registration;

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -221,12 +221,9 @@ namespace NuGet.Jobs
                 .As<IFeatureFlagStorageService>();
         }
 
-        public static void ConfigureFeatureFlagServices(IServiceCollection services, IConfigurationRoot configurationRoot = null)
+        public static void ConfigureFeatureFlagServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
-            if (configurationRoot != null)
-            {
-                services.Configure<FeatureFlagConfiguration>(configurationRoot.GetSection(FeatureFlagConfigurationSectionName));
-            }
+            services.Configure<FeatureFlagConfiguration>(configurationRoot.GetSection(FeatureFlagConfigurationSectionName));
 
             services
                 .AddTransient(p =>
@@ -239,6 +236,7 @@ namespace NuGet.Jobs
                 });
 
             services.AddTransient<IFeatureFlagClient, FeatureFlagClient>();
+            services.AddTransient<ICloudBlobContainerInformationProvider, GalleryCloudBlobContainerInformationProvider>();
             services.AddTransient<IFeatureFlagTelemetryService, FeatureFlagTelemetryService>();
 
             services.AddSingleton<IFeatureFlagCacheService, FeatureFlagCacheService>();

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/DownloadSetComparer.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/DownloadSetComparer.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 {

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/IDownloadSetComparer.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/IDownloadSetComparer.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 {

--- a/src/NuGet.Services.AzureSearch/AzureSearchJob.cs
+++ b/src/NuGet.Services.AzureSearch/AzureSearchJob.cs
@@ -8,14 +8,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Rest;
 using NuGet.Jobs;
-using NuGet.Jobs.Configuration;
 
 namespace NuGet.Services.AzureSearch
 {
     public abstract class AzureSearchJob<T> : JsonConfigurationJob where T : IAzureSearchCommand
     {
-        private const string FeatureFlagConfigurationSectionName = "FeatureFlags";
-
         public override async Task Run()
         {
             ServicePointManager.DefaultConnectionLimit = 64;
@@ -47,9 +44,7 @@ namespace NuGet.Services.AzureSearch
 
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
-            services.AddAzureSearch(GlobalTelemetryDimensions);
-
-            services.Configure<FeatureFlagConfiguration>(configurationRoot.GetSection(FeatureFlagConfigurationSectionName));
+            services.AddAzureSearch(GlobalTelemetryDimensions, configurationRoot);
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using Autofac;
 using Microsoft.Azure.Search;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -31,7 +32,7 @@ namespace NuGet.Services.AzureSearch
     {
         public static ContainerBuilder AddAzureSearch(this ContainerBuilder containerBuilder)
         {
-            containerBuilder.AddFeatureFlags();
+            containerBuilder.AddV3();
 
             /// Here, we register services that depend on an interface that there are multiple implementations.
 
@@ -229,11 +230,10 @@ namespace NuGet.Services.AzureSearch
 
         public static IServiceCollection AddAzureSearch(
             this IServiceCollection services,
-            IDictionary<string, string> telemetryGlobalDimensions)
+            IDictionary<string, string> telemetryGlobalDimensions,
+            IConfigurationRoot configurationRoot)
         {
-            services.AddV3(telemetryGlobalDimensions);
-
-            services.AddFeatureFlags();
+            services.AddV3(telemetryGlobalDimensions, configurationRoot);
             services.AddTransient<IFeatureFlagService, FeatureFlagService>();
 
             services.AddTransient<ISearchServiceClientWrapper>(p => new SearchServiceClientWrapper(

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -56,7 +56,6 @@ namespace NuGet.Services.SearchService
 
             services.Configure<AzureSearchConfiguration>(Configuration.GetSection(ConfigurationSectionName));
             services.Configure<SearchServiceConfiguration>(Configuration.GetSection(ConfigurationSectionName));
-            services.Configure<FeatureFlagConfiguration>(Configuration.GetSection(FeatureFlagSectionName));
 
             services.AddApplicationInsightsTelemetry(o =>
             {
@@ -79,7 +78,7 @@ namespace NuGet.Services.SearchService
             services.AddHostedService<SecretRefresherBackgroundService>();
             services.AddHostedService<FeatureFlagBackgroundService>();
 
-            services.AddAzureSearch(new Dictionary<string, string>());
+            services.AddAzureSearch(new Dictionary<string, string>(), Configuration);
 
             // The maximum SNAT ports on Azure App Service is 128:
             // https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-intermittent-outbound-connection-errors#cause

--- a/src/NuGet.Services.V3/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.V3/DependencyInjectionExtensions.cs
@@ -1,38 +1,34 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using Autofac;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using NuGet.Jobs;
-using NuGet.Jobs.Configuration;
-using NuGet.Jobs.Validation;
 using NuGet.Protocol.Catalog;
 using NuGet.Protocol.Registration;
 using NuGet.Services.FeatureFlags;
 using NuGet.Services.Logging;
 using NuGet.Services.Metadata.Catalog;
-using NuGetGallery;
 using NuGetGallery.Diagnostics;
-using NuGetGallery.Features;
 
 namespace NuGet.Services.V3
 {
     public static class DependencyInjectionExtensions
     {
-        private const string FeatureFlagBindingKey = nameof(FeatureFlagBindingKey);
+        public static void AddV3(this ContainerBuilder containerBuilder)
+        {
+            JsonConfigurationJob.ConfigureFeatureFlagAutofacServices(containerBuilder);
+        }
 
-        private static readonly TimeSpan FeatureFlagServerTimeout = TimeSpan.FromSeconds(30);
-        private static readonly TimeSpan FeatureFlagMaxExecutionTime = TimeSpan.FromMinutes(10);
-
-        public static IServiceCollection AddV3(this IServiceCollection services, IDictionary<string, string> telemetryGlobalDimensions)
+        public static IServiceCollection AddV3(
+            this IServiceCollection services,
+            IDictionary<string, string> telemetryGlobalDimensions,
+            IConfigurationRoot configurationRoot)
         {
             services
                 .AddTransient(p => new HttpClientHandler
@@ -63,46 +59,7 @@ namespace NuGet.Services.V3
                 telemetryGlobalDimensions));
             services.AddTransient<IV3TelemetryService, V3TelemetryService>();
 
-            return services;
-        }
-
-        public static void AddFeatureFlags(this ContainerBuilder containerBuilder)
-        {
-            containerBuilder
-                .Register(c =>
-                {
-                    var options = c.Resolve<IOptionsSnapshot<FeatureFlagConfiguration>>();
-                    var requestOptions = new BlobRequestOptions
-                    {
-                        ServerTimeout = FeatureFlagServerTimeout,
-                        MaximumExecutionTime = FeatureFlagMaxExecutionTime,
-                        LocationMode = LocationMode.PrimaryThenSecondary,
-                        RetryPolicy = new ExponentialRetry(),
-                    };
-
-                    return new CloudBlobClientWrapper(
-                        options.Value.ConnectionString,
-                        requestOptions);
-                })
-                .Keyed<ICloudBlobClient>(FeatureFlagBindingKey);
-
-            containerBuilder
-                .Register(c => new CloudBlobCoreFileStorageService(
-                    c.ResolveKeyed<ICloudBlobClient>(FeatureFlagBindingKey),
-                    c.Resolve<IDiagnosticsService>(),
-                    c.Resolve<ICloudBlobContainerInformationProvider>()))
-                .Keyed<ICoreFileStorageService>(FeatureFlagBindingKey);
-
-            containerBuilder
-                .Register(c => new FeatureFlagFileStorageService(
-                    c.ResolveKeyed<ICoreFileStorageService>(FeatureFlagBindingKey)))
-                .As<IFeatureFlagStorageService>();
-        }
-
-        public static IServiceCollection AddFeatureFlags(this IServiceCollection services)
-        {
-            JsonConfigurationJob.ConfigureFeatureFlagServices(services);
-
+            JsonConfigurationJob.ConfigureFeatureFlagServices(services, configurationRoot);
             services.AddTransient<IFeatureFlagTelemetryService, V3TelemetryService>();
 
             return services;

--- a/src/Validation.Common.Job/SubscriptionProcessorJob.cs
+++ b/src/Validation.Common.Job/SubscriptionProcessorJob.cs
@@ -58,11 +58,6 @@ namespace NuGet.Jobs.Validation
             await featureFlagRefresher.StopAndWaitAsync();
         }
 
-        protected override void ConfigureDefaultJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
-        {
-            base.ConfigureDefaultJobServices(services, configurationRoot);
-        }
-
         protected static void ConfigureDefaultSubscriptionProcessor(ContainerBuilder containerBuilder)
         {
             const string bindingKey = "SubscriptionProcessorJob_SubscriptionProcessorKey";

--- a/tests/BasicSearchTests.FunctionalTests.Core/Models/V3SearchResultEntry.cs
+++ b/tests/BasicSearchTests.FunctionalTests.Core/Models/V3SearchResultEntry.cs
@@ -38,6 +38,8 @@ namespace BasicSearchTests.FunctionalTests.Core.Models
 
         public string[] Authors { get; set; }
 
+        public string[] Owners { get; set; }
+
         public long TotalDownloads { get; set; }
 
         public List<V3SearchResultPackageType> PackageTypes { get; set; }

--- a/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
+++ b/tests/NuGet.Services.AzureSearch.FunctionalTests/BasicTests/V3SearchProtocolTests.cs
@@ -402,6 +402,7 @@ namespace NuGet.Services.AzureSearch.FunctionalTests
             Assert.NotNull(results);
             Assert.NotEmpty(results.Data);
             Assert.Equal(Constants.TestPackageId, results.Data[0].Id);
+            Assert.Equal(Constants.TestPackageOwner, Assert.Single(results.Data[0].Owners));
         }
 
         [Fact]


### PR DESCRIPTION
Resolve https://github.com/NuGet/Engineering/issues/4194.

This bug only affects `dev` branch so we need this prior to the next merge.

The approach I took was to make a single path for registering feature flag dependencies. This removes so duplicated code and works because all services use the `"FeatureFlags"` configuration section in JSON.

Tests:
- [x] Verify locally
- [x] Add functional test to ensure owners in search keeps working (this is a hint the FF is not working)
- [x] Deploy orchestrator
- [x] Deploy process signature
- [x] Deploy a stats job
- [x] Deploy Azure Search jobs
- [x] Deploy Catalog2Registration
- [x] Deploy Azure Search service