### PR TITLE
Metrics for Stats.CollectAzureCdnLogs job

### DIFF
--- a/src/Stats.CollectAzureCdnLogs/ITelemetryService.cs
+++ b/src/Stats.CollectAzureCdnLogs/ITelemetryService.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Stats.CollectAzureCdnLogs
 {
     public interface ITelemetryService
     {
         void TrackRawLogCount(int count);
+        void TrackProcessedBlob(string fileName, long compressedBytes, int lineCount);
+        IDisposable TrackLogProcessingDuration(string fileName);
     }
 }

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/src/Stats.CollectAzureCdnLogs/Job.cs
+++ b/src/Stats.CollectAzureCdnLogs/Job.cs
@@ -229,6 +229,9 @@ namespace Stats.CollectAzureCdnLogs
                                     try
                                     {
                                         var lineCount = 0;
+                                        // ProcessLogStream function below closes the stream, so we need to take note of its length
+                                        // now to log later.
+                                        var compressedBlobSize = rawLogStreamInMemory.Length;
                                         using (var resultGzipStream = new GZipOutputStream(resultLogStream))
                                         {
                                             resultGzipStream.IsStreamOwner = false;
@@ -240,7 +243,7 @@ namespace Stats.CollectAzureCdnLogs
                                         resultLogStream.Commit();
 
                                         uploadSucceeded = true;
-                                        _telemetryService.TrackProcessedBlob(fileName, rawLogStreamInMemory.Length, lineCount);
+                                        _telemetryService.TrackProcessedBlob(fileName, compressedBlobSize, lineCount);
                                     }
                                     catch
                                     {

--- a/src/Stats.CollectAzureCdnLogs/TelemetryService.cs
+++ b/src/Stats.CollectAzureCdnLogs/TelemetryService.cs
@@ -14,7 +14,7 @@ namespace Stats.CollectAzureCdnLogs
     public class TelemetryService : ITelemetryService
     {
         private const string Prefix = "Stats.CollectAzureCdnLogs.";
-        private const string FilenamePropertyName = "Filename";
+        private const string FileNamePropertyName = "FileName";
         private readonly ITelemetryClient _telemetryClient;
 
         public TelemetryService(ITelemetryClient telemetryClient)
@@ -29,7 +29,7 @@ namespace Stats.CollectAzureCdnLogs
 
         public void TrackProcessedBlob(string fileName, long compressedBytes, int lineCount)
         {
-            var properties = new Dictionary<string, string> { { FilenamePropertyName, fileName } };
+            var properties = new Dictionary<string, string> { { FileNamePropertyName, fileName } };
             _telemetryClient.TrackMetric(Prefix + "LogCompressedSourceFileSizeBytes", compressedBytes, properties);
             _telemetryClient.TrackMetric(Prefix + "LogLineCount", lineCount, properties);
         }
@@ -37,7 +37,7 @@ namespace Stats.CollectAzureCdnLogs
         public IDisposable TrackLogProcessingDuration(string fileName)
             => _telemetryClient.TrackDuration(Prefix + "LogProcessingTimeSeconds", new Dictionary<string, string>
                 {
-                    { FilenamePropertyName, fileName },
+                    { FileNamePropertyName, fileName },
                 });
     }
 }

--- a/src/Stats.CollectAzureCdnLogs/TelemetryService.cs
+++ b/src/Stats.CollectAzureCdnLogs/TelemetryService.cs
@@ -14,7 +14,7 @@ namespace Stats.CollectAzureCdnLogs
     public class TelemetryService : ITelemetryService
     {
         private const string Prefix = "Stats.CollectAzureCdnLogs.";
-
+        private const string FilenamePropertyName = "Filename";
         private readonly ITelemetryClient _telemetryClient;
 
         public TelemetryService(ITelemetryClient telemetryClient)
@@ -26,5 +26,18 @@ namespace Stats.CollectAzureCdnLogs
         {
             _telemetryClient.TrackMetric(Prefix + "RawLogCount", count);
         }
+
+        public void TrackProcessedBlob(string fileName, long compressedBytes, int lineCount)
+        {
+            var properties = new Dictionary<string, string> { { FilenamePropertyName, fileName } };
+            _telemetryClient.TrackMetric(Prefix + "LogCompressedSourceFileSizeBytes", compressedBytes, properties);
+            _telemetryClient.TrackMetric(Prefix + "LogLineCount", lineCount, properties);
+        }
+
+        public IDisposable TrackLogProcessingDuration(string fileName)
+            => _telemetryClient.TrackDuration(Prefix + "LogProcessingTimeSeconds", new Dictionary<string, string>
+                {
+                    { FilenamePropertyName, fileName },
+                });
     }
 }


### PR DESCRIPTION
Related to https://github.com/NuGet/Engineering/issues/4596

For each blob it consumes it now reports its size, number of lines and time it took to process.

Consider turning off showing whitespace difference when viewing, it'll make the diff simpler.