### PR TITLE
Wrapped method call in try catch block

### DIFF
--- a/src/Validation.Symbols/SymbolsValidatorService.cs
+++ b/src/Validation.Symbols/SymbolsValidatorService.cs
@@ -14,6 +14,7 @@ using NuGet.Jobs.Validation;
 using NuGet.Jobs.Validation.Symbols.Core;
 using NuGet.Services.Validation;
 using NuGet.Services.Validation.Issues;
+using System.Reflection.Metadata;
 
 namespace Validation.Symbols
 {
@@ -192,66 +193,89 @@ namespace Validation.Symbols
                 // This checks if portable PDB is associated with the PE file and opens it for reading. 
                 // It also validates that it matches the PE file.
                 // It does not validate that the checksum matches, so we need to do that in the following block.
-                if (peReader.TryOpenAssociatedPortablePdb(peFilePath, File.OpenRead, out var pdbReaderProvider, out var pdbPath) &&
-                   // No need to validate embedded PDB (pdbPath == null for embedded)
-                   pdbPath != null)
+                if (!TryOpenReadPortablePdb(peReader, peFilePath, out var pdbReaderProvider, out var pdbPath))
                 {
-                    // Get all checksum entries. There can be more than one. At least one must match the PDB.
-                    var checksumRecords = peReader.ReadDebugDirectory().Where(entry => entry.Type == DebugDirectoryEntryType.PdbChecksum)
-                        .Select(e => peReader.ReadPdbChecksumDebugDirectoryData(e))
-                        .ToArray();
+                    _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound), assemblyName: Path.GetFileName(peFilePath));
+                    validationResponse = NuGetValidationResponse.FailedWithIssues(ValidationIssue.Unknown);
 
-                    if (checksumRecords.Length == 0)
+                    return false;
+                }
+
+                // No need to validate embedded PDB (pdbPath == null for embedded)
+                if (pdbPath == null)
+                {
+                    _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound), assemblyName: Path.GetFileName(peFilePath));
+                    validationResponse = NuGetValidationResponse.FailedWithIssues(ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound);
+                    return false;
+                }
+
+                // Get all checksum entries. There can be more than one. At least one must match the PDB.
+                var checksumRecords = peReader.ReadDebugDirectory().Where(entry => entry.Type == DebugDirectoryEntryType.PdbChecksum)
+                    .Select(e => peReader.ReadPdbChecksumDebugDirectoryData(e))
+                    .ToArray();
+
+                if (checksumRecords.Length == 0)
+                {
+                    _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch), assemblyName: Path.GetFileName(peFilePath));
+                    validationResponse = NuGetValidationResponse.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
+                    return false;
+                }
+
+                var pdbBytes = File.ReadAllBytes(pdbPath);
+                var hashes = new Dictionary<string, byte[]>();
+
+                using (pdbReaderProvider)
+                {
+                    var pdbReader = pdbReaderProvider.GetMetadataReader();
+                    int idOffset = pdbReader.DebugMetadataHeader.IdStartOffset;
+
+                    foreach (var checksumRecord in checksumRecords)
                     {
-                        _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch), assemblyName: Path.GetFileName(peFilePath));
-                        validationResponse = NuGetValidationResponse.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
-                        return false;
-                    }
-
-                    var pdbBytes = File.ReadAllBytes(pdbPath);
-                    var hashes = new Dictionary<string, byte[]>();
-
-                    using (pdbReaderProvider)
-                    {
-                        var pdbReader = pdbReaderProvider.GetMetadataReader();
-                        int idOffset = pdbReader.DebugMetadataHeader.IdStartOffset;
-
-                        foreach (var checksumRecord in checksumRecords)
+                        if (!hashes.TryGetValue(checksumRecord.AlgorithmName, out var hash))
                         {
-                            if (!hashes.TryGetValue(checksumRecord.AlgorithmName, out var hash))
+                            HashAlgorithmName han = new HashAlgorithmName(checksumRecord.AlgorithmName);
+                            using (var hashAlg = IncrementalHash.CreateHash(han))
                             {
-                                HashAlgorithmName han = new HashAlgorithmName(checksumRecord.AlgorithmName);
-                                using (var hashAlg = IncrementalHash.CreateHash(han))
-                                {
-                                    hashAlg.AppendData(pdbBytes, 0, idOffset);
-                                    hashAlg.AppendData(new byte[20]);
-                                    int offset = idOffset + 20;
-                                    int count = pdbBytes.Length - offset;
-                                    hashAlg.AppendData(pdbBytes, offset, count);
-                                    hash = hashAlg.GetHashAndReset();
-                                }
-                                hashes.Add(checksumRecord.AlgorithmName, hash);
+                                hashAlg.AppendData(pdbBytes, 0, idOffset);
+                                hashAlg.AppendData(new byte[20]);
+                                int offset = idOffset + 20;
+                                int count = pdbBytes.Length - offset;
+                                hashAlg.AppendData(pdbBytes, offset, count);
+                                hash = hashAlg.GetHashAndReset();
                             }
-                            if (checksumRecord.Checksum.ToArray().SequenceEqual(hash))
-                            {
-                                // found the right checksum
-                                _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion,  ValidationStatus.Succeeded, issue:"", assemblyName:Path.GetFileName(peFilePath));
-                                return true;
-                            }
+                            hashes.Add(checksumRecord.AlgorithmName, hash);
                         }
-
-                        // Not found any checksum record that matches the PDB.
-                        _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch), assemblyName: Path.GetFileName(peFilePath));
-                        validationResponse = NuGetValidationResponse.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
-                        return false;
+                        if (checksumRecord.Checksum.ToArray().SequenceEqual(hash))
+                        {
+                            // found the right checksum
+                            _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Succeeded, issue: "", assemblyName: Path.GetFileName(peFilePath));
+                            return true;
+                        }
                     }
+
+                    // Not found any checksum record that matches the PDB.
+                    _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch), assemblyName: Path.GetFileName(peFilePath));
+                    validationResponse = NuGetValidationResponse.FailedWithIssues(ValidationIssue.SymbolErrorCode_ChecksumDoesNotMatch);
+                    return false;
                 }
             }
-            _telemetryService.TrackSymbolsAssemblyValidationResultEvent(packageId, packageNormalizedVersion, ValidationStatus.Failed, nameof(ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound), assemblyName: Path.GetFileName(peFilePath));
-            validationResponse = NuGetValidationResponse.FailedWithIssues(ValidationIssue.SymbolErrorCode_MatchingAssemblyNotFound);
-            return false;
         }
 
+        private bool TryOpenReadPortablePdb(PEReader peReader, string peFilePath, out MetadataReaderProvider pdbReaderProvider, out string pdbPath)
+        {
+            try
+            {
+                return peReader.TryOpenAssociatedPortablePdb(peFilePath, File.OpenRead, out pdbReaderProvider, out pdbPath);
+            }
+            catch (BadImageFormatException ex)
+            {
+                _logger.LogDebug(ex,"Cannot open PDB file for {FilePath}", peFilePath);
+            }
+
+            pdbReaderProvider = null;
+            pdbPath = null;
+            return false;
+        }
         /// <summary>
         /// Verifies if the pdb is portable.
         /// </summary>


### PR DESCRIPTION
An exception thrown by the PEReaer.TryOpenAssociatedPortablePdb method caused a snupkg to be deadlettered. This PR fixes that by wrapping the method call in a try catch block. 