### PR TITLE
Address CodeQL issue to make code more defensive

### DIFF
--- a/src/Validation.Symbols.Core/ZipArchiveService.cs
+++ b/src/Validation.Symbols.Core/ZipArchiveService.cs
@@ -93,7 +93,14 @@ namespace NuGet.Jobs.Validation.Symbols.Core
                    }).
                    Select((e) =>
                    {
-                       OnExtract(e, targetDirectory);
+                       string destinationPath = Path.GetFullPath(Path.Combine(targetDirectory, e.FullName));
+                       string fullTargetDirectory = Path.GetFullPath(targetDirectory + Path.DirectorySeparatorChar);
+                       if (!destinationPath.StartsWith(fullTargetDirectory))
+                       {
+                           throw new InvalidDataException($"Invalid zip entry '{e.FullName}'.");
+                       }
+
+                       OnExtract(e, destinationPath, targetDirectory);
                        return e.FullName;
                    });
         }
@@ -103,9 +110,8 @@ namespace NuGet.Jobs.Validation.Symbols.Core
         /// </summary>
         /// <param name="entry"><see cref="ZipArchiveEntry" /> entry.</param>
         /// <param name="targetDirectory">The target directory to extract the compressed data.</param>
-        public virtual void OnExtract(ZipArchiveEntry entry, string targetDirectory)
+        public virtual void OnExtract(ZipArchiveEntry entry, string destinationPath, string targetDirectory)
         {
-            string destinationPath = Path.GetFullPath(Path.Combine(targetDirectory, entry.FullName));
             string destinationDirectory = Path.GetDirectoryName(destinationPath);
             if (!Directory.Exists(destinationDirectory))
             {

--- a/tests/Validation.Symbols.Tests/ZipArchiveTests.cs
+++ b/tests/Validation.Symbols.Tests/ZipArchiveTests.cs
@@ -130,6 +130,17 @@ namespace Validation.Symbols.Tests
                     Assert.Contains(s, result);
                 }
             }
+
+            [Fact]
+            public void FailsWithDirectoryTraversal()
+            {
+                // Arrange
+                IReadOnlyCollection<ZipArchiveEntry> input = CreateTestZipEntries(new string[] { "../foo.pdb" });
+                var service = new TestZipArchiveService();
+
+                // Act & Assert
+                Assert.Throws<InvalidDataException>(() => service.Extract(input, "Dir1").ToList());
+            }
         }
 
         public static IReadOnlyCollection<ZipArchiveEntry> CreateTestZipEntries(string[] files)
@@ -157,7 +168,7 @@ namespace Validation.Symbols.Tests
 
             public bool OnExtractInvoked = false;
 
-            public override void OnExtract(ZipArchiveEntry entry, string targetDirectory)
+            public override void OnExtract(ZipArchiveEntry entry, string destinationPath, string targetDirectory)
             {
                 OnExtractInvoked = true;
             }


### PR DESCRIPTION
This is not an issue in production because we do this validation upon ingestion of packages and symbol packages.