### PR TITLE
Update newtonsoftjson for GC 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.100.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.104.0</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.0.0</NuGetClientPackageVersion>
     <NuGetGalleryPackageVersion>4.4.5-main-6321808</NuGetGalleryPackageVersion>
   </PropertyGroup>

--- a/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
+++ b/src/NuGetCDNRedirect/NuGetCDNRedirect.csproj
@@ -116,7 +116,7 @@
       <Version>3.6.0</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.2</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SplitLargeFiles/SplitLargeFiles.csproj
+++ b/src/SplitLargeFiles/SplitLargeFiles.csproj
@@ -58,6 +58,9 @@
     <None Include="SplitLargeFiles.nuspec" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.1</Version>
+    </PackageReference>
     <PackageReference Include="NuGet.Services.KeyVault">
       <Version>$(ServerCommonPackageVersion)</Version>
     </PackageReference>

--- a/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
+++ b/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
@@ -99,6 +99,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
       <Version>2.2.0</Version>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.1</Version>
+    </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
     </PackageReference>

--- a/src/Stats.LogInterpretation/Stats.LogInterpretation.csproj
+++ b/src/Stats.LogInterpretation/Stats.LogInterpretation.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
       <Version>$(NuGetClientPackageVersion)</Version>

--- a/tests/BasicSearchTests.FunctionalTests.Core/BasicSearchTests.FunctionalTests.Core.csproj
+++ b/tests/BasicSearchTests.FunctionalTests.Core/BasicSearchTests.FunctionalTests.Core.csproj
@@ -77,7 +77,7 @@
       <Version>5.2.3</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
       <Version>2.4.1</Version>


### PR DESCRIPTION

Update newtonsoft.json/Servercommon

WindowsAzure.Storage
9.3.3 has dependency of newtonsoft. Update newtonsoft.json to 13.0.1 avoid bring low version newtonsoft

Address: [#4452](https://github.com/NuGet/Engineering/issues/4452)