### PR TITLE
[Search MSI 1] Move models and analyzers to new SDK

### DIFF
--- a/src/NuGet.Services.AzureSearch/Analysis/DescriptionCustomAnalyzer.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/DescriptionCustomAnalyzer.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -15,15 +14,15 @@ namespace NuGet.Services.AzureSearch
     {
         public const string Name = "nuget_description_analyzer";
 
-        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(
-            Name,
-            PackageIdCustomTokenizer.Name,
-            new List<TokenFilterName>
+        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(Name, PackageIdCustomTokenizer.Name)
+        {
+            TokenFilters =
             {
                 IdentifierCustomTokenFilter.Name,
                 TokenFilterName.Lowercase,
                 TokenFilterName.Stopwords,
                 TruncateCustomTokenFilter.Name,
-            });
+            }
+        };
     }
 }

--- a/src/NuGet.Services.AzureSearch/Analysis/ExactMatchCustomAnalyzer.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/ExactMatchCustomAnalyzer.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -14,12 +13,12 @@ namespace NuGet.Services.AzureSearch
     {
         public const string Name = "nuget_exact_match_analyzer";
 
-        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(
-            Name,
-            TokenizerName.Keyword,
-            new List<TokenFilterName>
+        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(Name, LexicalTokenizerName.Keyword)
+        {
+            TokenFilters =
             {
                 TokenFilterName.Lowercase
-            });
+            }
+        };
     }
 }

--- a/src/NuGet.Services.AzureSearch/Analysis/IdentifierCustomTokenFilter.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/IdentifierCustomTokenFilter.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -14,9 +14,10 @@ namespace NuGet.Services.AzureSearch
     {
         public const string Name = "nuget_id_filter";
 
-        public static WordDelimiterTokenFilter Instance = new WordDelimiterTokenFilter(
-            Name,
-            splitOnCaseChange: true,
-            preserveOriginal: true);
+        public static WordDelimiterTokenFilter Instance = new WordDelimiterTokenFilter(Name)
+        {
+            SplitOnCaseChange = true,
+            PreserveOriginal = true,
+        };
     }
 }

--- a/src/NuGet.Services.AzureSearch/Analysis/PackageIdCustomAnalyzer.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/PackageIdCustomAnalyzer.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -15,14 +14,14 @@ namespace NuGet.Services.AzureSearch
     {
         public const string Name = "nuget_package_id_analyzer";
 
-        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(
-            Name,
-            PackageIdCustomTokenizer.Name,
-            new List<TokenFilterName>
+        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(Name, PackageIdCustomTokenizer.Name)
+        {
+            TokenFilters =
             {
                 IdentifierCustomTokenFilter.Name,
                 TokenFilterName.Lowercase,
                 TruncateCustomTokenFilter.Name,
-            });
+            }
+        };
     }
 }

--- a/src/NuGet.Services.AzureSearch/Analysis/PackageIdCustomTokenizer.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/PackageIdCustomTokenizer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.Search.Models;
+﻿using Azure.Search.Documents.Indexes.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -10,8 +10,9 @@ namespace NuGet.Services.AzureSearch
     {
         public const string Name = "nuget_package_id_tokenizer";
 
-        public static readonly PatternTokenizer Instance = new PatternTokenizer(
-            Name,
-            @"[.\-_,;:'*#!~+()\[\]{}\s]");
+        public static readonly PatternTokenizer Instance = new PatternTokenizer(Name)
+        {
+            Pattern = @"[.\-_,;:'*#!~+()\[\]{}\s]",
+        };
     }
 }

--- a/src/NuGet.Services.AzureSearch/Analysis/TagsCustomAnalyzer.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/TagsCustomAnalyzer.cs
@@ -1,8 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -20,14 +19,14 @@ namespace NuGet.Services.AzureSearch
     {
         public const string Name = "nuget_tags_analyzer";
 
-        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(
-            Name,
-            TokenizerName.Keyword,
-            new List<TokenFilterName>
+        public static readonly CustomAnalyzer Instance = new CustomAnalyzer(Name, LexicalTokenizerName.Keyword)
+        {
+            TokenFilters =
             {
                 TokenFilterName.Lowercase,
                 TokenFilterName.Trim,
-                TokenFilterName.Unique
-            });
+                TokenFilterName.Unique,
+            }
+        };
     }
 }

