### PR TITLE
Add binding redirect for Microsoft.CodeDom.Providers.DotNetCompilerPlatform

### DIFF
--- a/src/NuGetCDNRedirect/Web.config
+++ b/src/NuGetCDNRedirect/Web.config
@@ -65,6 +65,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.6.0.0" newVersion="3.6.0.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Fix from https://github.com/NuGet/NuGet.Jobs/pull/1012
Progress on https://github.com/NuGet/Engineering/issues/4366