### PR TITLE
Add forcible timeout for GitHubSearchWrapper

### DIFF
--- a/src/NuGet.Jobs.GitHubIndexer/DiskRepositoriesCache.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/DiskRepositoriesCache.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitHubIndexerConfiguration.cs
@@ -52,5 +52,10 @@ namespace NuGet.Jobs.GitHubIndexer
         /// The list of repositories to be ignored by the indexing job. ("{repoOwner}/{repoName}")
         /// </summary>
         public HashSet<string> IgnoreList { get; set; }
+
+        /// <summary>
+        /// The maximum time allowed for a GitHub HTTP request, per <see cref="Octokit.GitHubClient.SetRequestTimeout(TimeSpan)"/>.
+        /// </summary>
+        public TimeSpan GitHubRequestTimeout { get; set; } = TimeSpan.FromSeconds(30);
     }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
@@ -31,6 +31,12 @@ namespace NuGet.Jobs.GitHubIndexer
 
         public async Task<GitHubSearchApiResponse> GetResponse(SearchRepositoriesRequest request)
         {
+            // We execute this with a forcible timeout because we've seen this method hang in the past, despite having
+            // the timeout that is built-in on IGitHubClient connection. The forcible timeout duration is set to twice
+            // the timeout applied to IGitHubClient (and by extension HttpClient) to allow the built-in timeout to work,
+            // if possible. If the built-in timeout does not work, this will essentially abandon the HTTP task
+            // and throw an OperationCanceledException, with a custom message. If the built-in timeout does work, a
+            // TaskCanceledException will be thrown.
             var apiResponse = await ExecuteWithTimeoutAsync(
                 token => _client.Connection.Get<SearchRepositoryResult>(
                     ApiUrls.SearchRepositories(),

--- a/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/GitRepoSearchers/GitHub/GitHubSearchWrapper.cs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using Octokit;
 
 namespace NuGet.Jobs.GitHubIndexer
@@ -15,10 +15,12 @@ namespace NuGet.Jobs.GitHubIndexer
     public class GitHubSearchWrapper : IGitHubSearchWrapper
     {
         private readonly IGitHubClient _client;
+        private readonly IOptionsSnapshot<GitHubIndexerConfiguration> _options;
 
-        public GitHubSearchWrapper(IGitHubClient client)
+        public GitHubSearchWrapper(IGitHubClient client, IOptionsSnapshot<GitHubIndexerConfiguration> options)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         public int? GetRemainingRequestCount()
@@ -29,7 +31,13 @@ namespace NuGet.Jobs.GitHubIndexer
 
         public async Task<GitHubSearchApiResponse> GetResponse(SearchRepositoriesRequest request)
         {
-            var apiResponse = await _client.Connection.Get<SearchRepositoryResult>(ApiUrls.SearchRepositories(), request.Parameters, null);
+            var apiResponse = await ExecuteWithTimeoutAsync(
+                token => _client.Connection.Get<SearchRepositoryResult>(
+                    ApiUrls.SearchRepositories(),
+                    request.Parameters,
+                    accepts: null,
+                    cancellationToken: token),
+                timeout: TimeSpan.FromTicks(_options.Value.GitHubRequestTimeout.Ticks * 2));
 
             // According to RFC 2616, Http headers are case-insensitive. We should treat them as such.
             var caseInsensitiveHeaders = apiResponse.HttpResponse.Headers
@@ -60,6 +68,30 @@ namespace NuGet.Jobs.GitHubIndexer
                     .ToList(),
                 ghTime,
                 DateTimeOffset.FromUnixTimeSeconds(ghResetTime));
+        }
+
+        private static async Task<T> ExecuteWithTimeoutAsync<T>(Func<CancellationToken, Task<T>> getTask, TimeSpan timeout)
+        {
+            // Source:
+            // https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#using-a-timeout
+            using (var cts = new CancellationTokenSource())
+            {
+                var delayTask = Task.Delay(timeout, cts.Token);
+                var mainTask = getTask(cts.Token);
+                var resultTask = await Task.WhenAny(mainTask, delayTask);
+                if (resultTask == delayTask)
+                {
+                    // Operation cancelled
+                    throw new OperationCanceledException("The operation was forcibly canceled.");
+                }
+                else
+                {
+                    // Cancel the timer task so that it does not fire
+                    cts.Cancel();
+                }
+
+                return await mainTask;
+            }
         }
     }
 }

--- a/src/NuGet.Jobs.GitHubIndexer/Job.cs
+++ b/src/NuGet.Jobs.GitHubIndexer/Job.cs
@@ -29,7 +29,13 @@ namespace NuGet.Jobs.GitHubIndexer
 
             services.AddTransient<ITelemetryService, TelemetryService>();
             services.AddTransient<IGitRepoSearcher, GitHubSearcher>();
-            services.AddSingleton<IGitHubClient>(provider => new GitHubClient(new ProductHeaderValue(assemblyName, assemblyVersion)));
+            services.AddSingleton<IGitHubClient>(provider =>
+            {
+                var configuration = provider.GetRequiredService<IOptionsSnapshot<GitHubIndexerConfiguration>>();
+                var client = new GitHubClient(new ProductHeaderValue(assemblyName, assemblyVersion));
+                client.SetRequestTimeout(configuration.Value.GitHubRequestTimeout);
+                return client;
+            });
             services.AddSingleton<IGitHubSearchWrapper, GitHubSearchWrapper>();
             services.AddTransient<RepoUtils>();
             services.AddTransient<ReposIndexer>();

--- a/tests/NuGet.Jobs.GitHubIndexer.Tests/RepoUtilsFacts.cs
+++ b/tests/NuGet.Jobs.GitHubIndexer.Tests/RepoUtilsFacts.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xunit;


### PR DESCRIPTION
Also, reduce the timeout for IGitHubClient to 30 seconds by default. It was the default `HttpClient` 100 seconds before. We've seen a recurring pattern of hangs at this point in the job. Mitigation for https://github.com/NuGet/Engineering/issues/4551