### PR TITLE
[Search MSI 4] Remove Newtonsoft.Json annotations from search models (no longer needed)

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteContext.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteContext.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class AutocompleteContext
     {
-        [JsonProperty("@vocab")]
         [JsonPropertyName("@vocab")]
         public string Vocab { get; set; }
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AutocompleteResponse.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -12,15 +11,12 @@ namespace NuGet.Services.AzureSearch.SearchService
     /// </summary>
     public class AutocompleteResponse
     {
-        [JsonProperty("@context")]
         [JsonPropertyName("@context")]
         public AutocompleteContext Context { get; set; }
 
-        [JsonProperty("totalHits")]
         [JsonPropertyName("totalHits")]
         public long TotalHits { get; set; }
 
-        [JsonProperty("data")]
         [JsonPropertyName("data")]
         public List<string> Data { get; set; }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/AuxiliaryFilesMetadata.cs
@@ -2,14 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Newtonsoft.Json;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class AuxiliaryFilesMetadata
     {
-        [JsonConstructor]
         public AuxiliaryFilesMetadata(
             DateTimeOffset loaded,
             AuxiliaryFileMetadata downloads,

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/DebugInformation.cs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents;
+using NuGet.Services.AzureSearch.Wrappers;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -21,7 +22,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string IndexName { get; set; }
         public IndexOperationType IndexOperationType { get; set; }
         public string DocumentKey { get; set; }
-        public SearchParameters SearchParameters { get; set; }
+        public SearchOptions SearchParameters { get; set; }
         public string SearchText { get; set; }
         public object DocumentSearchResult { get; set; }
         public TimeSpan? QueryDuration { get; set; }
@@ -44,9 +45,9 @@ namespace NuGet.Services.AzureSearch.SearchService
         public static DebugInformation CreateFromSearchOrNull<T>(
             SearchRequest request,
             string indexName,
-            SearchParameters parameters,
+            SearchOptions parameters,
             string text,
-            DocumentSearchResult<T> result,
+            SingleSearchResultPage<T> result,
             TimeSpan duration,
             AuxiliaryFilesMetadata auxiliaryFilesMetadata) where T : class
         {

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchResponse.cs
@@ -3,17 +3,14 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class V2SearchResponse
     {
-        [JsonProperty("totalHits")]
         [JsonPropertyName("totalHits")]
         public long TotalHits { get; set; }
 
-        [JsonProperty("data")]
         [JsonPropertyName("data")]
         public List<V2SearchPackage> Data { get; set; }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchContext.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchContext.cs
@@ -1,18 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public class V3SearchContext
     {
-        [JsonProperty("@vocab")]
         [JsonPropertyName("@vocab")]
         public string Vocab { get; set; }
 
-        [JsonProperty("@base")]
         [JsonPropertyName("@base")]
         public string Base { get; set; }
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackage.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -12,75 +11,57 @@ namespace NuGet.Services.AzureSearch.SearchService
     /// </summary>
     public class V3SearchPackage
     {
-        [JsonProperty("@id")]
         [JsonPropertyName("@id")]
         public string AtId { get; set; }
 
-        [JsonProperty("@type")]
         [JsonPropertyName("@type")]
         public string Type { get; set; }
 
-        [JsonProperty("registration")]
         [JsonPropertyName("registration")]
         public string Registration { get; set; }
 
-        [JsonProperty("id")]
         [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        [JsonProperty("version")]
         [JsonPropertyName("version")]
         public string Version { get; set; }
 
-        [JsonProperty("description")]
         [JsonPropertyName("description")]
         public string Description { get; set; }
 
-        [JsonProperty("summary")]
         [JsonPropertyName("summary")]
         public string Summary { get; set; }
 
-        [JsonProperty("title")]
         [JsonPropertyName("title")]
         public string Title { get; set; }
 
-        [JsonProperty("iconUrl")]
         [JsonPropertyName("iconUrl")]
         public string IconUrl { get; set; }
 
-        [JsonProperty("licenseUrl")]
         [JsonPropertyName("licenseUrl")]
         public string LicenseUrl { get; set; }
 
-        [JsonProperty("projectUrl")]
         [JsonPropertyName("projectUrl")]
         public string ProjectUrl { get; set; }
 
-        [JsonProperty("tags")]
         [JsonPropertyName("tags")]
         public string[] Tags { get; set; }
 
-        [JsonProperty("authors")]
         [JsonPropertyName("authors")]
         public string[] Authors { get; set; }
 
-        [JsonProperty("owners")]
         [JsonPropertyName("owners")]
         public string[] Owners { get; set; }
 
-        [JsonProperty("totalDownloads")]
         [JsonPropertyName("totalDownloads")]
         public long TotalDownloads { get; set; }
 
-        [JsonProperty("verified")]
         [JsonPropertyName("verified")]
         public bool Verified { get; set; }
 
-        [JsonProperty("packageTypes")]
         [JsonPropertyName("packageTypes")]
         public List<V3SearchPackageType> PackageTypes { get; set; }
 
-        [JsonProperty("versions")]
         [JsonPropertyName("versions")]
         public List<V3SearchVersion> Versions { get; set; }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackageType.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchPackageType.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -11,7 +10,6 @@ namespace NuGet.Services.AzureSearch.SearchService
     /// </summary>
     public class V3SearchPackageType
     {
-        [JsonProperty("name")]
         [JsonPropertyName("name")]
         public string Name { get; set; }
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchResponse.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchResponse.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Newtonsoft.Json;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -12,15 +11,12 @@ namespace NuGet.Services.AzureSearch.SearchService
     /// </summary>
     public class V3SearchResponse
     {
-        [JsonProperty("@context")]
         [JsonPropertyName("@context")]
         public V3SearchContext Context { get; set; }
 
-        [JsonProperty("totalHits")]
         [JsonPropertyName("totalHits")]
         public long TotalHits { get; set; }
 
-        [JsonProperty("data")]
         [JsonPropertyName("data")]
         public List<V3SearchPackage> Data { get; set; }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchVersion.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchVersion.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 
 namespace NuGet.Services.AzureSearch.SearchService
@@ -12,15 +11,12 @@ namespace NuGet.Services.AzureSearch.SearchService
     /// </summary>
     public class V3SearchVersion
     {
-        [JsonProperty("version")]
         [JsonPropertyName("version")]
         public string Version { get; set; }
 
-        [JsonProperty("downloads")]
         [JsonPropertyName("downloads")]
         public long Downloads { get; set; }
 
-        [JsonProperty("@id")]
         [JsonPropertyName("@id")]
         public string AtId { get; set; }
     }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4103.
Spec: https://github.com/NuGet/Engineering/blob/main/Server.Specs/AzureSearchManagedIdentities.md
Depends on https://github.com/NuGet/NuGet.Jobs/pull/1035.

This PR removes old Newtonsoft.Json annotations from our models. We don't use Newtonsoft.Json for ingress or egress now.

Note that this PR is into a feature branch (ab-newsdk) which will be used for an A/B test to assess performance and stability of this change. This PR is NOT ATOMIC meaning it does not work on its own. Instead, it shows an incremental step towards using the new SDK which as a whole is too large of a change for a single PR.