### PR TITLE
Add smaller boost to exact match of IDs with no separators

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -11,7 +11,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public float NamespaceBoost { get; set; } = 100;
         public float SeparatorSplitBoost { get; set; } = 2;
         public float ExactMatchBoost { get; set; } = 1000;
-        public float ExactMatchWithSeparatorsBoost { get; set; } = 2;
+        public float ExactMatchWithSeparatorsBoost { get; set; } = 10;
         public string SemVer1RegistrationsBaseUrl { get; set; }
         public string SemVer2RegistrationsBaseUrl { get; set; }
         public TimeSpan AuxiliaryDataReloadFrequency { get; set; } = TimeSpan.FromHours(1);

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchServiceConfiguration.cs
@@ -11,6 +11,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public float NamespaceBoost { get; set; } = 100;
         public float SeparatorSplitBoost { get; set; } = 2;
         public float ExactMatchBoost { get; set; } = 1000;
+        public float ExactMatchWithSeparatorsBoost { get; set; } = 2;
         public string SemVer1RegistrationsBaseUrl { get; set; }
         public string SemVer2RegistrationsBaseUrl { get; set; }
         public TimeSpan AuxiliaryDataReloadFrequency { get; set; } = TimeSpan.FromHours(1);

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -71,13 +71,13 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [InlineData("foo", false, false, "+foo* packageId:foo^2 -owners:TestUserA -owners:TestUserB")]
+            [InlineData("foo", false, false, "+foo* packageId:foo^10 -owners:TestUserA -owners:TestUserB")]
             [InlineData("", false, false, "packageId:/.*/ -owners:TestUserA -owners:TestUserB")]
-            [InlineData("foo", true, false, "+foo* packageId:foo^2")]
+            [InlineData("foo", true, false, "+foo* packageId:foo^10")]
             [InlineData("", true, false, "*")]
-            [InlineData("foo", false, true, "+foo* packageId:foo^2")]
+            [InlineData("foo", false, true, "+foo* packageId:foo^10")]
             [InlineData("", false, true, "*")]
