### PR TITLE
[Search MSI 8] Allow classic index creation in the new SDK via API version hack

### DIFF
--- a/src/NuGet.Jobs.Db2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Db2AzureSearch/Job.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Net.Http;
+using Azure.Core.Pipeline;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Db2AzureSearch;
@@ -17,6 +20,19 @@ namespace NuGet.Jobs
         protected override void ConfigureJobServices(IServiceCollection services, IConfigurationRoot configurationRoot)
         {
             base.ConfigureJobServices(services, configurationRoot);
+
+            services.AddTransient<HttpPipelineTransport>(p =>
+            {
+                var options = p.GetRequiredService<IOptionsSnapshot<Db2AzureSearchConfiguration>>();
+                if (options.Value.UseClassicSimilarity)
+                {
+                    var clientHandler = p.GetRequiredService<HttpClientHandler>();
+                    var classicSimilarityHandler = new ClassicSimilarityHandler { InnerHandler = clientHandler };
+                    return new HttpClientTransport(classicSimilarityHandler);
+                }
+
+                return HttpClientTransport.Shared;
+            });
 
             services.Configure<Db2AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<AuxiliaryDataStorageConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/ClassicSimilarityHandler.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/ClassicSimilarityHandler.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Services.AzureSearch.Db2AzureSearch
+{
+    /// <summary>
+    /// This is a workaround for this problem:
+    /// https://github.com/Azure/azure-sdk-for-net/issues/26197
+    /// 
+    /// For it to work, the provided index must have a null (unset similarity value). This allows the Azure Search
+    /// REST API to pick the default similarity based on the API version.
+    /// 2020-06-30 and later defaults to BM25.
+    /// 2019-05-06 and earlier defaults to classic.
+    /// </summary>
+    public class ClassicSimilarityHandler : DelegatingHandler
+    {
+        private const string ExpectedPathAndQuery = "/indexes?api-version=2020-06-30";
+        private const string QueryReplacement = "api-version=2019-05-06";
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Only pacth the API version query parameter on the POST request to create an index. Leave everything else
+            // untouched.
+            if (request.Method == HttpMethod.Post
+                && request.RequestUri.PathAndQuery == ExpectedPathAndQuery)
+            {
+                var uriBuilder = new UriBuilder(request.RequestUri);
+                uriBuilder.Query = QueryReplacement;
+                request.RequestUri = uriBuilder.Uri;
+            }
+
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/ClassicSimilarityHandler.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/ClassicSimilarityHandler.cs
@@ -24,7 +24,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            // Only pacth the API version query parameter on the POST request to create an index. Leave everything else
+            // Only patch the API version query parameter on the POST request to create an index. Leave everything else
             // untouched.
             if (request.Method == HttpMethod.Post
                 && request.RequestUri.PathAndQuery == ExpectedPathAndQuery)

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
@@ -15,5 +15,12 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
         public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
         public string DownloadsV1JsonUrl { get; set; }
+
+        /// <summary>
+        /// Toggles the usage of <see cref="ClassicSimilarityHandler"/>. This allows the creation of a search index
+        /// with "classic" similarity. By default, indexes created with the new SDK use "BM25" similarity with yields
+        /// slightly different search relevance.
+        /// </summary>
+        public bool UseClassicSimilarity { get; set; }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4103.
Spec: https://github.com/NuGet/Engineering/blob/main/Server.Specs/AzureSearchManagedIdentities.md
Depends on https://github.com/NuGet/NuGet.Jobs/pull/1039.

This PR adds the hack mentioned in the spec which allows us to create classic similarity indexes using the new SDK. It was shown to the SDK team (https://github.com/Azure/azure-sdk-for-net/issues/26197) and they said "awesome" 😄:
https://github.com/Azure/azure-sdk-for-net/issues/26197#issuecomment-1011412123

Note that this PR is into a feature branch (ab-newsdk) which will be used for an A/B test to assess performance and stability of this change. This PR brings the feature branch to a building and passing state.