### PR TITLE
ScanAndSign context passing

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolScanValidator.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/Symbols/SymbolScanValidator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -102,7 +103,7 @@ namespace NuGet.Services.Validation.Symbols
                 return NuGetValidationResponse.Succeeded;
             }
 
-            await _scanAndSignEnqueuer.EnqueueScanAsync(request.ValidationId, request.NupkgUrl);
+            await _scanAndSignEnqueuer.EnqueueScanAsync(request.ValidationId, request.NupkgUrl, context: new Dictionary<string, string>());
 
             var status = await _validatorStateService.TryAddValidatorStatusAsync(request, validatorStatus, ValidationStatus.Incomplete);
 

--- a/src/NuGetCDNRedirect/Web.config
+++ b/src/NuGetCDNRedirect/Web.config
@@ -63,7 +63,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" publicKeyToken="31BF3856AD364E35" culture="neutral"/>

--- a/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
@@ -14,7 +14,11 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// </summary>
         /// <param name="validationId">Validation ID for which scan is requested.</param>
         /// <param name="nupkgUrl">Url of the package to scan.</param>
-        Task EnqueueScanAsync(Guid validationId, string nupkgUrl);
+        /// <param name="context">Request context to pass to the actual signing service.</param>
+        Task EnqueueScanAsync(
+            Guid validationId,
+            string nupkgUrl,
+            IReadOnlyDictionary<string, string> context);
 
         /// <summary>
         /// Enqueues Scan operation. The message delivery is going to be delayed by <paramref name="messageDeliveryDelayOverride"/>.
@@ -22,7 +26,12 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <param name="validationId">Validation ID for which scan is requested.</param>
         /// <param name="nupkgUrl">Url of the package to scan.</param>
         /// <param name="messageDeliveryDelayOverride">The message delivery delay.</param>
-        Task EnqueueScanAsync(Guid validationId, string nupkgUrl, TimeSpan messageDeliveryDelayOverride);
+        /// <param name="context">Request context to pass to the actual signing service.</param>
+        Task EnqueueScanAsync(
+            Guid validationId,
+            string nupkgUrl,
+            IReadOnlyDictionary<string, string> context,
+            TimeSpan messageDeliveryDelayOverride);
 
         /// <summary>
         /// Enqueues Scan And Sign operation. The message delivery is going to be delayed by <see cref="ScanAndSignEnqueuerConfiguration.MessageDelay"/> setting.
@@ -31,7 +40,13 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <param name="nupkgUrl">Url of the package to scan and sign.</param>
         /// <param name="v3ServiceIndexUrl">The service index URL that should be put on the package's repository signature.</param>
         /// <param name="owners">The list of owners that should be put on the package's repository signature.</param>
-        Task EnqueueScanAndSignAsync(Guid validationId, string nupkgUrl, string v3ServiceIndexUrl, IReadOnlyList<string> owners);
+        /// <param name="context">Request context to pass to the actual signing service.</param>
+        Task EnqueueScanAndSignAsync(
+            Guid validationId,
+            string nupkgUrl,
+            string v3ServiceIndexUrl,
+            IReadOnlyList<string> owners,
+            IReadOnlyDictionary<string, string> context);
 
         /// <summary>
         /// Enqueues Scan And Sign operation. The message delivery is going to be delayed by <paramref name="messageDeliveryDelayOverride"/>.
@@ -40,7 +55,14 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <param name="nupkgUrl">Url of the package to scan and sign.</param>
         /// <param name="v3ServiceIndexUrl">The service index URL that should be put on the package's repository signature.</param>
         /// <param name="owners">The list of owners that should be put on the package's repository signature.</param>
+        /// <param name="context">Request context to pass to the actual signing service.</param>
         /// <param name="messageDeliveryDelayOverride">The message delivery delay.</param>