-            [InlineData("foo", true, true, "+foo* packageId:foo^2")]
+            [InlineData("foo", true, true, "+foo* packageId:foo^10")]
             [InlineData("", true, true, "*")]
             public void CanExcludeTestData(string query, bool ignoreFilter, bool includeTestData, string expected)
             {
@@ -140,9 +140,9 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [InlineData("foo", false, "+foo* packageId:foo^2 -owners:TestUserA -owners:TestUserB")]
+            [InlineData("foo", false, "+foo* packageId:foo^10 -owners:TestUserA -owners:TestUserB")]
             [InlineData("", false, "packageId:/.*/ -owners:TestUserA -owners:TestUserB")]
-            [InlineData("foo", true, "+foo* packageId:foo^2")]
+            [InlineData("foo", true, "+foo* packageId:foo^10")]
             [InlineData("", true, "*")]
             public void CanExcludeTestData(string query, bool includeTestData, string expected)
             {
@@ -320,8 +320,8 @@ namespace NuGet.Services.AzureSearch.SearchService
                     // If there are no field-scoped terms, results that prefix match the last term are boosted
                     // Results that match all terms are boosted.
                     // Results that match all terms after tokenization are boosted.
-                    { "foo", "+foo* packageId:foo^2" },
-                    { "foobar", "+foobar* foobar^2 packageId:foobar^2" },
+                    { "foo", "+foo* packageId:foo^10" },
+                    { "foobar", "+foobar* foobar^2 packageId:foobar^10" },
                     { "foo bar", "+foo +bar*" },
                     { "foo.bar baz.qux", "+foo +bar +baz +qux*" },
                     { "id packageId VERSION Title description tag author summary owner owners",
@@ -346,17 +346,17 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { "foo_bar buzz", "+foo +bar +buzz* buzz^2" },
                     { "foo-bar buzz", "+foo +bar +buzz* buzz^2" },
                     { "foo,bar, buzz", "+foo +bar +buzz* buzz^2" },
-                    { "fooBar", "+(foobar* (+foo +Bar)) foobar^2 packageId:fooBar^2" },
+                    { "fooBar", "+(foobar* (+foo +Bar)) foobar^2 packageId:fooBar^10" },
                     { "fooBar.", "+(foobar* (+foo +Bar)) foobar^2 packageId:fooBar.*^100" },
                     { "fooBar buzz", "+(foobar (+foo +Bar)) foobar^2 +buzz* buzz^2" },
-                    { "foo5", "+(foo5* (+foo +5)) foo5^2 packageId:foo5^2" },
+                    { "foo5", "+(foo5* (+foo +5)) foo5^2 packageId:foo5^10" },
                     { "foo5 buzz", "+(foo5 (+foo +5)) foo5^2 +buzz* buzz^2" },
                     { "FOO5 buzz", "+(foo5 (+FOO +5)) foo5^2 +buzz* buzz^2" },
                     { "5FOO buzz", "+(5foo (+5 +FOO)) 5foo^2 +buzz* buzz^2" },
-                    { "foo5foo", "+(foo5foo* (+foo +5)) foo5foo^2 packageId:foo5foo^2" },
-                    { "FOO5FOO", "+(foo5foo* (+FOO +5)) foo5foo^2 packageId:FOO5FOO^2" },
-                    { "fooFoo", "+foofoo* foofoo^2 packageId:fooFoo^2" },
-                    { "FOOFoo", "+foofoo* foofoo^2 packageId:FOOFoo^2" },
+                    { "foo5foo", "+(foo5foo* (+foo +5)) foo5foo^2 packageId:foo5foo^10" },
+                    { "FOO5FOO", "+(foo5foo* (+FOO +5)) foo5foo^2 packageId:FOO5FOO^10" },
+                    { "fooFoo", "+foofoo* foofoo^2 packageId:fooFoo^10" },
+                    { "FOOFoo", "+foofoo* foofoo^2 packageId:FOOFoo^10" },
 
                     // Phrases are supported in queries
                     { @"""foo bar""", @"+foo\ bar* ""foo bar""^2" },
@@ -371,7 +371,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { @"json Tags:""net Tags:""windows sdk""", @"+tags:(net Tags\:) +json json^2 +windows windows^2 +sdk*" },
                     { @"sdk Tags:""windows", "+tags:windows +sdk*" },
                     { @"Tags:""windows sdk", "tags:(windows sdk)" },
-                    { @"Tags:""""windows""", "+windows* windows^2 packageId:windows^2" },
+                    { @"Tags:""""windows""", "+windows* windows^2 packageId:windows^10" },
 
                     // Empty quotes are ignored
                     { @"Tags:""""", @"*" },
@@ -381,13 +381,13 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { @"windows Tags:""      "" Tags:sdk", @"+tags:sdk +windows* windows^2" },
 
                     // Duplicate search terms on the same query field are folded
-                    { "a a", "+a* packageId:a^2" },
+                    { "a a", "+a* packageId:a^10" },
                     { "title:a title:a", "title:a" },
                     { "tag:a tags:a", "tags:a" },
                     { "tags:a,a", "tags:a" },
 
                     // Single word query terms are unquoted.
-                    { @"""a""", "+a* packageId:a^2" },
+                    { @"""a""", "+a* packageId:a^10" },
                     { @"title:""a""", "title:a" },
 
                     // Lucene keywords are removed unless quoted with other terms

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -71,13 +71,13 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [InlineData("foo", false, false, "+foo* -owners:TestUserA -owners:TestUserB")]
+            [InlineData("foo", false, false, "+foo* packageId:foo^2 -owners:TestUserA -owners:TestUserB")]
             [InlineData("", false, false, "packageId:/.*/ -owners:TestUserA -owners:TestUserB")]
-            [InlineData("foo", true, false, "+foo*")]
+            [InlineData("foo", true, false, "+foo* packageId:foo^2")]
             [InlineData("", true, false, "*")]
-            [InlineData("foo", false, true, "+foo*")]
+            [InlineData("foo", false, true, "+foo* packageId:foo^2")]
             [InlineData("", false, true, "*")]
-            [InlineData("foo", true, true, "+foo*")]
+            [InlineData("foo", true, true, "+foo* packageId:foo^2")]
             [InlineData("", true, true, "*")]
             public void CanExcludeTestData(string query, bool ignoreFilter, bool includeTestData, string expected)
             {
@@ -140,9 +140,9 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [InlineData("foo", false, "+foo* -owners:TestUserA -owners:TestUserB")]
+            [InlineData("foo", false, "+foo* packageId:foo^2 -owners:TestUserA -owners:TestUserB")]
             [InlineData("", false, "packageId:/.*/ -owners:TestUserA -owners:TestUserB")]
-            [InlineData("foo", true, "+foo*")]
+            [InlineData("foo", true, "+foo* packageId:foo^2")]
             [InlineData("", true, "*")]
             public void CanExcludeTestData(string query, bool includeTestData, string expected)
             {
@@ -320,8 +320,8 @@ namespace NuGet.Services.AzureSearch.SearchService
                     // If there are no field-scoped terms, results that prefix match the last term are boosted
                     // Results that match all terms are boosted.
                     // Results that match all terms after tokenization are boosted.
-                    { "foo", "+foo*" },
-                    { "foobar", "+foobar* foobar^2" },
+                    { "foo", "+foo* packageId:foo^2" },
+                    { "foobar", "+foobar* foobar^2 packageId:foobar^2" },
                     { "foo bar", "+foo +bar*" },
                     { "foo.bar baz.qux", "+foo +bar +baz +qux*" },
                     { "id packageId VERSION Title description tag author summary owner owners",
@@ -346,17 +346,17 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { "foo_bar buzz", "+foo +bar +buzz* buzz^2" },
                     { "foo-bar buzz", "+foo +bar +buzz* buzz^2" },
                     { "foo,bar, buzz", "+foo +bar +buzz* buzz^2" },
-                    { "fooBar", "+(foobar* (+foo +Bar)) foobar^2" },
+                    { "fooBar", "+(foobar* (+foo +Bar)) foobar^2 packageId:fooBar^2" },
                     { "fooBar.", "+(foobar* (+foo +Bar)) foobar^2 packageId:fooBar.*^100" },
                     { "fooBar buzz", "+(foobar (+foo +Bar)) foobar^2 +buzz* buzz^2" },
-                    { "foo5", "+(foo5* (+foo +5)) foo5^2" },
+                    { "foo5", "+(foo5* (+foo +5)) foo5^2 packageId:foo5^2" },
                     { "foo5 buzz", "+(foo5 (+foo +5)) foo5^2 +buzz* buzz^2" },
                     { "FOO5 buzz", "+(foo5 (+FOO +5)) foo5^2 +buzz* buzz^2" },
                     { "5FOO buzz", "+(5foo (+5 +FOO)) 5foo^2 +buzz* buzz^2" },
-                    { "foo5foo", "+(foo5foo* (+foo +5)) foo5foo^2" },
-                    { "FOO5FOO", "+(foo5foo* (+FOO +5)) foo5foo^2" },
-                    { "fooFoo", "+foofoo* foofoo^2" },
-                    { "FOOFoo", "+foofoo* foofoo^2" },
+                    { "foo5foo", "+(foo5foo* (+foo +5)) foo5foo^2 packageId:foo5foo^2" },
+                    { "FOO5FOO", "+(foo5foo* (+FOO +5)) foo5foo^2 packageId:FOO5FOO^2" },
+                    { "fooFoo", "+foofoo* foofoo^2 packageId:fooFoo^2" },
+                    { "FOOFoo", "+foofoo* foofoo^2 packageId:FOOFoo^2" },
 
                     // Phrases are supported in queries
                     { @"""foo bar""", @"+foo\ bar* ""foo bar""^2" },
@@ -371,23 +371,23 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { @"json Tags:""net Tags:""windows sdk""", @"+tags:(net Tags\:) +json json^2 +windows windows^2 +sdk*" },
                     { @"sdk Tags:""windows", "+tags:windows +sdk*" },
                     { @"Tags:""windows sdk", "tags:(windows sdk)" },
-                    { @"Tags:""""windows""", "+windows* windows^2" },
+                    { @"Tags:""""windows""", "+windows* windows^2 packageId:windows^2" },
 
                     // Empty quotes are ignored
                     { @"Tags:""""", @"*" },
                     { @"Tags:"" """, @"*" },
                     { @"Tags:""      """, @"*" },
-                    { @"windows Tags:""      """, @"+windows* windows^2" },
+                    { @"windows Tags:""      """, @"+windows* windows^2 packageId:windows^2" },
                     { @"windows Tags:""      "" Tags:sdk", @"+tags:sdk +windows* windows^2" },
 
                     // Duplicate search terms on the same query field are folded
-                    { "a a", "+a*" },
+                    { "a a", "+a* packageId:a^2" },
                     { "title:a title:a", "title:a" },
                     { "tag:a tags:a", "tags:a" },
                     { "tags:a,a", "tags:a" },
 
                     // Single word query terms are unquoted.
-                    { @"""a""", "+a*" },
+                    { @"""a""", "+a* packageId:a^2" },
                     { @"title:""a""", "title:a" },
 
                     // Lucene keywords are removed unless quoted with other terms

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchTextBuilderFacts.cs
@@ -377,7 +377,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                     { @"Tags:""""", @"*" },
                     { @"Tags:"" """, @"*" },
                     { @"Tags:""      """, @"*" },
-                    { @"windows Tags:""      """, @"+windows* windows^2 packageId:windows^2" },
+                    { @"windows Tags:""      """, @"+windows* windows^2 packageId:windows^10" },
                     { @"windows Tags:""      "" Tags:sdk", @"+tags:sdk +windows* windows^2" },
 
                     // Duplicate search terms on the same query field are folded


### PR DESCRIPTION
Before this change, the exact match mega boost (`^1000`) was only applied for package IDs with dots, hyphens, or underscores in them. The goal of the mega boost was to put make sure a search for `foo.bar.baz` put a package with the matching ID at the top. However we only scoped to boost to package IDs with separators. This scoping was to avoid very common searches like `entity` which should really show [Microsoft.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore) at the top not the [Entity](https://www.nuget.org/packages/Entity) package which has very low downloads. More context is here: https://github.com/NuGet/NuGet.Services.Metadata/pull/652.

With the switch to the new SDK, BM25 is now being using on all new indexes. [This is mandated by Azure Search](https://docs.microsoft.com/en-us/azure/search/index-ranking-similarity). This similarity algorithm change results in slightly different results from the Classic similarity which is in PROD right now. From the `SearchScorer` tool, the only notable regressions were related to exact match queries for IDs without separators (i.e. the case that was excluded until now).

This PR adds a smaller boost for exact match queries on package IDs _without_ separators. Based on testing, a boost of (`^10`) is the sweet spot. `entity` shows Microsoft.EntityFrameworkCore at the top and `sqlite` shows `SQLite` at the top because the relative download counts on the exact match packages are so different.

By the way, the long term fix is to highlight the exact match in the search UI clearly and just put all exact matches at the top no matter what. This is tracked here: https://github.com/NuGet/NuGetGallery/issues/7463.

The goal of this PR is to make a targeted fix in the relevancy algorithm to unblock the index rebuild needed for Azure Search Managed Identities.

The search scorer is showing this (**higher on the treatment is better**):

```
Curated Search Queries
======================
Control:   0.740516068252731
Treatment: 0.741433678994227

Client Curated Search Queries
=============================
Control:   0.673364861619194
Treatment: 0.675891116995111

Feedback
========
Control:   0.701412154740343
Treatment: 0.702295157305885
```

In other words, there's not much of a change. If there's any change at all, we expect a minor improvement.