### PR TITLE
Less confusing log wording.

### DIFF
--- a/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
@@ -90,7 +90,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             }
 
             _logger.LogInformation(
-                "Requested scan only for validation {ValidationId} {BlobUrl}, delay override: {DelayOverride}",
+                "Enqueued scan only message for validation {ValidationId} {BlobUrl}, delay override: {DelayOverride}",
                 validationId,
                 nupkgUrl,
                 messageDeliveryDelayOverride);
@@ -138,7 +138,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             }
 
             _logger.LogInformation(
-                "Requested scan and sign for validation {ValidationId} {BlobUrl} using service index {ServiceIndex} and owners {Owners}, delay override: {DelayOverride}",
+                "Enqueued scan and sign message for validation {ValidationId} {BlobUrl} using service index {ServiceIndex} and owners {Owners}, delay override: {DelayOverride}",
                 validationId,
                 nupkgUrl,
                 v3ServiceIndexUrl,

--- a/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
+++ b/src/Validation.ScanAndSign.Core/ScanAndSignEnqueuer.cs
@@ -90,7 +90,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             }
 
             _logger.LogInformation(
-                "Enqueued scan only message for validation {ValidationId} {BlobUrl}, delay override: {DelayOverride}",
+                "Enqueuing scan only message for validation {ValidationId} {BlobUrl}, delay override: {DelayOverride}",
                 validationId,
                 nupkgUrl,
                 messageDeliveryDelayOverride);
@@ -138,7 +138,7 @@ namespace NuGet.Jobs.Validation.ScanAndSign
             }
 
             _logger.LogInformation(
-                "Enqueued scan and sign message for validation {ValidationId} {BlobUrl} using service index {ServiceIndex} and owners {Owners}, delay override: {DelayOverride}",
+                "Enqueuing scan and sign message for validation {ValidationId} {BlobUrl} using service index {ServiceIndex} and owners {Owners}, delay override: {DelayOverride}",
                 validationId,
                 nupkgUrl,
                 v3ServiceIndexUrl,


### PR DESCRIPTION
Reworded log message about sending a request to start or check status of scan and sign validator. The updated class is used both in Orchestrator and ScanAndSign validator and in context of the latter, the "Requested scan and sign for..." messages look confusing when looking through logs (especially when you can't find that line in the validator code itself).