### PR TITLE
Clean up unused Azure Search configuration and fix docs

### DIFF
--- a/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
+++ b/src/NuGet.Jobs.Auxiliary2AzureSearch/Job.cs
@@ -18,7 +18,6 @@ namespace NuGet.Jobs
             base.ConfigureJobServices(services, configurationRoot);
 
             services.Configure<Auxiliary2AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
-            services.Configure<AuxiliaryDataStorageConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<AzureSearchJobConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
             services.Configure<AzureSearchConfiguration>(configurationRoot.GetSection(ConfigurationSectionName));
         }

--- a/src/NuGet.Jobs.Auxiliary2AzureSearch/README.md
+++ b/src/NuGet.Jobs.Auxiliary2AzureSearch/README.md
@@ -4,6 +4,9 @@
 
 This job updates the [search auxiliary files](../../docs/Search-auxiliary-files.md) used by the [search service](../NuGet.Services.SearchService). This also updates the downloads and owners data in the [Azure Search "search" index](../../docs/Azure-Search-indexes.md).
 
+Note that the "excluded packages" list is currently not updated by this job. For more information, see the
+[`ExcludedPackages.v1.json` documentation](../../docs/Search-auxiliary-files.md#excluded-packages).
+
 ## Running the job
 
 You can run this job using:
@@ -70,11 +73,7 @@ Once you've created your Azure resources, you can create your `settings.json` fi
     "StorageConnectionString": "PLACEHOLDER",
     "StorageContainer": "v3-azuresearch-000",
     "StoragePath": "",
-    "AuxiliaryDataStorageConnectionString": "PLACEHOLDER",
-    "AuxiliaryDataStorageContainer": "ng-search-data",
-    "AuxiliaryDataStorageDownloadsPath": "downloads.v1.json",
-    "AuxiliaryDataStorageExcludedPackagesPath": "ExcludedPackages.v1.json",
-    "AuxiliaryDataStorageVerifiedPackagesPath": "verifiedPackages.json",
+    "DownloadsV1JsonUrl": "PLACEHOLDER",
     "MinPushPeriod": "00:00:10",
     "MaxDownloadCountDecreases": 30000,
     "EnablePopularityTransfers": true,
@@ -91,14 +90,14 @@ At a high-level, here's how Auxiliary2AzureSearch works:
 
 1. Update verified packages
     1. Get the "old" list of verified package IDs from search auxiliary storage
-    2. Get the "new" list of verified package IDs from Gallery DB
-    3. Replace the verified package auxiliary file if needed
+    1. Get the "new" list of verified package IDs from Gallery DB
+    1. Replace the verified package auxiliary file if needed
 1. Update downloads
     1. Get the "old" downloads data from search auxiliary storage
-    1. Get the "new" downloads data from statistics auxiliary storage
+    1. Get the "new" downloads data from statistics auxiliary storage via URL
     1. Determine which packages have download changes
     1. Get the "old" popularity transfers data from search auxiliary storage
-    1. Get the "new" popularity transfers data from statistics auxiliary storage
+    1. Get the "new" popularity transfers data from Gallery DB
     1. Determine which packages have popularity transfer changes
     1. Update Azure Search documents in the "search" index to reflect the latest downloads and popularity transfers
     1. Save the "new" downloads data to the search auxiliary storage

--- a/src/NuGet.Jobs.Db2AzureSearch/README.md
+++ b/src/NuGet.Jobs.Db2AzureSearch/README.md
@@ -53,7 +53,6 @@ As an alternative to using nuget.org's DEV resources, you can also run this tool
 In your Azure Blob Storage account, you will need to create a container named `ng-search-data` and upload the following files:
 1. `downloads.v1.json` with content `[]`
 1. `ExcludedPackages.v1.json` with content `[]`
-1. `verifiedPackages.json` with content `[]`
 
 If you are on the nuget.org team, you can copy these files from the [PROD auxiliary files container](https://nuget.visualstudio.com/DefaultCollection/NuGetMicrosoft/_git/NuGetDeployment?path=%2Fsrc%2FJobs%2FNuGet.Jobs.Cloud%2FJobs%2FDb2AzureSearch%2FPROD%2Fnorthcentralus%2Fappsettings.json&version=GBmaster&line=18&lineEnd=24&lineStartColumn=1&lineEndColumn=1&lineStyle=plain).
 
@@ -65,6 +64,7 @@ Once you've created your Azure resources, you can create your `settings.json` fi
 * The `SearchServiceName` setting is the name of your Azure Search resource. For example, use the name `foo-bar` for the Azure Search service with URL `https://foo-bar.search.windows.net`.
 * The `SearchServiceApiKey` setting is an admin key that has write permissions to the Azure Search resource.
 * The `StorageConnectionString` and `AuxiliaryDataStorageConnectionString` settings are both the connection string to your Azure Blob Storage account.
+* The `DownloadsV1JsonUrl` setting is the URL to `downloads.v1.json` file above. Make sure it works without authentication.
 
 ```json
 {
@@ -86,9 +86,8 @@ Once you've created your Azure resources, you can create your `settings.json` fi
     "GalleryBaseUrl": "https://www.nuget.org/",
     "AuxiliaryDataStorageConnectionString": "PLACEHOLDER",
     "AuxiliaryDataStorageContainer": "ng-search-data",
-    "AuxiliaryDataStorageDownloadsPath": "downloads.v1.json",
     "AuxiliaryDataStorageExcludedPackagesPath": "ExcludedPackages.v1.json",
-    "AuxiliaryDataStorageVerifiedPackagesPath": "verifiedPackages.json",
+    "DownloadsV1JsonUrl": "PLACEHOLDER",
     "FlatContainerBaseUrl": "https://api.nuget.org/",
     "FlatContainerContainerName": "v3-flatcontainer",
     "AllIconsInFlatContainer": false,

--- a/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Auxiliary2AzureSearch/Auxiliary2AzureSearchConfiguration.cs
@@ -2,17 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using NuGet.Services.AzureSearch.AuxiliaryFiles;
 
 namespace NuGet.Services.AzureSearch.Auxiliary2AzureSearch
 {
-    public class Auxiliary2AzureSearchConfiguration : AzureSearchJobConfiguration, IAuxiliaryDataStorageConfiguration
+    public class Auxiliary2AzureSearchConfiguration : AzureSearchJobConfiguration
     {
-        public string AuxiliaryDataStorageConnectionString { get; set; }
-        public string AuxiliaryDataStorageContainer { get; set; }
-        public string AuxiliaryDataStorageDownloadsPath { get; set; }
-        public string AuxiliaryDataStorageExcludedPackagesPath { get; }
-        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
         public string DownloadsV1JsonUrl { get; set; }
         public TimeSpan MinPushPeriod { get; set; }
         public int MaxDownloadCountDecreases { get; set; } = 15000;

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/AuxiliaryDataStorageConfiguration.cs
@@ -7,8 +7,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
     {
         public string AuxiliaryDataStorageConnectionString { get; set; }
         public string AuxiliaryDataStorageContainer { get; set; }
-        public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
-        public string DownloadsV1JsonUrl { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryDataStorageConfiguration.cs
@@ -7,14 +7,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
     {
         string AuxiliaryDataStorageConnectionString { get; }
         string AuxiliaryDataStorageContainer { get; }
-        string AuxiliaryDataStorageDownloadsPath { get; }
         string AuxiliaryDataStorageExcludedPackagesPath { get; }
-
-        /// <summary>
-        /// The URL to get downloads.v1.json. This property, if set, takes precedence over <see cref="AuxiliaryDataStorageDownloadsPath"/>.
-        /// This setting allows the downloads.v1.json report to be generated in a place different from
-        /// <see cref="AuxiliaryDataStorageExcludedPackagesPath"/>.
-        /// </summary>
-        string DownloadsV1JsonUrl { get; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
+++ b/src/NuGet.Services.AzureSearch/AuxiliaryFiles/IAuxiliaryFileClient.cs
@@ -8,7 +8,6 @@ namespace NuGet.Services.AzureSearch.AuxiliaryFiles
 {
     public interface IAuxiliaryFileClient
     {
-        Task<DownloadData> LoadDownloadDataAsync();
         Task<HashSet<string>> LoadExcludedPackagesAsync();
     }
 }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/Db2AzureSearchConfiguration.cs
@@ -13,7 +13,6 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public string AuxiliaryDataStorageContainer { get; set; }
         public string AuxiliaryDataStorageDownloadsPath { get; set; }
         public string AuxiliaryDataStorageExcludedPackagesPath { get; set; }
-        public string AuxiliaryDataStorageVerifiedPackagesPath { get; set; }
         public string DownloadsV1JsonUrl { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.Entities;
+using NuGet.Services.Metadata.Catalog;
 using NuGetGallery;
 
 namespace NuGet.Services.AzureSearch.Db2AzureSearch
@@ -21,6 +22,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
     {
         private readonly IEntitiesContextFactory _contextFactory;
         private readonly IAuxiliaryFileClient _auxiliaryFileClient;
+        private readonly IDownloadsV1JsonClient _downloadsV1JsonClient;
         private readonly IDatabaseAuxiliaryDataFetcher _databaseFetcher;
         private readonly IDownloadTransferrer _downloadTransferrer;
         private readonly IFeatureFlagService _featureFlags;
@@ -31,6 +33,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         public NewPackageRegistrationProducer(
             IEntitiesContextFactory contextFactory,
             IAuxiliaryFileClient auxiliaryFileClient,
+            IDownloadsV1JsonClient downloadsV1JsonClient,
             IDatabaseAuxiliaryDataFetcher databaseFetcher,
             IDownloadTransferrer downloadTransferrer,
             IFeatureFlagService featureFlags,
@@ -40,6 +43,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
         {
             _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
             _auxiliaryFileClient = auxiliaryFileClient ?? throw new ArgumentNullException(nameof(auxiliaryFileClient));
+            _downloadsV1JsonClient = downloadsV1JsonClient ?? throw new ArgumentNullException(nameof(downloadsV1JsonClient));
             _databaseFetcher = databaseFetcher ?? throw new ArgumentNullException(nameof(databaseFetcher));
             _downloadTransferrer = downloadTransferrer ?? throw new ArgumentNullException(nameof(downloadTransferrer));
             _featureFlags = featureFlags ?? throw new ArgumentNullException(nameof(featureFlags));
@@ -65,7 +69,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             // Fetch the download data from the auxiliary file, since this is what is used for displaying download
             // counts in the search service. We don't use the gallery DB values as they are different from the
             // auxiliary file.
-            var downloads = await _auxiliaryFileClient.LoadDownloadDataAsync();
+            var downloads = await _downloadsV1JsonClient.ReadAsync(_options.Value.DownloadsV1JsonUrl);
             var popularityTransfers = await GetPopularityTransfersAsync();
 
             // Apply changes from popularity transfers.

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Rest;
-using Microsoft.Rest.TransientFaultHandling;
 using Microsoft.WindowsAzure.Storage;
 using NuGet.Protocol;
 using NuGet.Protocol.Catalog;
@@ -229,7 +228,6 @@ namespace NuGet.Services.AzureSearch
             containerBuilder
                 .Register<IAuxiliaryFileClient>(c => new AuxiliaryFileClient(
                     c.ResolveKeyed<ICloudBlobClient>(key),
-                    c.Resolve<IDownloadsV1JsonClient>(),
                     c.Resolve<IOptionsSnapshot<AuxiliaryDataStorageConfiguration>>(),
                     c.Resolve<IAzureSearchTelemetryService>(),
                     c.Resolve<ILogger<AuxiliaryFileClient>>()));

--- a/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/DownloadSetComparerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Auxiliary2AzureSearch/DownloadSetComparerFacts.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Options;
 using Moq;
-using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/Db2AzureSearch/NewPackageRegistrationProducerFacts.cs
@@ -14,6 +14,7 @@ using Microsoft.WindowsAzure.Storage;
 using Moq;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.Entities;
+using NuGet.Services.Metadata.Catalog;
 using NuGetGallery;
 using Xunit;
 using Xunit.Abstractions;
@@ -37,6 +38,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
             private readonly CancellationToken _token;
             private readonly NewPackageRegistrationProducer _target;
             private readonly Mock<IAuxiliaryFileClient> _auxiliaryFileClient;
+            private readonly Mock<IDownloadsV1JsonClient> _downloadsV1JsonClient;
             private readonly Mock<IDatabaseAuxiliaryDataFetcher> _databaseFetcher;
             private readonly Mock<IDownloadTransferrer> _downloadTransferrer;
             private readonly Mock<IFeatureFlagService> _featureFlags;
@@ -68,9 +70,10 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 _auxiliaryFileClient
                     .Setup(x => x.LoadExcludedPackagesAsync())
                     .ReturnsAsync(() => _excludedPackages);
+                _downloadsV1JsonClient = new Mock<IDownloadsV1JsonClient>();
                 _downloads = new DownloadData();
-                _auxiliaryFileClient
-                    .Setup(x => x.LoadDownloadDataAsync())
+                _downloadsV1JsonClient
+                    .Setup(x => x.ReadAsync(It.IsAny<string>()))
                     .ReturnsAsync(() => _downloads);
 
                 _popularityTransfers = new PopularityTransferData();
@@ -111,6 +114,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                 _target = new NewPackageRegistrationProducer(
                     _entitiesContextFactory.Object,
                     _auxiliaryFileClient.Object,
+                    _downloadsV1JsonClient.Object,
                     _databaseFetcher.Object,
                     _downloadTransferrer.Object,
                     _featureFlags.Object,


### PR DESCRIPTION
Address https://github.com/NuGet/Engineering/issues/4341

This PR does the following things:
- Fixes documentation around `ExcludedPackages.v1.json`
- Fix example configuration in README.md files to be minimal
- Move the downloads.v1.json download API out of the auxiliary file client
- Remove the unused auxiliary file config from Auxiliary2AzureSearch (sounds weird, but data now comes from DB and downloads.v1.json URL entirely)
- Remove the unused verified package auxiliary file config since this data currently comes from DB