### PR TITLE
[Search MSI 5] Move search service logic to the new SDK and new wrappers

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
@@ -12,15 +12,15 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class AzureSearchService : ISearchService
     {
         private readonly IIndexOperationBuilder _operationBuilder;
-        private readonly ISearchIndexClientWrapper _searchIndex;
-        private readonly ISearchIndexClientWrapper _hijackIndex;
+        private readonly ISearchClientWrapper _searchIndex;
+        private readonly ISearchClientWrapper _hijackIndex;
         private readonly ISearchResponseBuilder _responseBuilder;
         private readonly IAzureSearchTelemetryService _telemetryService;
 
         public AzureSearchService(
             IIndexOperationBuilder operationBuilder,
-            ISearchIndexClientWrapper searchIndex,
-            ISearchIndexClientWrapper hijackIndex,
+            ISearchClientWrapper searchIndex,
+            ISearchClientWrapper hijackIndex,
             ISearchResponseBuilder responseBuilder,
             IAzureSearchTelemetryService telemetryService)
         {
@@ -61,7 +61,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 case IndexOperationType.Get:
                     var documentResult = await Measure.DurationWithValueAsync(
-                        () => _searchIndex.Documents.GetOrNullAsync<SearchDocument.Full>(operation.DocumentKey));
+                        () => _searchIndex.GetOrNullAsync<SearchDocument.Full>(operation.DocumentKey));
 
                     output = _responseBuilder.V3FromSearchDocument(
                         request,
@@ -73,7 +73,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     break;
 
                 case IndexOperationType.Search:
-                    var result = await Measure.DurationWithValueAsync(() => _searchIndex.Documents.SearchAsync<SearchDocument.Full>(
+                    var result = await Measure.DurationWithValueAsync(() => _searchIndex.SearchAsync<SearchDocument.Full>(
                         operation.SearchText,
                         operation.SearchParameters));
 
@@ -106,7 +106,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             switch (operation.Type)
             {
                 case IndexOperationType.Search:
-                    var result = await Measure.DurationWithValueAsync(() => _searchIndex.Documents.SearchAsync<SearchDocument.Full>(
+                    var result = await Measure.DurationWithValueAsync(() => _searchIndex.SearchAsync<SearchDocument.Full>(
                         operation.SearchText,
                         operation.SearchParameters));
 
@@ -140,7 +140,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 case IndexOperationType.Get:
                     var documentResult = await Measure.DurationWithValueAsync(
-                        () => _hijackIndex.Documents.GetOrNullAsync<HijackDocument.Full>(operation.DocumentKey));
+                        () => _hijackIndex.GetOrNullAsync<HijackDocument.Full>(operation.DocumentKey));
 
                     // If the request is excluding SemVer 2.0.0 packages and the document is SemVer 2.0.0, filter it
                     // out. The must be done after fetching the document because some SemVer 2.0.0 packages are
@@ -175,7 +175,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     break;
 
                 case IndexOperationType.Search:
-                    var result = await Measure.DurationWithValueAsync(() => _hijackIndex.Documents.SearchAsync<HijackDocument.Full>(
+                    var result = await Measure.DurationWithValueAsync(() => _hijackIndex.SearchAsync<HijackDocument.Full>(
                         operation.SearchText,
                         operation.SearchParameters));
 
@@ -209,7 +209,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 case IndexOperationType.Get:
                     var documentResult = await Measure.DurationWithValueAsync(
-                        () => _searchIndex.Documents.GetOrNullAsync<SearchDocument.Full>(operation.DocumentKey));
+                        () => _searchIndex.GetOrNullAsync<SearchDocument.Full>(operation.DocumentKey));
 
                     output = _responseBuilder.V2FromSearchDocument(
                         request,
@@ -221,7 +221,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     break;
 
                 case IndexOperationType.Search:
-                    var result = await Measure.DurationWithValueAsync(() => _searchIndex.Documents.SearchAsync<SearchDocument.Full>(
+                    var result = await Measure.DurationWithValueAsync(() => _searchIndex.SearchAsync<SearchDocument.Full>(
                         operation.SearchText,
                         operation.SearchParameters));
 

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchParametersBuilder.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
     public interface ISearchParametersBuilder
     {
-        SearchParameters LastCommitTimestamp();
-        SearchParameters V2Search(V2SearchRequest request, bool isDefaultSearch);
-        SearchParameters V3Search(V3SearchRequest request, bool isDefaultSearch);
-        SearchParameters Autocomplete(AutocompleteRequest request, bool isDefaultSearch);
+        SearchOptions LastCommitTimestamp();
+        SearchOptions V2Search(V2SearchRequest request, bool isDefaultSearch);
+        SearchOptions V3Search(V3SearchRequest request, bool isDefaultSearch);
+        SearchOptions Autocomplete(AutocompleteRequest request, bool isDefaultSearch);
         SearchFilters GetSearchFilters(SearchRequest request);
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/ISearchResponseBuilder.cs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents;
+using NuGet.Services.AzureSearch.Wrappers;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -11,14 +12,14 @@ namespace NuGet.Services.AzureSearch.SearchService
         V2SearchResponse V2FromHijack(
             V2SearchRequest request,
             string text,
-            SearchParameters parameters,
-            DocumentSearchResult<HijackDocument.Full> result,
+            SearchOptions parameters,
+            SingleSearchResultPage<HijackDocument.Full> result,
             TimeSpan duration);
         V2SearchResponse V2FromSearch(
             V2SearchRequest request,
             string text,
-            SearchParameters parameters,
-            DocumentSearchResult<SearchDocument.Full> result,
+            SearchOptions parameters,
+            SingleSearchResultPage<SearchDocument.Full> result,
             TimeSpan duration);
         V2SearchResponse V2FromHijackDocument(
             V2SearchRequest request,
@@ -28,8 +29,8 @@ namespace NuGet.Services.AzureSearch.SearchService
         V3SearchResponse V3FromSearch(
             V3SearchRequest request,
             string text,
-            SearchParameters parameters,
-            DocumentSearchResult<SearchDocument.Full> result,
+            SearchOptions parameters,
+            SingleSearchResultPage<SearchDocument.Full> result,
             TimeSpan duration);
         V2SearchResponse V2FromSearchDocument(
             V2SearchRequest request,
@@ -44,8 +45,8 @@ namespace NuGet.Services.AzureSearch.SearchService
         AutocompleteResponse AutocompleteFromSearch(
             AutocompleteRequest request,
             string text,
-            SearchParameters parameters,
-            DocumentSearchResult<SearchDocument.Full> result,
+            SearchOptions parameters,
+            SingleSearchResultPage<SearchDocument.Full> result,
             TimeSpan duration);
         V2SearchResponse EmptyV2(V2SearchRequest request);
         V3SearchResponse EmptyV3(V3SearchRequest request);

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperation.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents;
 
 namespace NuGet.Services.AzureSearch.SearchService
 {
@@ -11,7 +11,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             IndexOperationType type,
             string documentKey,
             string searchText,
-            SearchParameters searchParameters)
+            SearchOptions searchParameters)
         {
             Type = type;
             DocumentKey = documentKey;
@@ -40,7 +40,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         /// The parameters to use for an Azure Search query.
         /// Used when <see cref="Type"/> is <see cref="IndexOperationType.Search"/>.
         /// </summary>
-        public SearchParameters SearchParameters { get; }
+        public SearchOptions SearchParameters { get; }
 
         public static IndexOperation Get(string documentKey)
         {
@@ -51,7 +51,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 searchParameters: null);
         }
 
-        public static IndexOperation Search(string text, SearchParameters parameters)
+        public static IndexOperation Search(string text, SearchOptions parameters)
         {
             return new IndexOperation(
                 IndexOperationType.Search,

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -4,9 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Azure.Search.Models;
+using Azure.Search.Documents;
 using Microsoft.Extensions.Options;
 using NuGet.Protocol.Registration;
+using NuGet.Services.AzureSearch.Wrappers;
 using NuGet.Services.Metadata.Catalog;
 using NuGet.Versioning;
 
@@ -62,8 +63,8 @@ namespace NuGet.Services.AzureSearch.SearchService
         public V2SearchResponse V2FromHijack(
             V2SearchRequest request,
             string text,
-            SearchParameters searchParameters,
-            DocumentSearchResult<HijackDocument.Full> result,
+            SearchOptions searchParameters,
+            SingleSearchResultPage<HijackDocument.Full> result,
             TimeSpan duration)
         {
             return ToResponse(
@@ -79,8 +80,8 @@ namespace NuGet.Services.AzureSearch.SearchService
         public V2SearchResponse V2FromSearch(
             V2SearchRequest request,
             string text,
-            SearchParameters parameters,
-            DocumentSearchResult<SearchDocument.Full> result,
+            SearchOptions parameters,
+            SingleSearchResultPage<SearchDocument.Full> result,
             TimeSpan duration)
         {
             return ToResponse(
@@ -160,12 +161,12 @@ namespace NuGet.Services.AzureSearch.SearchService
         public V3SearchResponse V3FromSearch(
             V3SearchRequest request,
             string text,
-            SearchParameters parameters,
-            DocumentSearchResult<SearchDocument.Full> result,
+            SearchOptions parameters,
+            SingleSearchResultPage<SearchDocument.Full> result,
             TimeSpan duration)
         {
-            var results = result.Results;
-            result.Results = null;
+            var results = result.Values;
+            result.Values = null;
 
             var registrationsBaseUrl = GetRegistrationsBaseUrl(request.IncludeSemVer2);
 
@@ -195,12 +196,12 @@ namespace NuGet.Services.AzureSearch.SearchService
         public AutocompleteResponse AutocompleteFromSearch(
             AutocompleteRequest request,
             string text,
-            SearchParameters parameters,
-            DocumentSearchResult<SearchDocument.Full> result,
+            SearchOptions parameters,
+            SingleSearchResultPage<SearchDocument.Full> result,
             TimeSpan duration)
         {
-            var results = result.Results;
-            result.Results = null;
+            var results = result.Values;
+            result.Values = null;
 
             List<string> data;
             switch (request.Type)
@@ -298,16 +299,16 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         private V2SearchResponse ToResponse<T>(
             V2SearchRequest request,
-            SearchParameters parameters,
+            SearchOptions parameters,
             string text,
             string indexName,
-            DocumentSearchResult<T> result,
+            SingleSearchResultPage<T> result,
             TimeSpan duration,
             Func<T, V2SearchPackage> toPackage)
             where T : class
         {
-            var results = result.Results;
-            result.Results = null;
+            var results = result.Values;
+            result.Values = null;
 
             if (request.CountOnly)
             {


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4103.
Spec: https://github.com/NuGet/Engineering/blob/main/Server.Specs/AzureSearchManagedIdentities.md
Depends on https://github.com/NuGet/NuGet.Jobs/pull/1036.

This PR moves the search service specific logic to the new SDK and wrappers. There's not much interesting to note on this. It's just type changes without any significant change to the flow.

Note that this PR is into a feature branch (ab-newsdk) which will be used for an A/B test to assess performance and stability of this change. This PR is NOT ATOMIC meaning it does not work on its own. Instead, it shows an incremental step towards using the new SDK which as a whole is too large of a change for a single PR.