### PR TITLE
New function for stats pipeline to extract version out of nuget.exe URLs

### DIFF
--- a/src/Stats.LogInterpretation/PackageDefinition.cs
+++ b/src/Stats.LogInterpretation/PackageDefinition.cs
@@ -12,6 +12,9 @@ namespace Stats.LogInterpretation
     public class PackageDefinition
     {
         private const string _nupkgExtension = ".nupkg";
+        private const string _nugetExeUrlEnding = "/nuget.exe";
+        private const string _nugetExeLatestVersionSegment = "latest";
+        private const string _nugetExePackageId = "client/nuget.exe"; // to eliminate the chances of clashing with a real package
         private const string _dotSeparator = ".";
 
         public string PackageId { get; set; }
@@ -29,9 +32,14 @@ namespace Stats.LogInterpretation
 
         public static IList<PackageDefinition> FromRequestUrl(string requestUrl)
         {
-            if (string.IsNullOrWhiteSpace(requestUrl) || !requestUrl.EndsWith(_nupkgExtension, StringComparison.InvariantCultureIgnoreCase))
+            if (string.IsNullOrWhiteSpace(requestUrl) || !HasExpectedEnding(requestUrl))
             {
                 return null;
+            }
+
+            if (requestUrl.EndsWith(_nugetExeUrlEnding, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return ParseNuGetExe(requestUrl);
             }
 
             List<PackageDefinition> resolutionOptions = new List<PackageDefinition>();
@@ -85,6 +93,52 @@ namespace Stats.LogInterpretation
         public override string ToString()
         {
             return $"[{PackageId}, {PackageVersion}]";
+        }
+
+        private static bool HasExpectedEnding(string requestUrl) =>
+            requestUrl.EndsWith(_nupkgExtension, StringComparison.InvariantCultureIgnoreCase)
+                || requestUrl.EndsWith(_nugetExeUrlEnding, StringComparison.InvariantCultureIgnoreCase);
+
+
+        private static IList<PackageDefinition> ParseNuGetExe(string requestUrl)
+        {
+            // path example: /artifacts/win-x86-commandline/v5.9.1/nuget.exe
+
+            requestUrl = HttpUtility.UrlDecode(requestUrl);
+
+            var urlSegments = requestUrl.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (urlSegments.Length < 4)
+            {
+                // proper nuget.exe URL paths have at least 4 segments
+                return null;
+            }
+
+            var suspectedVersionSegment = urlSegments[urlSegments.Length - 2];
+
+            if (suspectedVersionSegment == _nugetExeLatestVersionSegment)
+            {
+                return new List<PackageDefinition>
+                {
+                    new PackageDefinition(_nugetExePackageId, _nugetExeLatestVersionSegment)
+                };
+            }
+
+            if (!suspectedVersionSegment.StartsWith("v"))
+            {
+                return null;
+            }
+
+            var versionString = suspectedVersionSegment.Substring(1);
+            if (NuGetVersion.TryParse(versionString, out var parsedVersion))
+            {
+                return new List<PackageDefinition>
+                {
+                    new PackageDefinition(_nugetExePackageId, parsedVersion.ToNormalizedString())
+                };
+            }
+
+            return null;
         }
     }
 }

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDefinitionFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDefinitionFacts.cs
@@ -30,6 +30,10 @@ namespace Tests.Stats.LogInterpretation
         [InlineData("xunit.1", "2.4.1", "https://api.nuget.org/v3-flatcontainer/xunit.1/2.4.1/xunit.1.2.4.1.nupkg")]
         //[InlineData("ImisComplexIpart20.2.1.235-EA", "20.2.1.235-EA", "http://localhost/packages/ImisComplexIpart20.2.1.235-EA.20.2.1.235-EA.nupkg")]
         //[InlineData("runtime.tizen.4.0.0-armel.Microsoft.NETCore.App", "2.0.0-preview1-002111-00", "http://localhost/packages/runtime.tizen.4.0.0-armel.Microsoft.NETCore.App.2.0.0-preview1-002111-00.nupkg")]
+        [InlineData("client/nuget.exe", "5.9.1", "https://localhost/artifacts/win-x86-commandline/v5.9.1/nuget.exe")]
+        [InlineData("client/nuget.exe", "5.8.0-preview.2", "https://localhost/artifacts/win-x86-commandline/v5.8.0-preview.2/nuget.exe")]
+        [InlineData("client/nuget.exe", "3.5.0-beta2", "https://localhost/artifacts/win-x86-commandline/v3.5.0-beta2/nuget.exe")]
+        [InlineData("client/nuget.exe", "latest", "https://localhost/artifacts/win-x86-commandline/latest/nuget.exe")]
         public void ExtractsPackageIdAndVersionFromRequestUrl(string expectedPackageId, string expectedPackageVersion, string requestUrl)
         {
             var packageDefinitions = PackageDefinition.FromRequestUrl(requestUrl);
@@ -38,10 +42,14 @@ namespace Tests.Stats.LogInterpretation
             Assert.Equal(expectedPackageVersion, packageDefinition.PackageVersion);
         }
 
-        [Fact]
-        public void ReturnsNullWhenInvalidPackageRequestUrl()
+        [Theory]
+        [InlineData("http://localhost/api/v3/index.json")]
+        [InlineData("http://localhost/downloads/nuget.exe")]
+        [InlineData("http://localhost/artifacts/win-x86-commandline/3.5.0/nuget.exe")]
+        [InlineData("http://localhost/artifacts/win-x86-commandline/vlatest/nuget.exe")]
+        public void ReturnsNullWhenInvalidPackageRequestUrl(string requestUrl)
         {
-            var packageDefinition = PackageDefinition.FromRequestUrl("http://localhost/api/v3/index.json");
+            var packageDefinition = PackageDefinition.FromRequestUrl(requestUrl);
             Assert.Null(packageDefinition);
         }
 

--- a/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDefinitionFacts.cs
+++ b/tests/Tests.Stats.ImportAzureCdnStatistics/PackageDefinitionFacts.cs
@@ -30,10 +30,6 @@ namespace Tests.Stats.LogInterpretation
         [InlineData("xunit.1", "2.4.1", "https://api.nuget.org/v3-flatcontainer/xunit.1/2.4.1/xunit.1.2.4.1.nupkg")]
         //[InlineData("ImisComplexIpart20.2.1.235-EA", "20.2.1.235-EA", "http://localhost/packages/ImisComplexIpart20.2.1.235-EA.20.2.1.235-EA.nupkg")]
         //[InlineData("runtime.tizen.4.0.0-armel.Microsoft.NETCore.App", "2.0.0-preview1-002111-00", "http://localhost/packages/runtime.tizen.4.0.0-armel.Microsoft.NETCore.App.2.0.0-preview1-002111-00.nupkg")]
-        [InlineData("client/nuget.exe", "5.9.1", "https://localhost/artifacts/win-x86-commandline/v5.9.1/nuget.exe")]
-        [InlineData("client/nuget.exe", "5.8.0-preview.2", "https://localhost/artifacts/win-x86-commandline/v5.8.0-preview.2/nuget.exe")]
-        [InlineData("client/nuget.exe", "3.5.0-beta2", "https://localhost/artifacts/win-x86-commandline/v3.5.0-beta2/nuget.exe")]
-        [InlineData("client/nuget.exe", "latest", "https://localhost/artifacts/win-x86-commandline/latest/nuget.exe")]
         public void ExtractsPackageIdAndVersionFromRequestUrl(string expectedPackageId, string expectedPackageVersion, string requestUrl)
         {
             var packageDefinitions = PackageDefinition.FromRequestUrl(requestUrl);
@@ -42,14 +38,32 @@ namespace Tests.Stats.LogInterpretation
             Assert.Equal(expectedPackageVersion, packageDefinition.PackageVersion);
         }
 
+        [Fact]
+        public void ReturnsNullWhenInvalidPackageRequestUrl()
+        {
+            var packageDefinition = PackageDefinition.FromRequestUrl("http://localhost/api/v3/index.json");
+            Assert.Null(packageDefinition);
+        }
+
         [Theory]
-        [InlineData("http://localhost/api/v3/index.json")]
+        [InlineData("5.9.1", "https://localhost/artifacts/win-x86-commandline/v5.9.1/nuget.exe")]
+        [InlineData("5.8.0-preview.2", "https://localhost/artifacts/win-x86-commandline/v5.8.0-preview.2/nuget.exe")]
+        [InlineData("3.5.0-beta2", "https://localhost/artifacts/win-x86-commandline/v3.5.0-beta2/nuget.exe")]
+        [InlineData("latest", "https://localhost/artifacts/win-x86-commandline/latest/nuget.exe")]
+        public void FromNuGetExeUrlExtractsNuGetExeVersionFromUrl(string expectedVersion, string requestUrl)
+        {
+            var packageDefinition = PackageDefinition.FromNuGetExeUrl(requestUrl);
+            Assert.Equal("tool/nuget.exe", packageDefinition.PackageId);
+            Assert.Equal(expectedVersion, packageDefinition.PackageVersion);
+        }
+
+        [Theory]
         [InlineData("http://localhost/downloads/nuget.exe")]
         [InlineData("http://localhost/artifacts/win-x86-commandline/3.5.0/nuget.exe")]
         [InlineData("http://localhost/artifacts/win-x86-commandline/vlatest/nuget.exe")]
-        public void ReturnsNullWhenInvalidPackageRequestUrl(string requestUrl)
+        public void FromNuGetExeUrlReturnsNullWhenInvalidUrl(string requestUrl)
         {
-            var packageDefinition = PackageDefinition.FromRequestUrl(requestUrl);
+            var packageDefinition = PackageDefinition.FromNuGetExeUrl(requestUrl);
             Assert.Null(packageDefinition);
         }
 


### PR DESCRIPTION
To process nuget.exe download stats, we need to code to get version from download URLs. This change adds it.