### PR TITLE
[Hotfix] Support package id with file extension

### DIFF
--- a/src/NuGetCDNRedirect/Web.config
+++ b/src/NuGetCDNRedirect/Web.config
@@ -43,7 +43,23 @@
         <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains"/>
       </customHeaders>
     </httpProtocol>
+    <handlers>
+      <remove name="StaticFile"/>
+    </handlers>
+    <security>
+      <requestFiltering>
+        <fileExtensions>
+          <clear/>
+        </fileExtensions>
+        <hiddenSegments>
+          <clear/>
+        </hiddenSegments>
+      </requestFiltering>
+    </security>
   </system.webServer>
+  <system.serviceModel>
+    <serviceHostingEnvironment aspNetCompatibilityEnabled="true"/>
+  </system.serviceModel>
   <location path="Status/Index">
     <system.webServer>
       <httpRedirect enabled="false"/>


### PR DESCRIPTION
CDNRedirect was not redirecting packages with id that contained file extension names as part of the id like GET v3-flatcontainer/orchardcore.rules/index.json.

These changes are also on the Gallery web.config.

Address: https://github.com/NuGet/NuGetGallery/issues/9244