### PR TITLE
Catalog2AzureSearch changes for Search-by-TFM

### DIFF
--- a/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
+++ b/src/NuGet.Protocol.Catalog/Models/PackageDetailsCatalogLeaf.cs
@@ -52,6 +52,9 @@ namespace NuGet.Protocol.Catalog
         [JsonProperty("minClientVersion")]
         public string MinClientVersion { get; set; }
 
+        [JsonProperty("packageEntries")]
+        public List<PackageEntry> PackageEntries { get; set; }
+
         [JsonProperty("packageHash")]
         public string PackageHash { get; set; }
 

--- a/src/NuGet.Protocol.Catalog/Models/PackageEntry.cs
+++ b/src/NuGet.Protocol.Catalog/Models/PackageEntry.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace NuGet.Protocol.Catalog
+{
+    public class PackageEntry
+    {
+        [JsonProperty("@id")]
+        public string Url { get; set; }
+
+        [JsonProperty("@type")]
+        public string Type { get; set; }
+
+        [JsonProperty("fullName")]
+        public string FullName { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("compressedLength")]
+        public string CompressedLength { get; set; }
+
+        [JsonProperty("length")]
+        public string Length { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -177,12 +177,8 @@ namespace NuGet.Services.AzureSearch
                 leaf.PackageTypes.Select(pt => pt.Name).ToArray() :
                 null;
 
-            var frameworks = leaf.PackageEntries == null
-                                                ? Array.Empty<string>()
-                                                : GetFrameworksFromCatalogLeaf(leaf);
-            var tfms = leaf.PackageEntries == null
-                                                ? Array.Empty<string>()
-                                                : GetTfmsFromCatalogLeaf(leaf);
+            var frameworks = GetFrameworksFromCatalogLeaf(leaf);
+            var tfms = GetTfmsFromCatalogLeaf(leaf);
 
             PopulateUpdateLatest(
                 document,
@@ -443,7 +439,7 @@ namespace NuGet.Services.AzureSearch
 
         private static IEnumerable<NuGetFramework> GetSupportedFrameworks(PackageDetailsCatalogLeaf leaf)
         {
-            string[] files = leaf.PackageEntries.Count == 0
+            string[] files = leaf.PackageEntries == null || leaf.PackageEntries.Count == 0
                                     ? Array.Empty<string>()
                                     : leaf.PackageEntries.Select(pe => pe.FullName).ToArray();
             var packageTypes = leaf.PackageTypes == null || leaf.PackageTypes.Count == 0

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -446,7 +446,7 @@ namespace NuGet.Services.AzureSearch
             string[] files = leaf.PackageEntries.Count == 0
                                     ? Array.Empty<string>()
                                     : leaf.PackageEntries.Select(pe => pe.FullName).ToArray();
-            var packageTypes = leaf.PackageTypes == null
+            var packageTypes = leaf.PackageTypes == null || leaf.PackageTypes.Count == 0
                                     ? new List<Packaging.Core.PackageType>()
                                     : GetPackageTypes(leaf);
 
@@ -456,15 +456,13 @@ namespace NuGet.Services.AzureSearch
 
         private static List<Packaging.Core.PackageType> GetPackageTypes(PackageDetailsCatalogLeaf leaf)
         {
-            return leaf.PackageTypes.Count == 0
-                            ? new List<Packaging.Core.PackageType>()
-                            : leaf.PackageTypes
-                                        .Select(pt => new Packaging.Core.PackageType(
-                                                                pt.Name,
-                                                                pt.Version == null
-                                                                    ? Packaging.Core.PackageType.EmptyVersion
-                                                                    : new Version(pt.Version)))
-                                        .ToList();
+            return leaf.PackageTypes
+                            .Select(pt => new Packaging.Core.PackageType(
+                                                    pt.Name,
+                                                    pt.Version == null
+                                                        ? Packaging.Core.PackageType.EmptyVersion
+                                                        : new Version(pt.Version)))
+                            .ToList();
         }
     }
 }

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -594,13 +594,13 @@ namespace NuGet.Services.AzureSearch
                     owners: Data.Owners);
 
                 // assert
-                Assert.True(document.Tfms.Length == expectedTfms.Count);
+                Assert.Equal(document.Tfms.Length, expectedTfms.Count);
                 foreach (var item in expectedTfms)
                 {
                     Assert.Contains(item, document.Tfms);
                 }
 
-                Assert.True(document.Frameworks.Length == expectedFrameworks.Count);
+                Assert.Equal(document.Frameworks.Length, expectedFrameworks.Count);
                 foreach (var item in expectedFrameworks)
                 {
                     Assert.Contains(item, document.Frameworks);
@@ -609,20 +609,17 @@ namespace NuGet.Services.AzureSearch
 
             [Theory]
             [MemberData(nameof(AdditionalCatalogTFMCases))]
-            public void CalculatesAssetFrameworksFromPackageEntriesAndPackageTypes(bool isTools, List<string> files, List<string> expectedTfms, List<string> expectedFrameworks)
+            public void CalculatesAssetFrameworksFromPackageEntriesAndPackageTypes(List<NuGet.Protocol.Catalog.PackageType> packageTypes,
+                                                                                   List<string> files,
+                                                                                   List<string> expectedTfms,
+                                                                                   List<string> expectedFrameworks)
             {
                 // arrange
                 var leaf = Data.Leaf;
                 leaf.PackageEntries = files
                                         .Select(f => new NuGet.Protocol.Catalog.PackageEntry { FullName = f })
                                         .ToList();
-                if (isTools)
-                {
-                    leaf.PackageTypes = new List<NuGet.Protocol.Catalog.PackageType>
-                                            {
-                                                new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }
-                                            };
-                }
+                leaf.PackageTypes = packageTypes;
 
                 // act
                 var document = _target.UpdateLatestFromCatalog(
@@ -636,13 +633,13 @@ namespace NuGet.Services.AzureSearch
                     owners: Data.Owners);
 
                 // assert
-                Assert.True(document.Tfms.Length == expectedTfms.Count);
+                Assert.Equal(document.Tfms.Length, expectedTfms.Count);
                 foreach (var item in expectedTfms)
                 {
                     Assert.Contains(item, document.Tfms);
                 }
 
-                Assert.True(document.Frameworks.Length == expectedFrameworks.Count);
+                Assert.Equal(document.Frameworks.Length, expectedFrameworks.Count);
                 foreach (var item in expectedFrameworks)
                 {
                     Assert.Contains(item, document.Frameworks);
@@ -987,13 +984,13 @@ namespace NuGet.Services.AzureSearch
                     isExcludedByDefault: false);
 
                 // assert
-                Assert.True(document.Tfms.Length == expectedTfms.Count);
+                Assert.Equal(document.Tfms.Length, expectedTfms.Count);
                 foreach (var item in expectedTfms)
                 {
                     Assert.Contains(item, document.Tfms);
                 }
 
-                Assert.True(document.Frameworks.Length == expectedFrameworks.Count);
+                Assert.Equal(document.Frameworks.Length, expectedFrameworks.Count);
                 foreach (var item in expectedFrameworks)
                 {
                     Assert.Contains(item, document.Frameworks);
@@ -1212,37 +1209,48 @@ namespace NuGet.Services.AzureSearch
             public static IEnumerable<object[]> AdditionalCatalogTFMCases =>
             new List<object[]>
             {
-                    new object[] {false, new List<string> {"lib/netcoreapp31/_._", "lib/netstandard20/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                    new List<string> {"lib/netcoreapp31/_._", "lib/netstandard20/_._"},
                                     new List<string> {"netcoreapp3.1", "netstandard2.0"}, new List<string> {"netcoreapp", "netstandard"}},
-                    new object[] {false, new List<string> {"lib/net40/_._", "lib/net4.7.1/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"lib/net40/_._", "lib/net4.7.1/_._"},
                                     new List<string> {"net40", "net471"}, new List<string> {"netframework"}},
-                    new object[] {false, new List<string> {"lib/_._"}, new List<string> {"net"}, new List<string> {"netframework"}}, // no version
-
-                    new object[] {false, new List<string> {"runtimes/win/net40/_._", "runtimes/win/net471/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"lib/_._"},
+                                    new List<string> {"net"}, new List<string> {"netframework"}}, // no version
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                    new List<string> {"runtimes/win/net40/_._", "runtimes/win/net471/_._"},
                                     new List<string>(), new List<string>()}, // no "lib" dir
-                    new object[] {false, new List<string> {"runtimes/win/lib/net40/", "runtimes/win/lib/net471/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                    new List<string> {"runtimes/win/lib/net40/", "runtimes/win/lib/net471/_._"},
                                     new List<string> {"net471"}, new List<string> {"netframework"}}, // no file in "net40" dir
-                    new object[] {false, new List<string> {"lib/net5.0/_1._", "lib/net5.0/_2._", "lib/native/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                    new List<string> {"lib/net5.0/_1._", "lib/net5.0/_2._", "lib/native/_._"},
                                     new List<string> {"native", "net5.0" }, new List<string> {"net"}},
-                    new object[] {false, new List<string> {"ref/_._"}, new List<string>(), new List<string>()},
-                    new object[] {false, new List<string> {"ref/net40/_._", "ref/net451/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"ref/_._"},
+                                    new List<string>(), new List<string>()},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                    new List<string> {"ref/net40/_._", "ref/net451/_._"},
                                     new List<string> {"net40", "net451"}, new List<string> {"netframework"}},
-                    new object[] {false, new List<string> {"contentFiles/vb/net45/_._", "contentFiles/cs/netcoreapp3.1/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                    new List<string> {"contentFiles/vb/net45/_._", "contentFiles/cs/netcoreapp3.1/_._"},
                                     new List<string>{"net45", "netcoreapp3.1"}, new List<string> {"netframework", "netcoreapp"}},
 
                     // Tools cases
-                    new object[] {true, new List<string> {"tools/netcoreapp3.1/_._"}, new List<string>(), new List<string>()},
-                    new object[] {true, new List<string> {"tools/netcoreapp3.1/win10-x86/tool1/_._", "tools/netcoreapp3.1/win10-x86/tool2/_._" },
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
+                                    new List<string> {"tools/netcoreapp3.1/_._"}, new List<string>(), new List<string>()},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
+                                    new List<string> {"tools/netcoreapp3.1/win10-x86/tool1/_._", "tools/netcoreapp3.1/win10-x86/tool2/_._" },
                                     new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
-                    new object[] {true, new List<string> {"tools/netcoreapp3.1/any/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
+                                    new List<string> {"tools/netcoreapp3.1/any/_._"},
                                     new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
-                    new object[] {false, new List<string> {"tools/netcoreapp3.1/any/_._"},
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"tools/netcoreapp3.1/any/_._"},
                                     new List<string>(), new List<string>()}, // not a tools package, no supported TFMs
-                    new object[] {false, new List<string> {"Foo.nuspec", "runtimes/win10-x86/lib/net40/_._", "runtimes/win10-x86/lib/net471/_._",
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), // not a tools package
+                                    new List<string> {"Foo.nuspec", "runtimes/win10-x86/lib/net40/_._", "runtimes/win10-x86/lib/net471/_._",
                                     "ref/net5.0-watchos/_1._", "ref/net5.0-watchos/_2._", "tools/netcoreapp3.1/win10-x86/tool1/_._",
                                     "tools/netcoreapp3.1/win10-x86/tool2/_._"},
                                     new List<string> {"net40", "net471", "net5.0-watchos"}, new List<string> {"netframework", "net"}},
-                    new object[] {true, // tools package
+                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
                                     new List<string> {"Foo.nuspec", "runtimes/win10-x86/lib/net40/_._", "runtimes/win10-x86/lib/net471/_._",
                                     "ref/net5.0-watchos/_1._", "ref/net5.0-watchos/_2._", "tools/netcoreapp3.1/win10-x86/tool1/_._",
                                     "tools/netcoreapp3.1/win10-x86/tool2/_._"},

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -392,8 +392,12 @@ namespace NuGet.Services.AzureSearch
       ""packageTypes"": [
         ""Dependency""
       ],
-      ""frameworks"": [],
-      ""tfms"": [],
+      ""frameworks"": [
+        ""netframework""
+      ],
+      ""tfms"": [
+        ""net40-client""
+      ],
       ""isLatestStable"": false,
       ""isLatest"": true,
       ""semVerLevel"": 2,
@@ -869,6 +873,7 @@ namespace NuGet.Services.AzureSearch
 
             [Theory]
             [MemberData(nameof(TargetFrameworkCases))]
+            [MemberData(nameof(SpecialTFMCases))]
             public void AddsFrameworksAndTfmsFromPackage(List<string> supportedFrameworks, List<string> expectedTfms, List<string> expectedFrameworks)
             {
                 // arrange
@@ -914,41 +919,44 @@ namespace NuGet.Services.AzureSearch
                 }
             }
 
-            public static IEnumerable<object[]> TargetFrameworkCases =>
-                new List<object[]>
+            [Theory]
+            [MemberData(nameof(TargetFrameworkCases))]
+            public void AddsFrameworksAndTfmsFromCatalogLeaf(List<string> supportedFrameworks, List<string> expectedTfms, List<string> expectedFrameworks)
+            {
+                // arrange
+                var leaf = Data.Leaf;
+                leaf.PackageEntries = supportedFrameworks
+                                                .Select(f => new NuGet.Protocol.Catalog.PackageEntry
+                                                                    {
+                                                                        FullName = $"lib/{f}/Package.dll",
+                                                                        Name = "Package.dll"
+                                                                    })
+                                                .ToList();
+
+                // act
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                // assert
+                Assert.True(document.Tfms.Length == expectedTfms.Count);
+                foreach (var item in expectedTfms)
                 {
-                    new object[] {new List<string> {}, new List<string>(), new List<string> {}},
-                    new object[] {new List<string> {"any"}, new List<string> {}, new List<string> {}},
-                    new object[] {new List<string> {"net"}, new List<string> {"net"}, new List<string> {"netframework"}},
-                    new object[] {new List<string> {"win"}, new List<string> {"win"}, new List<string> {}},
-                    new object[] {new List<string> {"foo"}, new List<string> {}, new List<string> {}}, // unsupported tfm is not included
-                    new object[] {new List<string> {"dotnet"}, new List<string> {"dotnet"}, new List<string> {}},
-                    new object[] {new List<string> {"net472"}, new List<string> {"net472"}, new List<string> {"netframework"}},
-                    new object[] {new List<string> {"net40-client"}, new List<string> {"net40-client"}, new List<string> {"netframework"}},
-                    new object[] {new List<string> {"net5.0"}, new List<string> {"net5.0"}, new List<string> {"net"}},
-                    new object[] {new List<string> {"netcoreapp3.0"}, new List<string> { "netcoreapp3.0" }, new List<string> { "netcoreapp" } },
-                    new object[] {new List<string> {"netstandard2.0"}, new List<string> { "netstandard2.0" }, new List<string> { "netstandard" } },
-                    new object[] {new List<string> {"net40", "net45"}, new List<string> {"net40", "net45"}, new List<string> {"netframework"}},
-                    new object[] {new List<string> {"net5.0-tvos", "net5.0-ios"}, new List<string> {"net5.0-ios", "net5.0-tvos"}, new List<string> {"net"}},
-                    new object[] {new List<string> {"net5.0-tvos", "net5.0-ios13.0"}, new List<string> {"net5.0-ios13.0", "net5.0-tvos"}, new List<string> {"net"}},
-                    new object[] {new List<string> {"net5.1-tvos", "net5.1", "net5.0-tvos"}, new List<string> {"net5.0-tvos", "net5.1", "net5.1-tvos"}, new List<string> {"net"}},
-                    new object[] {new List<string> {"net5.0", "netcoreapp3.1", "native"}, new List<string> {"native", "net5.0", "netcoreapp3.1"}, new List<string> {"net", "netcoreapp"}},
+                    Assert.Contains(item, document.Tfms);
+                }
 
-                    new object[] {new List<string> {"netcoreapp3.1", "netstandard2.0"}, new List<string> {"netcoreapp3.1", "netstandard2.0"},
-                                    new List<string> {"netcoreapp", "netstandard"}},
-
-                    new object[] {new List<string> {"netstandard2.1", "net45", "net472", "tizen40"}, new List<string> {"netstandard2.1", "net45", "net472", "tizen40"},
-                                    new List<string> {"netframework", "netstandard"}},
-
-                    new object[] {new List<string>{"net40", "net471", "net5.0-watchos", "netstandard2.0", "netstandard2.1"},
-                                    new List<string>{"net40", "net471", "net5.0-watchos", "netstandard2.0", "netstandard2.1"}, new List<string> {"netframework", "net", "netstandard"}},
-
-                    new object[] {new List<string>{"net45", "netstandard2.1", "xamarinios"}, new List<string>{"net45", "netstandard2.1", "xamarinios"},
-                                    new List<string> {"netframework", "netstandard"}},
-
-                    new object[] {new List<string> {"net20", "net35", "net40", "net45", "netstandard1.0", "netstandard1.3", "netstandard2.0"},
-                                    new List<string> {"net20", "net35", "net40", "net45", "netstandard1.0", "netstandard1.3", "netstandard2.0"}, new List<string> {"netframework", "netstandard"}}
-                };
+                Assert.True(document.Frameworks.Length == expectedFrameworks.Count);
+                foreach (var item in expectedFrameworks)
+                {
+                    Assert.Contains(item, document.Frameworks);
+                }
+            }
         }
 
         public abstract class BaseFacts
@@ -1112,6 +1120,47 @@ namespace NuGet.Services.AzureSearch
 
                 _target = new SearchDocumentBuilder(_baseDocumentBuilder);
             }
+
+            public static IEnumerable<object[]> TargetFrameworkCases =>
+                new List<object[]>
+                {
+                    new object[] {new List<string> {}, new List<string>(), new List<string> {}},
+                    new object[] {new List<string> {"net"}, new List<string> {"net"}, new List<string> {"netframework"}},
+                    new object[] {new List<string> {"win"}, new List<string> {"win"}, new List<string> {}},
+                    new object[] {new List<string> {"dotnet"}, new List<string> {"dotnet"}, new List<string> {}},
+                    new object[] {new List<string> {"net472"}, new List<string> {"net472"}, new List<string> {"netframework"}},
+                    new object[] {new List<string> {"net40-client"}, new List<string> {"net40-client"}, new List<string> {"netframework"}},
+                    new object[] {new List<string> {"net5.0"}, new List<string> {"net5.0"}, new List<string> {"net"}},
+                    new object[] {new List<string> {"netcoreapp3.0"}, new List<string> { "netcoreapp3.0" }, new List<string> { "netcoreapp" } },
+                    new object[] {new List<string> {"netstandard2.0"}, new List<string> { "netstandard2.0" }, new List<string> { "netstandard" } },
+                    new object[] {new List<string> {"net40", "net45"}, new List<string> {"net40", "net45"}, new List<string> {"netframework"}},
+                    new object[] {new List<string> {"net5.0-tvos", "net5.0-ios"}, new List<string> {"net5.0-ios", "net5.0-tvos"}, new List<string> {"net"}},
+                    new object[] {new List<string> {"net5.0-tvos", "net5.0-ios13.0"}, new List<string> {"net5.0-ios13.0", "net5.0-tvos"}, new List<string> {"net"}},
+                    new object[] {new List<string> {"net5.1-tvos", "net5.1", "net5.0-tvos"}, new List<string> {"net5.0-tvos", "net5.1", "net5.1-tvos"}, new List<string> {"net"}},
+                    new object[] {new List<string> {"net5.0", "netcoreapp3.1", "native"}, new List<string> {"native", "net5.0", "netcoreapp3.1"}, new List<string> {"net", "netcoreapp"}},
+
+                    new object[] {new List<string> {"netcoreapp3.1", "netstandard2.0"}, new List<string> {"netcoreapp3.1", "netstandard2.0"},
+                                    new List<string> {"netcoreapp", "netstandard"}},
+
+                    new object[] {new List<string> {"netstandard2.1", "net45", "net472", "tizen40"}, new List<string> {"netstandard2.1", "net45", "net472", "tizen40"},
+                                    new List<string> {"netframework", "netstandard"}},
+
+                    new object[] {new List<string>{"net40", "net471", "net5.0-watchos", "netstandard2.0", "netstandard2.1"},
+                                    new List<string>{"net40", "net471", "net5.0-watchos", "netstandard2.0", "netstandard2.1"}, new List<string> {"netframework", "net", "netstandard"}},
+
+                    new object[] {new List<string>{"net45", "netstandard2.1", "xamarinios"}, new List<string>{"net45", "netstandard2.1", "xamarinios"},
+                                    new List<string> {"netframework", "netstandard"}},
+
+                    new object[] {new List<string> {"net20", "net35", "net40", "net45", "netstandard1.0", "netstandard1.3", "netstandard2.0"},
+                                    new List<string> {"net20", "net35", "net40", "net45", "netstandard1.0", "netstandard1.3", "netstandard2.0"}, new List<string> {"netframework", "netstandard"}}
+                };
+
+            public static IEnumerable<object[]> SpecialTFMCases =>
+            new List<object[]>
+            {
+                    new object[] {new List<string> {"any"}, new List<string> {}, new List<string> {}},
+                    new object[] {new List<string> {"foo"}, new List<string> {}, new List<string> {}} // unsupported tfm is not included
+            };
         }
     }
 }

--- a/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
+++ b/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
@@ -95,7 +95,16 @@ namespace NuGet.Services
             PackageHash = "oMs9XKzRTsbnIpITcqZ5XAv1h2z6oyJ33+Z/PJx36iVikge/8wm5AORqAv7soKND3v5/0QWW9PQ0ktQuQu9aQQ==",
             PackageHashAlgorithm = "SHA512",
             PackageId = PackageId,
+            PackageEntries = new List<NuGet.Protocol.Catalog.PackageEntry>
+            {
+                new NuGet.Protocol.Catalog.PackageEntry
+                {
+                    FullName = "lib/net40-client/Package.dll",
+                    Name = "Package.dll"
+                },
+            },
             PackageSize = 3039254,
+            PackageTypes = new List<NuGet.Protocol.Catalog.PackageType>(),
             PackageVersion = FullVersion,
             ProjectUrl = "https://github.com/Azure/azure-storage-net",
             Published = new DateTimeOffset(new DateTime(2017, 1, 3), TimeSpan.Zero),

--- a/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
+++ b/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
@@ -99,8 +99,8 @@ namespace NuGet.Services
             {
                 new NuGet.Protocol.Catalog.PackageEntry
                 {
-                    FullName = "lib/net40-client/Package.dll",
-                    Name = "Package.dll"
+                    FullName = $"lib/net40-client/{PackageId}.dll",
+                    Name = $"{PackageId}.dll"
                 },
             },
             PackageSize = 3039254,


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/4576

This change adds framework data to the Search Index through the Catalog2AzureSearch job:
* Read packageEntries (list of package's files) from the Catalog leaves
* Calculate a package's asset frameworks using catalog leaf properties (packageId, packageTypes, packageEntries)
* Populate 'Tfms' and 'Frameworks' index fields
* Add tests