### PR TITLE
[Search MSI 3] Move index updater logic (search jobs) the new SDK

### DIFF
--- a/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/BaseDocumentBuilder.cs
@@ -111,7 +111,7 @@ namespace NuGet.Services.AzureSearch
             document.SemVerLevel = package.SemVerLevelKey;
             document.SortableTitle = GetSortableTitle(package.Title, packageId);
             document.Summary = package.Summary;
-            document.Tags = package.Tags == null ? null : Utils.SplitTags(package.Tags);
+            document.Tags = package.Tags == null ? Array.Empty<string>() : Utils.SplitTags(package.Tags);
             document.Title = GetTitle(package.Title, packageId);
             document.TokenizedPackageId = packageId;
 

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/DocumentFixUpEvaluator.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/DocumentFixUpEvaluator.cs
@@ -7,10 +7,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Logging;
 using NuGet.Packaging.Core;
+using NuGet.Services.AzureSearch.Wrappers;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Versioning;
 
@@ -50,7 +50,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
             // 1. The first step is to find all of the document keys that failed with a 404 Not Found error.
             var notFoundKeys = new HashSet<string>(innerEx
                 .IndexingResults
-                .Where(x => x.StatusCode == (int)HttpStatusCode.NotFound)
+                .Where(x => x.Status == (int)HttpStatusCode.NotFound)
                 .Select(x => x.Key));
             if (!notFoundKeys.Any())
             {

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/PackageEntityIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/PackageEntityIndexActionBuilder.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Logging;
 using NuGet.Services.Entities;
 using NuGet.Versioning;
@@ -110,7 +110,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     semVer2: x.SemVerLevelKey.HasValue && x.SemVerLevelKey.Value >= SemVerLevelKey.SemVer2));
         }
 
