### PR TITLE
Fixed some bugs in the SearchService code for Search-by-TFM

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/AzureSearchService.cs
@@ -39,6 +39,14 @@ namespace NuGet.Services.AzureSearch.SearchService
                 {
                     throw new InvalidSearchRequestException("Can't apply the packageType filter on the Hijack index");
                 }
+                else if (request.Frameworks != null && request.Frameworks.Any())
+                {
+                    throw new InvalidSearchRequestException("Can't apply the Frameworks filter on the Hijack index");
+                }
+                else if (request.Tfms != null && request.Tfms.Any())
+                {
+                    throw new InvalidSearchRequestException("Can't apply the TFMs filter on the Hijack index");
+                }
                 else if (request.SortBy == V2SortBy.TotalDownloadsAsc || request.SortBy == V2SortBy.TotalDownloadsDesc)
                 {
                     throw new InvalidSearchRequestException("Can't sortBy downloads on the Hijack index");

--- a/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexOperationBuilder.cs
@@ -65,7 +65,10 @@ namespace NuGet.Services.AzureSearch.SearchService
             var parsed = _textBuilder.ParseV2Search(request);
 
             IndexOperation indexOperation;
+            // Only performs a GetDocument query if the query contains no Filters
             if (request.PackageType == null
+                && (request.Frameworks == null || !request.Frameworks.Any())
+                && (request.Tfms == null || !request.Tfms.Any())
                 && TryGetSearchDocumentByKey(request, parsed, out indexOperation))
             {
                 return indexOperation;

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/ParameterUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/ParameterUtilities.cs
@@ -75,7 +75,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 }
                 else
                 {
-                    throw new ArgumentException(Strings.V2Search_InvalidFrameworkParameter, framework);
+                    throw new InvalidSearchRequestException($"The provided Framework is not supported. (Parameter '{framework}')");
                 }
             }
 
@@ -103,7 +103,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 }
                 else
                 {
-                    throw new ArgumentException(Strings.V2Search_InvalidTFMParameter, tfm);
+                    throw new InvalidSearchRequestException($"The provided TFM is not supported. (Parameter '{tfm}')");
                 }
             }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/AzureSearchServiceFacts.cs
@@ -85,6 +85,46 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Fact]
+            public async Task ShouldThrowWhenFilteringByFrameworksOnHijackIndex()
+            {
+                _v2Request.IgnoreFilter = true;
+
+                _v2Request.Frameworks = new List<string>(); // Should not throw an exception
+                var notException = await Record.ExceptionAsync(async () => {
+                    await _target.V2SearchAsync(_v2Request);
+                });
+
+                Assert.Null(notException);
+
+                _v2Request.Frameworks = new List<string> { "netstandard" }; // Should throw
+                var exception = await Assert.ThrowsAsync<InvalidSearchRequestException>(async () => {
+                    await _target.V2SearchAsync(_v2Request);
+                });
+
+                Assert.Equal("Can't apply the Frameworks filter on the Hijack index", exception.Message);
+            }
+
+            [Fact]
+            public async Task ShouldThrowWhenFilteringByTfmsOnHijackIndex()
+            {
+                _v2Request.IgnoreFilter = true;
+
+                _v2Request.Tfms = new List<string>(); // Should not throw an exception
+                var notException = await Record.ExceptionAsync(async () => {
+                    await _target.V2SearchAsync(_v2Request);
+                });
+
+                Assert.Null(notException);
+
+                _v2Request.Tfms = new List<string> { "netstandard2.1" }; // Should throw
+                var exception = await Assert.ThrowsAsync<InvalidSearchRequestException>(async () => {
+                    await _target.V2SearchAsync(_v2Request);
+                });
+
+                Assert.Equal("Can't apply the TFMs filter on the Hijack index", exception.Message);
+            }
+
+            [Fact]
             public async Task SearchIndexAndGetOperation()
             {
                 _v2Request.IgnoreFilter = false;

--- a/tests/NuGet.Services.SearchService.Core.Tests/Controllers/SearchControllerFacts.cs
+++ b/tests/NuGet.Services.SearchService.Core.Tests/Controllers/SearchControllerFacts.cs
@@ -300,7 +300,7 @@ namespace NuGet.Services.SearchService.Controllers
             [MemberData(nameof(InvalidFrameworksAndTfms))]
             public async Task ThrowsInvalidFrameworksAndTfms(string frameworks, string tfms, string expectedException)
             {
-                var exception = await Assert.ThrowsAsync<ArgumentException>(() => _target.V2SearchAsync(frameworks: frameworks, tfms: tfms));
+                var exception = await Assert.ThrowsAsync<InvalidSearchRequestException>(() => _target.V2SearchAsync(frameworks: frameworks, tfms: tfms));
 
                 Assert.Equal(expectedException, exception.Message);
             }


### PR DESCRIPTION
Fixed some bugs I found in the Search Service code:

- Invalid Framework and TFM inputs were throwing HTTP 500 errors earlier, they now throw 400 (Bad request) errors. Added tests for this too.
- Framework and TFM filters cannot be applied to the Hijack index. Added tests.
- Document scoped queries ("packageid:<xx>") ignored the frameworks and tfm filters earlier and did a simple document key lookup in the index. Now, queries with framework and tfm filters go through the regular search query path, which takes into account the applied filters. (I've added functional tests for this separately, which I will merge in once these changes are in too: https://github.com/NuGet/NuGet.Jobs/compare/dev...dev-advay26-sbtfmfunctests#diff-8dbb67b6632dc0727cf0633dc59c2cd26eb30650bda7ddaadc31678d7cda5c8cR580)