-        Task EnqueueScanAndSignAsync(Guid validationId, string nupkgUrl, string v3ServiceIndexUrl, IReadOnlyList<string> owners, TimeSpan messageDeliveryDelayOverride);
+        Task EnqueueScanAndSignAsync(
+            Guid validationId,
+            string nupkgUrl,
+            string v3ServiceIndexUrl,
+            IReadOnlyList<string> owners,
+            IReadOnlyDictionary<string, string> context,
+            TimeSpan messageDeliveryDelayOverride);
     }
 }

--- a/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/IScanAndSignEnqueuer.cs
@@ -14,7 +14,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// </summary>
         /// <param name="validationId">Validation ID for which scan is requested.</param>
         /// <param name="nupkgUrl">Url of the package to scan.</param>
-        /// <param name="context">Request context to pass to the actual signing service.</param>
+        /// <param name="context">Request context to pass to the actual scan/sign job.</param>
         Task EnqueueScanAsync(
             Guid validationId,
             string nupkgUrl,
@@ -26,7 +26,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <param name="validationId">Validation ID for which scan is requested.</param>
         /// <param name="nupkgUrl">Url of the package to scan.</param>
         /// <param name="messageDeliveryDelayOverride">The message delivery delay.</param>
-        /// <param name="context">Request context to pass to the actual signing service.</param>
+        /// <param name="context">Request context to pass to the actual scan/sign job.</param>
         Task EnqueueScanAsync(
             Guid validationId,
             string nupkgUrl,
@@ -40,7 +40,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <param name="nupkgUrl">Url of the package to scan and sign.</param>
         /// <param name="v3ServiceIndexUrl">The service index URL that should be put on the package's repository signature.</param>
         /// <param name="owners">The list of owners that should be put on the package's repository signature.</param>
-        /// <param name="context">Request context to pass to the actual signing service.</param>
+        /// <param name="context">Request context to pass to the actual scan/sign job.</param>
         Task EnqueueScanAndSignAsync(
             Guid validationId,
             string nupkgUrl,
@@ -55,7 +55,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         /// <param name="nupkgUrl">Url of the package to scan and sign.</param>
         /// <param name="v3ServiceIndexUrl">The service index URL that should be put on the package's repository signature.</param>
         /// <param name="owners">The list of owners that should be put on the package's repository signature.</param>
-        /// <param name="context">Request context to pass to the actual signing service.</param>
+        /// <param name="context">Request context to pass to the actual scan/sign job.</param>
         /// <param name="messageDeliveryDelayOverride">The message delivery delay.</param>
         Task EnqueueScanAndSignAsync(
             Guid validationId,

--- a/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
@@ -38,19 +38,41 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             _configuration = configurationAccessor.Value;
         }
 
-        public Task EnqueueScanAsync(Guid validationId, string nupkgUrl)
-            => EnqueueScanImplAsync(validationId, nupkgUrl, messageDeliveryDelayOverride: null);
+        public Task EnqueueScanAsync(
+            Guid validationId,
+            string nupkgUrl,
+            IReadOnlyDictionary<string, string> context)
+            => EnqueueScanImplAsync(validationId, nupkgUrl, context, messageDeliveryDelayOverride: null);
 
-        public Task EnqueueScanAsync(Guid validationId, string nupkgUrl, TimeSpan messageDeliveryDelayOverride)
-            => EnqueueScanImplAsync(validationId, nupkgUrl, messageDeliveryDelayOverride);
+        public Task EnqueueScanAsync(
+            Guid validationId,
+            string nupkgUrl,
+            IReadOnlyDictionary<string, string> context,
+            TimeSpan messageDeliveryDelayOverride)
+            => EnqueueScanImplAsync(validationId, nupkgUrl, context, messageDeliveryDelayOverride);
 
-        public Task EnqueueScanAndSignAsync(Guid validationId, string nupkgUrl, string v3ServiceIndexUrl, IReadOnlyList<string> owners)
-            => EnqueueScanAndSignImplAsync(validationId, nupkgUrl, v3ServiceIndexUrl, owners, messageDeliveryDelayOverride: null);
+        public Task EnqueueScanAndSignAsync(
+            Guid validationId,
+            string nupkgUrl,
+            string v3ServiceIndexUrl,
+            IReadOnlyList<string> owners,
+            IReadOnlyDictionary<string, string> context)
+            => EnqueueScanAndSignImplAsync(validationId, nupkgUrl, v3ServiceIndexUrl, owners, context, messageDeliveryDelayOverride: null);
 
-        public Task EnqueueScanAndSignAsync(Guid validationId, string nupkgUrl, string v3ServiceIndexUrl, IReadOnlyList<string> owners, TimeSpan messageDeliveryDelayOverride)
-            => EnqueueScanAndSignImplAsync(validationId, nupkgUrl, v3ServiceIndexUrl, owners, messageDeliveryDelayOverride);
+        public Task EnqueueScanAndSignAsync(
+            Guid validationId,
+            string nupkgUrl,
+            string v3ServiceIndexUrl,
+            IReadOnlyList<string> owners,
+            IReadOnlyDictionary<string, string> context,
+            TimeSpan messageDeliveryDelayOverride)
+            => EnqueueScanAndSignImplAsync(validationId, nupkgUrl, v3ServiceIndexUrl, owners, context, messageDeliveryDelayOverride);
 
-        private Task EnqueueScanImplAsync(Guid validationId, string nupkgUrl, TimeSpan? messageDeliveryDelayOverride = null)
+        private Task EnqueueScanImplAsync(
+            Guid validationId,
+            string nupkgUrl,
+            IReadOnlyDictionary<string, string> context,
+            TimeSpan? messageDeliveryDelayOverride = null)
         {
             if (nupkgUrl == null)
             {
@@ -60,6 +82,11 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             if (messageDeliveryDelayOverride.HasValue && messageDeliveryDelayOverride < TimeSpan.Zero)
             {
                 throw new ArgumentOutOfRangeException(nameof(messageDeliveryDelayOverride), $"{nameof(messageDeliveryDelayOverride)} cannot be negative");
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
             }
 
             _logger.LogInformation(
@@ -72,18 +99,33 @@ namespace NuGet.Jobs.Validation.ScanAndSign
                 new ScanAndSignMessage(
                     OperationRequestType.Scan,
                     validationId,
-                    new Uri(nupkgUrl)),
+                    new Uri(nupkgUrl),
+                    context),
                 messageDeliveryDelayOverride);
         }
 
-        private Task EnqueueScanAndSignImplAsync(Guid validationId, string nupkgUrl, string v3ServiceIndexUrl, IReadOnlyList<string> owners, TimeSpan? messageDeliveryDelayOverride = null)
+        private Task EnqueueScanAndSignImplAsync(
+            Guid validationId,
+            string nupkgUrl,
+            string v3ServiceIndexUrl,
+            IReadOnlyList<string> owners,
+            IReadOnlyDictionary<string, string> context,
+            TimeSpan? messageDeliveryDelayOverride = null)
         {
             if (nupkgUrl == null)
             {
                 throw new ArgumentNullException(nameof(nupkgUrl));
             }
 
-            if (owners == null) throw new ArgumentNullException(nameof(owners));
+            if (owners == null)
+            {
+                throw new ArgumentNullException(nameof(owners));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
 
             if (string.IsNullOrEmpty(v3ServiceIndexUrl))
             {
@@ -109,7 +151,8 @@ namespace NuGet.Jobs.Validation.ScanAndSign
                     validationId,
                     new Uri(nupkgUrl),
                     v3ServiceIndexUrl,
-                    owners),
+                    owners,
+                    context),
                 messageDeliveryDelayOverride);
         }
 

--- a/src/Validation.ScanAndSign.Core/ScanAndSignMessage.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignMessage.cs
@@ -11,7 +11,8 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         public ScanAndSignMessage(
             OperationRequestType operationRequestType,
             Guid packageValidationId,
-            Uri blobUri)
+            Uri blobUri,
+            IReadOnlyDictionary<string, string> context)
         {
             if (operationRequestType == OperationRequestType.Sign)
             {
@@ -21,6 +22,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             OperationRequestType = operationRequestType;
             PackageValidationId = packageValidationId;
             BlobUri = blobUri ?? throw new ArgumentNullException(nameof(blobUri));
+            Context = context;
         }
 
         public ScanAndSignMessage(
@@ -28,7 +30,8 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             Guid packageValidationId,
             Uri blobUri,
             string v3ServiceIndexUrl,
-            IReadOnlyList<string> owners)
+            IReadOnlyList<string> owners,
+            IReadOnlyDictionary<string, string> context)
         {
             OperationRequestType = operationRequestType;
             PackageValidationId = packageValidationId;
@@ -38,6 +41,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
                 V3ServiceIndexUrl = v3ServiceIndexUrl ?? throw new ArgumentNullException(nameof(v3ServiceIndexUrl));
                 Owners = owners ?? throw new ArgumentNullException(nameof(owners));
             }
+            Context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
         public OperationRequestType OperationRequestType { get; }
@@ -45,5 +49,6 @@ namespace NuGet.Jobs.Validation.ScanAndSign
         public Uri BlobUri { get; }
         public string V3ServiceIndexUrl { get; }
         public IReadOnlyList<string> Owners { get; }
+        public IReadOnlyDictionary<string, string> Context { get; }
     }
 }