--- a/src/NuGet.Services.AzureSearch/Analysis/TruncateCustomTokenFilter.cs
+++ b/src/NuGet.Services.AzureSearch/Analysis/TruncateCustomTokenFilter.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -13,8 +13,9 @@ namespace NuGet.Services.AzureSearch
     {
         public const string Name = "nuget_truncate_filter";
 
-        public static TruncateTokenFilter Instance = new TruncateTokenFilter(
-            Name,
-            length: 300);
+        public static TruncateTokenFilter Instance = new TruncateTokenFilter(Name)
+        {
+            Length = 300
+        };
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/BaseMetadataDocument.cs
@@ -2,28 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.Search;
-using Newtonsoft.Json;
+using Azure.Search.Documents.Indexes;
 
 namespace NuGet.Services.AzureSearch
 {
-    public abstract class BaseMetadataDocument : CommittedDocument, IBaseMetadataDocument
+    public class BaseMetadataDocument : CommittedDocument, IBaseMetadataDocument
     {
-        [IsFilterable]
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        [SimpleField(IsFilterable = true)]
         public int? SemVerLevel { get; set; }
 
-        [IsSearchable]
-        [Analyzer(DescriptionAnalyzer.Name)]
+        [SearchableField(AnalyzerName = DescriptionAnalyzer.Name)]
         public string Authors { get; set; }
 
         public string Copyright { get; set; }
 
-        [IsSortable]
+        [SimpleField(IsSortable = true)]
         public DateTimeOffset? Created { get; set; }
 
-        [IsSearchable]
-        [Analyzer(DescriptionAnalyzer.Name)]
+        [SearchableField(AnalyzerName = DescriptionAnalyzer.Name)]
         public string Description { get; set; }
 
         public long? FileSize { get; set; }
@@ -33,14 +29,13 @@ namespace NuGet.Services.AzureSearch
         public string IconUrl { get; set; }
         public string Language { get; set; }
 
-        [IsSortable]
+        [SimpleField(IsSortable = true)]
         public DateTimeOffset? LastEdited { get; set; }
 
         public string LicenseUrl { get; set; }
         public string MinClientVersion { get; set; }
 
-        [IsSearchable]
-        [Analyzer(ExactMatchCustomAnalyzer.Name)]
+        [SearchableField(AnalyzerName = ExactMatchCustomAnalyzer.Name)]
         public string NormalizedVersion { get; set; }
 
         public string OriginalVersion { get; set; }
@@ -48,42 +43,36 @@ namespace NuGet.Services.AzureSearch
         /// <summary>
         /// The package's identifier. Supports case insensitive exact matching.
         /// </summary>
-        [IsSearchable]
-        [Analyzer(ExactMatchCustomAnalyzer.Name)]
+        [SearchableField(AnalyzerName = ExactMatchCustomAnalyzer.Name)]
         public string PackageId { get; set; }
 
-        [IsFilterable]
+        [SimpleField(IsFilterable = true)]
         public bool? Prerelease { get; set; }
 
         public string ProjectUrl { get; set; }
 
-        [IsSortable]
-        [IsFilterable]
+        [SimpleField(IsSortable = true, IsFilterable = true)]
         public DateTimeOffset? Published { get; set; }
 
         public string ReleaseNotes { get; set; }
         public bool? RequiresLicenseAcceptance { get; set; }
 
-        [IsSortable]
+        [SimpleField(IsSortable = true)]
         public string SortableTitle { get; set; }
 
-        [IsSearchable]
-        [Analyzer(DescriptionAnalyzer.Name)]
+        [SearchableField(AnalyzerName = DescriptionAnalyzer.Name)]
         public string Summary { get; set; }
 
-        [IsSearchable]
-        [Analyzer(TagsCustomAnalyzer.Name)]
+        [SearchableField(AnalyzerName = TagsCustomAnalyzer.Name)]
         public string[] Tags { get; set; }
 
-        [IsSearchable]
-        [Analyzer(DescriptionAnalyzer.Name)]
+        [SearchableField(AnalyzerName = DescriptionAnalyzer.Name)]
         public string Title { get; set; }
 
         /// <summary>
         /// The package's identifier. Supports tokenized search.
         /// </summary>
-        [IsSearchable]
-        [Analyzer(PackageIdCustomAnalyzer.Name)]
+        [SearchableField(AnalyzerName = PackageIdCustomAnalyzer.Name)]
         public string TokenizedPackageId { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/CommittedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/CommittedDocument.cs
@@ -2,18 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.Search;
-using Newtonsoft.Json;
+using Azure.Search.Documents.Indexes;
 
 namespace NuGet.Services.AzureSearch
 {
     public abstract class CommittedDocument : UpdatedDocument, ICommittedDocument
     {
-        [IsSortable]
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        [SimpleField(IsSortable = true)]
         public DateTimeOffset? LastCommitTimestamp { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public string LastCommitId { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/HijackDocument.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -15,10 +14,9 @@ namespace NuGet.Services.AzureSearch
         /// All fields available in the hijack index. Used for reading the index and updating a document when
         /// <see cref="HijackDocumentChanges.UpdateMetadata"/> is <c>true</c>.
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class Full : BaseMetadataDocument, ILatest, IBaseMetadataDocument
         {
-            [IsFilterable]
+            [SimpleField(IsFilterable = true)]
             public bool? Listed { get; set; }
 
             public bool? IsLatestStableSemVer1 { get; set; }
@@ -31,7 +29,6 @@ namespace NuGet.Services.AzureSearch
         /// Used for updating a document when <see cref="HijackDocumentChanges.UpdateMetadata"/> is <c>false</c>
         /// and <see cref="HijackDocumentChanges.Delete"/> is <c>false</c>.
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class Latest : CommittedDocument, ILatest
         {
             public bool? IsLatestStableSemVer1 { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/KeyedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/KeyedDocument.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.ComponentModel.DataAnnotations;
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -11,15 +9,12 @@ namespace NuGet.Services.AzureSearch
     /// This is a base type but can be used directly for operations that only require a document key, such as deleting
     /// a document.
     /// </summary>
-    [SerializePropertyNamesAsCamelCase]
     public class KeyedDocument : IKeyedDocument
     {
         /// <remarks>
         /// This field is filterable and sortable so that the index can be reliably enumerated for diagnostic purposes.
         /// </remarks>
-        [Key]
-        [IsFilterable]
-        [IsSortable]
+        [SimpleField(IsKey = true, IsFilterable = true, IsSortable = true)]
         public string Key { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Indexes;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -16,17 +15,15 @@ namespace NuGet.Services.AzureSearch
         /// which has all fields available (as opposed to the catalog, which does not have all fields, like total
         /// download count).
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class Full : UpdateLatest, IDownloadCount, IIsExcludedByDefault
         {
-            [IsFilterable]
-            [IsSortable]
+            [SimpleField(IsFilterable = true, IsSortable = true)]
             public long? TotalDownloadCount { get; set; }
 
-            [IsFilterable]
+            [SimpleField(IsFilterable = true)]
             public double? DownloadScore { get; set; }
 
-            [IsFilterable]
+            [SimpleField(IsFilterable = true)]
             public bool? IsExcludedByDefault { get; set; }
         }
 
@@ -34,17 +31,15 @@ namespace NuGet.Services.AzureSearch
         /// Used when processing <see cref="SearchIndexChangeType.AddFirst"/>,
         /// <see cref="SearchIndexChangeType.UpdateLatest"/> or <see cref="SearchIndexChangeType.DowngradeLatest"/>.
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class UpdateLatest : BaseMetadataDocument, IVersions, IOwners
         {
-            [IsSearchable]
-            [Analyzer(ExactMatchCustomAnalyzer.Name)]
+            [SearchableField(AnalyzerName = ExactMatchCustomAnalyzer.Name)]
             public string[] Owners { get; set; }
 
-            [IsFilterable]
+            [SimpleField(IsFilterable = true)]
             public string SearchFilters { get; set; }
 
-            [IsFilterable]
+            [SimpleField(IsFilterable = true)]
             public string[] FilterablePackageTypes { get; set; }
 
             public string FullVersion { get; set; }
@@ -60,7 +55,6 @@ namespace NuGet.Services.AzureSearch
         /// need any analyzer or other Azure Search attributes since it is not used for index creation. The
         /// <see cref="Full"/> and its parent classes handle this.
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class UpdateVersionListAndOwners : UpdateVersionList, IOwners
         {
             public string[] Owners { get; set; }
@@ -69,7 +63,6 @@ namespace NuGet.Services.AzureSearch
         /// <summary>
         /// Used when processing <see cref="SearchIndexChangeType.UpdateVersionList"/>.
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class UpdateVersionList : CommittedDocument, IVersions
         {
             public string[] Versions { get; set; }
@@ -82,7 +75,6 @@ namespace NuGet.Services.AzureSearch
         /// other Azure Search attributes since it is not used for index creation. The <see cref="Full"/> and its
         /// parent classes handle this.
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class UpdateOwners : UpdatedDocument, IOwners
         {
             public string[] Owners { get; set; }
@@ -93,7 +85,6 @@ namespace NuGet.Services.AzureSearch
         /// not need any analyzer or other Azure Search attributes since it is not used for index creation. The
         /// <see cref="Full"/> and its parent classes handle this.
         /// </summary>
-        [SerializePropertyNamesAsCamelCase]
         public class UpdateDownloadCount : UpdatedDocument, IDownloadCount
         {
             public long? TotalDownloadCount { get; set; }

--- a/src/NuGet.Services.AzureSearch/Models/UpdatedDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/UpdatedDocument.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -10,17 +9,14 @@ namespace NuGet.Services.AzureSearch
     {
         private readonly CurrentTimestamp _lastUpdatedDocument = new CurrentTimestamp();
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public DateTimeOffset? LastUpdatedDocument
         {
             get => _lastUpdatedDocument.Value;
             set => _lastUpdatedDocument.Value = value;
         }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public string LastDocumentType { get; set; }
 
-        [JsonProperty(NullValueHandling = NullValueHandling.Include)]
         public bool? LastUpdatedFromCatalog { get; set; }
 
         public void SetLastUpdatedDocumentOnNextRead()

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.3" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.3.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexFields.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexFields.cs
@@ -1,17 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json.Serialization;
+using System.Text.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public static class IndexFields
     {
-        private static readonly NamingStrategy CamelCaseNamingStrategy = new CamelCaseNamingStrategy();
-
         private static string Name(string input)
         {
-            return CamelCaseNamingStrategy.GetPropertyName(input, hasSpecifiedName: false);
+            return JsonNamingPolicy.CamelCase.ConvertName(input);
         }
 
         public static readonly string Authors = Name(nameof(BaseMetadataDocument.Authors));


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4103.
Spec: https://github.com/NuGet/Engineering/blob/main/Server.Specs/AzureSearchManagedIdentities.md

This PR moves our Azure Search document models and analyzers from the old SDK (Microsoft.Azure.Search) to the new SDK (Azure.Search.Documents).

Note that this PR is into a feature branch (ab-newsdk) which will be used for an A/B test to assess performance and stability of this change. This PR is NOT ATOMIC meaning it does not work on its own. Instead, it shows an incremental step towards using the new SDK which as a whole is too large of a change for a single PR.