-        private IndexAction<KeyedDocument> GetSearchIndexAction(
+        private IndexDocumentsAction<KeyedDocument> GetSearchIndexAction(
             NewPackageRegistration packageRegistration,
             IReadOnlyDictionary<NuGetVersion, Package> versionToPackage,
             VersionLists versionLists,
@@ -119,7 +119,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         {
             if (changeType == SearchIndexChangeType.Delete)
             {
-                return IndexAction.Delete(_search.Keyed(
+                return IndexDocumentsAction.Delete(_search.Keyed(
                     packageRegistration.PackageId,
                     searchFilters));
             }
@@ -141,7 +141,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
             VerifyConsistency(packageRegistration.PackageId, package);
 
-            return IndexAction.Upload<KeyedDocument>(_search.FullFromDb(
+            return IndexDocumentsAction.Upload<KeyedDocument>(_search.FullFromDb(
                 packageRegistration.PackageId,
                 searchFilters,
                 latestFlags.LatestVersionInfo.ListedFullVersions,
@@ -154,7 +154,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 packageRegistration.IsExcludedByDefault));
         }
 
-        private IndexAction<KeyedDocument> GetHijackIndexAction(
+        private IndexDocumentsAction<KeyedDocument> GetHijackIndexAction(
             string packageId,
             Package package,
             HijackDocumentChanges changes)
@@ -168,7 +168,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
             VerifyConsistency(packageId, package);
 
-            return IndexAction.Upload<KeyedDocument>(_hijack.FullFromDb(
+            return IndexDocumentsAction.Upload<KeyedDocument>(_hijack.FullFromDb(
                 packageId,
                 changes,
                 package));

--- a/src/NuGet.Services.AzureSearch/IndexActions.cs
+++ b/src/NuGet.Services.AzureSearch/IndexActions.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Models;
 
 namespace NuGet.Services.AzureSearch
 {
@@ -14,8 +14,8 @@ namespace NuGet.Services.AzureSearch
     public class IndexActions
     {
         public IndexActions(
-            IReadOnlyList<IndexAction<KeyedDocument>> search,
-            IReadOnlyList<IndexAction<KeyedDocument>> hijack,
+            IReadOnlyList<IndexDocumentsAction<KeyedDocument>> search,
+            IReadOnlyList<IndexDocumentsAction<KeyedDocument>> hijack,
             ResultAndAccessCondition<VersionListData> versionListDataResult)
         {
             Search = search ?? throw new ArgumentNullException(nameof(search));
@@ -23,8 +23,8 @@ namespace NuGet.Services.AzureSearch
             VersionListDataResult = versionListDataResult ?? throw new ArgumentNullException(nameof(versionListDataResult));
         }
 
-        public IReadOnlyList<IndexAction<KeyedDocument>> Search { get; }
-        public IReadOnlyList<IndexAction<KeyedDocument>> Hijack { get; }
+        public IReadOnlyList<IndexDocumentsAction<KeyedDocument>> Search { get; }
+        public IReadOnlyList<IndexDocumentsAction<KeyedDocument>> Hijack { get; }
         public ResultAndAccessCondition<VersionListData> VersionListDataResult { get; }
 
         public bool IsEmpty => Search.Count == 0 && Hijack.Count == 0;

--- a/src/NuGet.Services.AzureSearch/Models/KeyedDocumentConverter.cs
+++ b/src/NuGet.Services.AzureSearch/Models/KeyedDocumentConverter.cs
@@ -9,7 +9,7 @@ namespace NuGet.Services.AzureSearch
 {
     /// <summary>
     /// This converter is necessary since polymorphic deserialization is not supported by System.Text.Json and by
-    /// extensionion Azure.Search.Documents. However we leverage polymorphism for performance and ergonmics reasons
+    /// extension Azure.Search.Documents. However we leverage polymorphism for performance and ergonomics reasons
     /// in <see cref="BatchPusher"/>. Azure Search supports a mixture document types and actions in a single "index
     /// documents" REST API call so it is possible from a service perspective just not from the SDK, out of the box.
     /// 

--- a/src/NuGet.Services.AzureSearch/Models/KeyedDocumentConverter.cs
+++ b/src/NuGet.Services.AzureSearch/Models/KeyedDocumentConverter.cs
@@ -66,11 +66,13 @@ namespace NuGet.Services.AzureSearch
                 case BaseMetadataDocument baseMetadata:
                     JsonSerializer.Serialize(writer, baseMetadata, options);
                     break;
-                default:
+                case KeyedDocument keyed:
                     writer.WriteStartObject();
-                    writer.WriteString("key", value.Key);
+                    writer.WriteString("key", keyed.Key);
                     writer.WriteEndObject();
                     break;
+                default:
+                    throw new NotImplementedException();
             }
         }
     }

--- a/src/NuGet.Services.AzureSearch/Models/KeyedDocumentConverter.cs
+++ b/src/NuGet.Services.AzureSearch/Models/KeyedDocumentConverter.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NuGet.Services.AzureSearch
+{
+    /// <summary>
+    /// This converter is necessary since polymorphic deserialization is not supported by System.Text.Json and by
+    /// extensionion Azure.Search.Documents. However we leverage polymorphism for performance and ergonmics reasons
+    /// in <see cref="BatchPusher"/>. Azure Search supports a mixture document types and actions in a single "index
+    /// documents" REST API call so it is possible from a service perspective just not from the SDK, out of the box.
+    /// 
+    /// If new model types are introduced, they will need to be added to this switch statement.
+    /// 
+    /// Polymorphism in System.Text.Json:
+    /// https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-5-0#polymorphic-serialization
+    /// 
+    /// Azure Search REST API:
+    /// https://docs.microsoft.com/en-us/rest/api/searchservice/addupdate-or-delete-documents
+    /// </summary>
+    public class KeyedDocumentConverter : JsonConverter<KeyedDocument>
+    {
+        public static KeyedDocumentConverter Instance { get; } = new KeyedDocumentConverter();
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeof(KeyedDocument) == typeToConvert;
+        }
+
+        public override KeyedDocument Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // We don't need to implement the read method because we never query for KeyedDocument instances
+            // directly. Instead we query for full search document models, which doesn't require polymorphism.
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, KeyedDocument value, JsonSerializerOptions options)
+        {
+            // Each non-abstract class descending from KeyedDocument should be in this switch to allow serialization.
+            switch (value)
+            {
+                case SearchDocument.Full searchFull:
+                    JsonSerializer.Serialize(writer, searchFull, options);
+                    break;
+                case SearchDocument.UpdateLatest searchUpdateLatest:
+                    JsonSerializer.Serialize(writer, searchUpdateLatest, options);
+                    break;
+                case SearchDocument.UpdateVersionList searchUpdateVersionList:
+                    JsonSerializer.Serialize(writer, searchUpdateVersionList, options);
+                    break;
+                case SearchDocument.UpdateOwners searchUpdateOwners:
+                    JsonSerializer.Serialize(writer, searchUpdateOwners, options);
+                    break;
+                case SearchDocument.UpdateDownloadCount searchUpdateDownloadCount:
+                    JsonSerializer.Serialize(writer, searchUpdateDownloadCount, options);
+                    break;
+                case HijackDocument.Full hijackFull:
+                    JsonSerializer.Serialize(writer, hijackFull, options);
+                    break;
+                case HijackDocument.Latest hijackLatest:
+                    JsonSerializer.Serialize(writer, hijackLatest, options);
+                    break;
+                case BaseMetadataDocument baseMetadata:
+                    JsonSerializer.Serialize(writer, baseMetadata, options);
+                    break;
+                default:
+                    writer.WriteStartObject();
+                    writer.WriteString("key", value.Key);
+                    writer.WriteEndObject();
+                    break;
+            }
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchIndexActionBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchIndexActionBuilder.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Logging;
 
 namespace NuGet.Services.AzureSearch
@@ -47,7 +47,7 @@ namespace NuGet.Services.AzureSearch
             ///   two search documents to be updated, one for <see cref="SearchFilters.IncludePrerelease"/> and one for
             ///   <see cref="SearchFilters.IncludePrereleaseAndSemVer2"/>. The latest version for each of these two
             ///   documents is different.
-            var search = new List<IndexAction<KeyedDocument>>();
+            var search = new List<IndexDocumentsAction<KeyedDocument>>();
             var searchFilters = new List<SearchFilters>();
             foreach (var searchFilter in DocumentUtilities.AllSearchFilters)
             {
@@ -58,7 +58,7 @@ namespace NuGet.Services.AzureSearch
                 }
 
                 var document = buildDocument(searchFilter);
-                var indexAction = IndexAction.Merge(document);
+                var indexAction = IndexDocumentsAction.Merge(document);
                 search.Add(indexAction);
                 searchFilters.Add(searchFilter);
             }
@@ -70,7 +70,7 @@ namespace NuGet.Services.AzureSearch
                 searchFilters);
 
             // No changes are made to the hijack index.
-            var hijack = new List<IndexAction<KeyedDocument>>();
+            var hijack = new List<IndexDocumentsAction<KeyedDocument>>();
 
             // We never make any change to the version list but still want to push it back to storage. This will give
             // us an etag mismatch if the version list has changed. This is good because if the version list has

--- a/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/HijackDocumentBuilderFacts.cs
@@ -84,14 +84,14 @@ namespace NuGet.Services.AzureSearch
             }
 
             [Fact]
-            public void LeavesNullTagsAsNull()
+            public void SetsNullTagsAsEmptyArray()
             {
                 var package = Data.PackageEntity;
                 package.Tags = null;
 
                 var document = _target.FullFromDb(Data.PackageId, Data.HijackDocumentChanges, package);
 
-                Assert.Null(document.Tags);
+                Assert.Empty(document.Tags);
             }
 
             [Fact]

--- a/tests/NuGet.Services.AzureSearch.Tests/Models/KeyedDocumentConverterTest.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Models/KeyedDocumentConverterTest.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace NuGet.Services.AzureSearch
+{
+    public class KeyedDocumentConverterTest
+    {
+        public static IEnumerable<object[]> SerializesAllConcreteKeyedDocumentsTestData = typeof(KeyedDocument)
+            .Assembly
+            .GetTypes()
+            .Where(t => !t.IsAbstract && typeof(KeyedDocument).IsAssignableFrom(t))
+            .Where(t => t != typeof(KeyedDocument))
+            .Select(t => new object[] { t });
+
+        [Theory]
+        [MemberData(nameof(SerializesAllConcreteKeyedDocumentsTestData))]
+        public void SerializesAllConcreteKeyedDocuments(Type type)
+        {
+            var model = (KeyedDocument)Activator.CreateInstance(type);
+
+            Target.Write(Writer, model, Options);
+
+            var jsonDocument = JsonDocument.Parse(GetJson());
+            var properties = jsonDocument.RootElement.EnumerateObject().Select(x => x.Name).Distinct().ToList();
+            Assert.Contains("key", properties);
+            Assert.True(properties.Count > 1);
+        }
+
+        [Fact]
+        public void SerializesKeyedDocument()
+        {
+            var model = new KeyedDocument { Key = "skeleton" };
+
+            Target.Write(Writer, model, Options);
+
+            Assert.Equal("{\"key\":\"skeleton\"}", GetJson());
+        }
+
+        private string GetJson()
+        {
+            Writer.Flush();
+            Stream.Flush();
+            var json = Encoding.UTF8.GetString(Stream.ToArray());
+            return json;
+        }
+
+        public KeyedDocumentConverterTest()
+        {
+            Stream = new MemoryStream();
+            Writer = new Utf8JsonWriter(Stream);
+            Options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+
+            Target = new KeyedDocumentConverter();
+        }
+
+        private readonly KeyedDocumentConverter Target;
+        private readonly MemoryStream Stream;
+        private readonly Utf8JsonWriter Writer;
+        private readonly JsonSerializerOptions Options;
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4103.
Spec: https://github.com/NuGet/Engineering/blob/main/Server.Specs/AzureSearchManagedIdentities.md
Depends on https://github.com/NuGet/NuGet.Jobs/pull/1034.

This PR moves the index updater logic to the new SDK. This is essentially Db2AzureSearch, Catalog2AzureSearch, and Auxiliary2AzureSearch although the actual changes are in shared classes rather than at the top level. Most of the changes are pretty basic but the things I should call out are:

1. Batch indexing errors are surfaced a bit differently. See the `BatchPusher` for this.
2. The new SDK uses System.Text.Json which does not support polymorphic serialization. `BatchPusher` leverages this for simplicity in the API surface area so I needed to add a customer converter to detect the serialized type at runtime. See `KeyedDocumentConverter` for this.

Note that this PR is into a feature branch (ab-newsdk) which will be used for an A/B test to assess performance and stability of this change. This PR is NOT ATOMIC meaning it does not work on its own. Instead, it shows an incremental step towards using the new SDK which as a whole is too large of a change for a single PR.