### PR TITLE
Delete redundant test (fix TSA VSTHRD110)

### DIFF
--- a/tests/Validation.PackageSigning.Core.Tests/Storage/CertificateStoreTests.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Storage/CertificateStoreTests.cs
@@ -50,7 +50,7 @@ namespace Validation.PackageSigning.Core.Tests
         public class TheLoadAsyncMethod
         {
             [Fact]
-            public void UsesExpectedFileNameAndThrowsWhenCertificateFailedToLoadFromStorage()
+            public async Task UsesExpectedFileNameAndThrowsWhenCertificateFailedToLoadFromStorage()
             {
                 // Arrange
                 var certificate = TestResources.GetTestCertificate(TestResources.TrustedCARootCertificate);
@@ -74,7 +74,7 @@ namespace Validation.PackageSigning.Core.Tests
                 Task invocation() => certificateStore.LoadAsync(sha256Thumbprint, cancellationToken);
 
                 // Assert
-                Assert.ThrowsAsync<InvalidOperationException>(invocation);
+                await Assert.ThrowsAsync<InvalidOperationException>(invocation);
                 storage.Verify();
             }
 

--- a/tests/Validation.PackageSigning.Core.Tests/Storage/CertificateStoreTests.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Storage/CertificateStoreTests.cs
@@ -111,40 +111,6 @@ namespace Validation.PackageSigning.Core.Tests
         public class TheSaveAsyncMethod
         {
             [Fact]
-            public void UsesExpectedFileNameAndUriAndDoesNotOverwriteBlob()
-            {
-                // Arrange
-                var certificate = TestResources.GetTestCertificate(TestResources.TrustedCARootCertificate);
-                var sha256Thumbprint = certificate.ComputeSHA256Thumbprint();
-                var expectedFileName = GetExpectedFileName(sha256Thumbprint);
-                var expectedUri = GetExpectedUri(sha256Thumbprint);
-                var cancellationToken = CancellationToken.None;
-                var storage = new Mock<IStorage>(MockBehavior.Strict);
-                storage
-                    .Setup(m => m.ResolveUri(expectedFileName))
-                    .Returns(expectedUri).Verifiable();
-                storage
-                    .Setup(m => m.Save(
-                        expectedUri,
-                        It.IsAny<StreamStorageContent>(),
-                        false,
-                        cancellationToken))
-                    .Returns(Task.CompletedTask)
-                    .Verifiable();
-
-                var logger = new Mock<ILogger<CertificateStore>>(MockBehavior.Loose);
-                var certificateStore = new CertificateStore(storage.Object, logger.Object);
-
-                // Act
-                Task invocation() => certificateStore.SaveAsync(certificate, cancellationToken);
-
-                // Assert
-                Assert.ThrowsAsync<InvalidOperationException>(invocation);
-                storage.Verify();
-                certificate.Verify();
-            }
-
-            [Fact]
             public async Task SavesCertificateToStorage()
             {
                 // Arrange


### PR DESCRIPTION
This test is causing `VSTHRD110` (unawaited task) but the test itself asserts nothing in addition to the next test in the file. So I am removing it.

Merging directly to `main` so that TSA is fixed immediately. I'll merge back to `dev` next.