### PR TITLE
NuGetCDNRedirect binding redirect fix.

### DIFF
--- a/src/NuGetCDNRedirect/Web.config
+++ b/src/NuGetCDNRedirect/Web.config
@@ -63,7 +63,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" publicKeyToken="31BF3856AD364E35" culture="neutral"/>


### PR DESCRIPTION
Binding redirect wasn't updated.