--- a/src/Validation.ScanAndSign.Core/ScanAndSignMessageSerializer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignMessageSerializer.cs
@@ -21,6 +21,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             try
             {
                 var deserializedMessage2 = _serializer2.Deserialize(message);
+
                 return new ScanAndSignMessage(
                     deserializedMessage2.OperationRequestType,
                     deserializedMessage2.PackageValidationId,

--- a/src/Validation.ScanAndSign.Core/ScanAndSignMessageSerializer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignMessageSerializer.cs
@@ -11,29 +11,49 @@ namespace NuGet.Jobs.Validation.ScanAndSign
     {
         private const string SchemaName = "SignatureValidationMessageData";
 
-        private IBrokeredMessageSerializer<ScanAndSignMessageData1> _serializer =
+        private IBrokeredMessageSerializer<ScanAndSignMessageData1> _serializer1 =
             new BrokeredMessageSerializer<ScanAndSignMessageData1>();
+        private IBrokeredMessageSerializer<ScanAndSignMessageData2> _serializer2 =
+            new BrokeredMessageSerializer<ScanAndSignMessageData2>();
 
         public ScanAndSignMessage Deserialize(IBrokeredMessage message)
         {
-            var deserializedMessage = _serializer.Deserialize(message);
+            try
+            {
+                var deserializedMessage2 = _serializer2.Deserialize(message);
+                return new ScanAndSignMessage(
+                    deserializedMessage2.OperationRequestType,
+                    deserializedMessage2.PackageValidationId,
+                    deserializedMessage2.BlobUri,
+                    deserializedMessage2.V3ServiceIndexUrl,
+                    deserializedMessage2.Owners,
+                    deserializedMessage2.Context);
+            }
+            catch (FormatException)
+            {
+                // do nothing, will try to deserialize with v1 below
+            }
+
+            var deserializedMessage1 = _serializer1.Deserialize(message);
 
             return new ScanAndSignMessage(
-                deserializedMessage.OperationRequestType,
-                deserializedMessage.PackageValidationId,
-                deserializedMessage.BlobUri,
-                deserializedMessage.V3ServiceIndexUrl,
-                deserializedMessage.Owners);
+                deserializedMessage1.OperationRequestType,
+                deserializedMessage1.PackageValidationId,
+                deserializedMessage1.BlobUri,
+                deserializedMessage1.V3ServiceIndexUrl,
+                deserializedMessage1.Owners,
+                new Dictionary<string, string>());
         }
 
         public IBrokeredMessage Serialize(ScanAndSignMessage message)
-            => _serializer.Serialize(new ScanAndSignMessageData1
+            => _serializer2.Serialize(new ScanAndSignMessageData2
             {
                 OperationRequestType = message.OperationRequestType,
                 PackageValidationId = message.PackageValidationId,
                 BlobUri = message.BlobUri,
                 V3ServiceIndexUrl = message.V3ServiceIndexUrl,
-                Owners = message.Owners
+                Owners = message.Owners,
+                Context = message.Context,
             });
 
         [Schema(Name = SchemaName, Version = 1)]
@@ -44,6 +64,17 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             public Uri BlobUri { get; set; }
             public string V3ServiceIndexUrl { get; set; }
             public IReadOnlyList<string> Owners { get; set; }
+        }
+
+        [Schema(Name = SchemaName, Version = 2)]
+        private class ScanAndSignMessageData2
+        {
+            public OperationRequestType OperationRequestType { get; set; }
+            public Guid PackageValidationId { get; set; }
+            public Uri BlobUri { get; set; }
+            public string V3ServiceIndexUrl { get; set; }
+            public IReadOnlyList<string> Owners { get; set; }
+            public IReadOnlyDictionary<string, string> Context { get; set; }
         }
     }
 }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolScanValidatorFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/Symbol/SymbolScanValidatorFacts.cs
