### PR TITLE
[Status] Protect and Deactivate an incident when client returns 404.

### DIFF
--- a/src/StatusAggregator/Update/AggregationEntityUpdater.cs
+++ b/src/StatusAggregator/Update/AggregationEntityUpdater.cs
@@ -47,7 +47,7 @@ namespace StatusAggregator.Update
 
             if (!aggregationEntity.IsActive)
             {
-                _logger.LogInformation("Aggregation is inactive, cannot update.");
+                _logger.LogInformation("Aggregation {AggregationRowKey} is inactive, cannot update.", aggregationEntity.RowKey);
                 return;
             }
 
@@ -58,7 +58,7 @@ namespace StatusAggregator.Update
 
             if (children.Any())
             {
-                _logger.LogInformation("Aggregation has {ChildrenCount} children. Updating each child.", children.Count);
+                _logger.LogInformation("Aggregation {AggregationRowKey} has {ChildrenCount} children. Updating each child.", aggregationEntity.RowKey, children.Count);
                 foreach (var child in children)
                 {
                     await _aggregatedEntityUpdater.UpdateAsync(child, cursor);
@@ -71,13 +71,13 @@ namespace StatusAggregator.Update
             }
             else
             {
-                _logger.LogInformation("Aggregation has no children and must have been created manually, cannot update.");
+                _logger.LogInformation("Aggregation {AggregationRowKey} has no children and must have been created manually, cannot update.", aggregationEntity.RowKey);
                 return;
             }
 
             if (!hasActiveOrRecentChildren)
             {
-                _logger.LogInformation("Deactivating aggregation because its children are inactive and too old.");
+                _logger.LogInformation("Deactivating aggregation {AggregationRowKey} because its children are inactive and too old.", aggregationEntity.RowKey);
                 var lastEndTime = children.Max(i => i.EndTime.Value);
                 aggregationEntity.EndTime = lastEndTime;
 
@@ -85,7 +85,7 @@ namespace StatusAggregator.Update
             }
             else
             {
-                _logger.LogInformation("Aggregation has active or recent children so it will not be deactivated.");
+                _logger.LogInformation("Aggregation {AggregationRowKey} has active or recent children so it will not be deactivated.", aggregationEntity.RowKey);
             }
         }
     }

--- a/tests/StatusAggregator.Tests/Update/IncidentUpdaterTests.cs
+++ b/tests/StatusAggregator.Tests/Update/IncidentUpdaterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage.Table;
@@ -100,6 +101,62 @@ namespace StatusAggregator.Tests.Update
                 Assert.False(incidentEntity.IsActive);
 
                 Table.Verify();
+            }
+
+            [Fact]
+            public async Task DeactivatesIfClientReturns404()
+            {
+                var cursor = new DateTime(2018, 10, 10);
+                var incidentEntity = new IncidentEntity
+                {
+                    IncidentApiId = "id"
+                };
+
+                var response = new Mock<HttpWebResponse>();
+                response.Setup(r => r.StatusCode).Returns(HttpStatusCode.NotFound);
+
+                Client
+                    .Setup(x => x.GetIncident(incidentEntity.IncidentApiId))
+                    .ThrowsAsync(new WebException(null, null, WebExceptionStatus.ProtocolError, response.Object));
+
+                Table
+                    .Setup(x => x.ReplaceAsync(incidentEntity))
+                    .Returns(Task.CompletedTask)
+                    .Verifiable();
+
+                await Updater.UpdateAsync(incidentEntity, cursor);
+
+                Assert.NotNull(incidentEntity.EndTime);
+                Assert.False(incidentEntity.IsActive);
+
+                Table.Verify();
+            }
+
+            [Fact]
+            public async Task RethrowsIfClientThrowsWebExceptionButNot404()
+            {
+                var cursor = new DateTime(2018, 10, 10);
+                var incidentEntity = new IncidentEntity
+                {
+                    IncidentApiId = "id"
+                };
+
+                var response = new Mock<HttpWebResponse>();
+                response.Setup(r => r.StatusCode).Returns(HttpStatusCode.ServiceUnavailable);
+
+                Client
+                    .Setup(x => x.GetIncident(incidentEntity.IncidentApiId))
+                    .ThrowsAsync(new WebException(null, null, WebExceptionStatus.ProtocolError, response.Object));
+
+                await Assert.ThrowsAsync<WebException>(() => Updater.UpdateAsync(incidentEntity, cursor));
+
+                Assert.Null(incidentEntity.EndTime);
+                Assert.True(incidentEntity.IsActive);
+
+                Table
+                    .Verify(
+                        x => x.ReplaceAsync(It.IsAny<ITableEntity>()),
+                        Times.Never());
             }
         }
 


### PR DESCRIPTION
The client wrapped in the dependent package doesn't protect when client throws "WebException" (such as 404), which breaks the job. For 404 cases, we will just deactivate the incident.

Also, enrich the telemetry.

Address: https://github.com/NuGet/Engineering/issues/4421