@@ -107,9 +107,9 @@ namespace NuGet.Services.Validation.Orchestrator.Tests.Symbol
                 var result = await _target.StartAsync(_request);
 
                 _scanAndSignEnqueuer
-                    .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+                    .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()), Times.Never);
                 _scanAndSignEnqueuer
-                    .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Never);
+                    .Verify(e => e.EnqueueScanAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>(), It.IsAny<TimeSpan>()), Times.Never);
                 _validatorStateServiceMock
                     .Verify(vss => vss.AddStatusAsync(It.IsAny<ValidatorStatus>()), Times.Never);
                 _validatorStateServiceMock

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignMessageFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignMessageFacts.cs
@@ -18,7 +18,8 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
                 Guid.NewGuid(),
                 new Uri("https://example.com/aaa.nupkg"),
                 v3ServiceIndexUrl: null,
-                owners: new List<string> { "owner1" }));
+                owners: new List<string> { "owner1" },
+                context: new Dictionary<string, string>()));
 
             Assert.Null(ex);
         }
@@ -31,7 +32,8 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
                 Guid.NewGuid(),
                 new Uri("https://example.com/aaa.nupkg"),
                 v3ServiceIndexUrl: "https://example.com/index.json",
-                owners: null));
+                owners: null,
+                context: new Dictionary<string, string>()));
 
             Assert.Null(ex);
         }
@@ -42,7 +44,8 @@ namespace Validation.PackageSigning.ScanAndSign.Tests
             var ex = Assert.Throws<ArgumentException>(() => new ScanAndSignMessage(
                 OperationRequestType.Sign,
                 Guid.NewGuid(),
-                new Uri("https://example.com/aaa.nupkg")));
+                new Uri("https://example.com/aaa.nupkg"),
+                new Dictionary<string, string>()));
 
             Assert.Contains(nameof(OperationRequestType.Sign), ex.Message);
         }

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignMessageSerializerFacts.cs
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/ScanAndSignMessageSerializerFacts.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NuGet.Jobs.Validation.ScanAndSign;
+using NuGet.Services.ServiceBus;
+using Xunit;
+
+namespace Validation.PackageSigning.ScanAndSign.Tests
+{
+    public class ScanAndSignMessageSerializerFacts
+    {
+        [Fact]
+        public void DeserializesVersion1()
+        {
+            var validationId = Guid.NewGuid();
+            var packageUrl = new Uri("https://package");
+            const string v3ServiceIndexUrl = "foobar";
+            var owners = new List<string> { "owner1", "owner2" };
+            var messageV1 = CreateMessage(1, OperationRequestType.Sign, validationId, packageUrl, v3ServiceIndexUrl, owners, context: null);
+
+            var result1 = _target.Deserialize(messageV1);
+
+            Assert.Equal(OperationRequestType.Sign, result1.OperationRequestType);
+            Assert.Equal(validationId, result1.PackageValidationId);
+            Assert.Equal(packageUrl, result1.BlobUri);
+            Assert.Equal(v3ServiceIndexUrl, result1.V3ServiceIndexUrl);
+            Assert.Equal(owners, result1.Owners);
+        }
+
+        [Fact]
+        public void DeserializesVersion2()
+        {
+            var validationId = Guid.NewGuid();
+            var packageUrl = new Uri("https://package");
+            const string v3ServiceIndexUrl = "foobar";
+            var owners = new List<string> { "owner1", "owner2" };
+            var context = new Dictionary<string, string> { { "property1", "value1" }, { "property2", "value2" } };
+            var messageV2 = CreateMessage(2, OperationRequestType.Sign, validationId, packageUrl, v3ServiceIndexUrl, owners, context);
+
+            var result2 = _target.Deserialize(messageV2);
+
+            Assert.Equal(OperationRequestType.Sign, result2.OperationRequestType);
+            Assert.Equal(validationId, result2.PackageValidationId);
+            Assert.Equal(packageUrl, result2.BlobUri);
+            Assert.Equal(v3ServiceIndexUrl, result2.V3ServiceIndexUrl);
+            Assert.Equal(owners, result2.Owners);
+            Assert.Equal(context, result2.Context);
+        }
+
+        [Fact]
+        public void SerializesVersion2()
+        {
+            var message = new ScanAndSignMessage(
+                OperationRequestType.Sign,
+                Guid.NewGuid(),
+                new Uri("https://package"),
+                "serviceIndexUrl",
+                new List<string>(),
+                new Dictionary<string, string>());
+
+            var brokeredMessage = _target.Serialize(message);
+
+            Assert.Equal(2, brokeredMessage.Properties["SchemaVersion"]);
+        }
+
+        private ScanAndSignMessageSerializer _target = new ScanAndSignMessageSerializer();
+
+        private IBrokeredMessage CreateMessage(
+            int version,
+            OperationRequestType operationType,
+            Guid validationId,
+            Uri blobUri,
+            string v3ServiceIndexUrl,
+            IReadOnlyList<string> owners,
+            IReadOnlyDictionary<string, string> context)
+        {
+            var payload = new Dictionary<string, object>
+            {
+                { "operationRequestType", operationType.ToString() },
+                { "packageValidationId", validationId },
+                { "blobUri", blobUri },
+                { "v3ServiceIndexUrl", v3ServiceIndexUrl },
+                { "owners", owners },
+            };
+            if (version == 2 && context != null)
+            {
+                payload["context"] = context;
+            }
+
+            var payloadStr = JsonConvert.SerializeObject(payload);
+
+            var message = new BrokeredMessageWrapper(payloadStr);
+            message.Properties["SchemaName"] = "SignatureValidationMessageData";
+            message.Properties["SchemaVersion"] = version;
+
+            return message;
+        }
+    }
+}

--- a/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
+++ b/tests/Validation.PackageSigning.ScanAndSign.Tests/Validation.PackageSigning.ScanAndSign.Tests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScanAndSignEnqueuerFacts.cs" />
     <Compile Include="ScanAndSignMessageFacts.cs" />
+    <Compile Include="ScanAndSignMessageSerializerFacts.cs" />
     <Compile Include="ScanAndSignProcessorFacts.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4482

Created a second version of `ScanAndSignMessageData` with a new `Context` property that reflect the change in `ScanAndSignMessage`. It is a simple key-value property bag that is passed as is to the scan/sign service.

Added code to fill that context with package id, version and the owner list. We already pass that information in different form to the service, so no changes in the amount of data passed, just some denormalization to not have the service understand NuGet packages in any depth.