### PR TITLE
deprecation and vulnerability - populate fields in search documents

### DIFF
--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -215,6 +215,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     .Include(x => x.PackageRegistration)
                     .Include(x => x.PackageTypes)
                     .Include(x => x.Deprecations)
+                    .Include(x => x.Deprecations.Select(d => d.AlternatePackage))
                     .Include(x => x.VulnerablePackageRanges)
                     .Where(p => p.PackageStatusKey == PackageStatus.Available)
                     .Where(p => p.PackageRegistrationKey >= minKey);

--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -214,6 +214,8 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     .Set<Package>()
                     .Include(x => x.PackageRegistration)
                     .Include(x => x.PackageTypes)
+                    .Include(x => x.Deprecations)
+                    .Include(x => x.VulnerablePackageRanges)
                     .Where(p => p.PackageStatusKey == PackageStatus.Available)
                     .Where(p => p.PackageRegistrationKey >= minKey);
 

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -26,10 +26,6 @@ namespace NuGet.Services.AzureSearch
 
             [SimpleField(IsFilterable = true)]
             public bool? IsExcludedByDefault { get; set; }
-
-            public Deprecation Deprecation { get; set; }
-
-            public List<Vulnerability> Vulnerabilities { get; set; }
         }
 
         /// <summary>
@@ -52,6 +48,9 @@ namespace NuGet.Services.AzureSearch
             public string[] PackageTypes { get; set; }
             public bool? IsLatestStable { get; set; }
             public bool? IsLatest { get; set; }
+
+            public Deprecation Deprecation { get; set; }
+            public List<Vulnerability> Vulnerabilities { get; set; }
         }
 
         /// <summary>

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -367,7 +367,7 @@ namespace NuGet.Services.AzureSearch
             SearchDocument.Full document,
             Package package)
         {
-            if ((int)package.Deprecations?.FirstOrDefault()?.Status > (int)PackageDeprecationStatus.NotDeprecated)
+            if (package.Deprecations?.FirstOrDefault()?.Status > PackageDeprecationStatus.NotDeprecated)
             {
                 var packageDeprecation = package.Deprecations.ElementAt(0);
                 document.Deprecation = new Deprecation();

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -367,7 +367,6 @@ namespace NuGet.Services.AzureSearch
             SearchDocument.Full document,
             Package package)
         {
-
             Entities.PackageDeprecation packageDeprecation;
             try
             {
@@ -422,7 +421,6 @@ namespace NuGet.Services.AzureSearch
             Package package)
         {
             document.Vulnerabilities = new List<Vulnerability>();
-
             if (package.VulnerablePackageRanges == null)
             {
                 return;
@@ -444,7 +442,6 @@ namespace NuGet.Services.AzureSearch
             PackageDetailsCatalogLeaf leaf)
         {
             document.Vulnerabilities = new List<Vulnerability>();
-
             if (leaf.Vulnerabilities == null)
             {
                 return;

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -367,8 +367,8 @@ namespace NuGet.Services.AzureSearch
             SearchDocument.Full document,
             Package package)
         {
-            if (package?.Deprecations?.FirstOrDefault()?.Status > PackageDeprecationStatus.NotDeprecated) {
-            
+            if ((int)package.Deprecations?.FirstOrDefault()?.Status > (int)PackageDeprecationStatus.NotDeprecated)
+            {
                 var packageDeprecation = package.Deprecations.ElementAt(0);
                 document.Deprecation = new Deprecation();
                 document.Deprecation.Message = packageDeprecation.CustomMessage;

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -372,7 +372,7 @@ namespace NuGet.Services.AzureSearch
                 return;
             }
 
-            var packageDeprecation = package.Deprecations?.ElementAt(0);
+            var packageDeprecation = package.Deprecations?.ElementAt(0) as Entities.PackageDeprecation;
             if (packageDeprecation == null || packageDeprecation.Status == PackageDeprecationStatus.NotDeprecated)
             {
                 return;

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -364,15 +364,40 @@ namespace NuGet.Services.AzureSearch
         private static void PopulateDeprecation(
             SearchDocument.Full document,
             Package package)
+        {
+            document.Deprecation = new Deprecation();
+            document.Deprecation.Reasons = Array.Empty<string>(); //db2azuresearch job cannot process if null
+
+            if (package.Deprecations != null && package.Deprecations.Count > 0)
             {
-                document.Deprecation = new Deprecation(); //TODO: https://github.com/NuGet/NuGetGallery/issues/7297
+                document.Deprecation.Message = package.Deprecations.ElementAt(0).CustomMessage;
+                document.Deprecation.Reasons = package.Deprecations.ElementAt(0).Status.ToString().Replace(" ", "").Split(',');
+
+                if (document.Deprecation.AlternatePackage != null)
+                {
+                        document.Deprecation.AlternatePackage = new AlternatePackage();
+                        document.Deprecation.AlternatePackage.Id = package.Deprecations.ElementAt(0).AlternatePackage.Id;
+                        document.Deprecation.AlternatePackage.Range = "[" + package.Deprecations.ElementAt(0).AlternatePackage.Version + ", )";
+                }
             }
+        }
 
         private static void PopulateVulnerabilities(
             SearchDocument.Full document,
             Package package)
+        {
+            document.Vulnerabilities = new List<Vulnerability>(); //TODO: https://github.com/NuGet/NuGetGallery/issues/7297
+
+            foreach (VulnerablePackageVersionRange v in package.VulnerablePackageRanges)
             {
-                document.Vulnerabilities = new List<Vulnerability>(); //TODO: https://github.com/NuGet/NuGetGallery/issues/7297
+                var vulnerability = new Vulnerability();
+                if (v.Vulnerability != null)
+                {
+                    vulnerability.AdvisoryURL = v.Vulnerability.AdvisoryUrl;
+                    vulnerability.Severity = (int)v.Vulnerability.Severity;
+                    document.Vulnerabilities.Add(vulnerability);
+                }
             }
+        }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -367,27 +367,23 @@ namespace NuGet.Services.AzureSearch
             SearchDocument.Full document,
             Package package)
         {
-            Entities.PackageDeprecation packageDeprecation;
-            try
+            if (package.Deprecations?.Count != 1)
             {
-                packageDeprecation = package.Deprecations?.SingleOrDefault();
-            }
-            catch (InvalidOperationException)
-            {
-                packageDeprecation = null;
+                return;
             }
 
+            var packageDeprecation = package.Deprecations?.ElementAt(0);
             if (packageDeprecation == null || packageDeprecation.Status == PackageDeprecationStatus.NotDeprecated)
             {
                 return;
             }
 
             var version = packageDeprecation.AlternatePackage?.Version ?? "";
-            document.Deprecation = new Deprecation
+            document.Deprecation = new Deprecation()
             {
                 Message = packageDeprecation.CustomMessage,
                 Reasons = packageDeprecation.Status.ToString().Replace(" ", "").Split(','),
-                AlternatePackage = packageDeprecation.AlternatePackage == null ? null : new AlternatePackage
+                AlternatePackage = packageDeprecation.AlternatePackage == null ? null : new AlternatePackage()
                 {
                     Id = packageDeprecation.AlternatePackage.Id,
                     Range = $"[{version}, )"
@@ -404,11 +400,11 @@ namespace NuGet.Services.AzureSearch
                 return;
             }
 
-            document.Deprecation = new Deprecation
+            document.Deprecation = new Deprecation()
             {
                 Reasons = leaf.Deprecation.Reasons.ToArray<string>(),
                 Message = leaf.Deprecation.Message,
-                AlternatePackage = leaf.Deprecation.AlternatePackage == null ? null : new AlternatePackage
+                AlternatePackage = leaf.Deprecation.AlternatePackage == null ? null : new AlternatePackage()
                 {
                     Id = leaf.Deprecation.AlternatePackage.Id,
                     Range = leaf.Deprecation.AlternatePackage.Range
@@ -429,7 +425,7 @@ namespace NuGet.Services.AzureSearch
             foreach (var range in package.VulnerablePackageRanges.Where( x => x?.Vulnerability != null ))
             {
 
-                document.Vulnerabilities.Add(new Vulnerability 
+                document.Vulnerabilities.Add(new Vulnerability() 
                 {  
                     AdvisoryURL = range.Vulnerability.AdvisoryUrl,
                     Severity = (int)range.Vulnerability.Severity
@@ -449,7 +445,7 @@ namespace NuGet.Services.AzureSearch
 
             foreach (var leafVulnerability in leaf.Vulnerabilities.Where( x => x != null ))
             {
-                document.Vulnerabilities.Add(new Vulnerability
+                document.Vulnerabilities.Add(new Vulnerability()
                 {
                     AdvisoryURL = leafVulnerability.AdvisoryUrl,
                     Severity = (int)Enum.Parse(typeof(PackageVulnerabilitySeverity), leafVulnerability.Severity)

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -378,7 +378,6 @@ namespace NuGet.Services.AzureSearch
                 return;
             }
 
-            var version = packageDeprecation.AlternatePackage?.Version ?? "";
             document.Deprecation = new Deprecation()
             {
                 Message = packageDeprecation.CustomMessage,
@@ -386,7 +385,7 @@ namespace NuGet.Services.AzureSearch
                 AlternatePackage = packageDeprecation.AlternatePackage == null ? null : new AlternatePackage()
                 {
                     Id = packageDeprecation.AlternatePackage.Id,
-                    Range = $"[{version}, )"
+                    Range = string.IsNullOrWhiteSpace(packageDeprecation.AlternatePackage.Version) ? "*" : $"[{packageDeprecation.AlternatePackage.Version}, )"
                 }
             };
         }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchVulnerability.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V3SearchVulnerability.cs
@@ -8,7 +8,7 @@ namespace NuGet.Services.AzureSearch.SearchService
     public class V3SearchVulnerability
     {
         [JsonPropertyName("advisoryUrl")]
-        public string AdvisoryURL { get; set; }
+        public string AdvisoryUrl { get; set; }
 
         [JsonPropertyName("severity")]
         public int Severity { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -474,7 +474,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 {
                     vulnerabilities.Add(new V3SearchVulnerability 
                     {
-                        AdvisoryURL = vulnerability.AdvisoryURL,
+                        AdvisoryUrl = vulnerability.AdvisoryURL,
                         Severity = vulnerability.Severity
                     });
                 }

--- a/tests/NuGet.Jobs.Catalog2Registration.Tests/Schema/EntityBuilderFacts.cs
+++ b/tests/NuGet.Jobs.Catalog2Registration.Tests/Schema/EntityBuilderFacts.cs
@@ -249,7 +249,17 @@ namespace NuGet.Jobs.Catalog2Registration
       ""windowsazureofficial""
     ],
     ""title"": ""Windows Azure Storage"",
-    ""version"": ""7.1.2-alpha+git""
+    ""version"": ""7.1.2-alpha+git"",
+    ""vulnerabilities"": [
+      {
+        ""advisoryUrl"": ""test AdvisoryUrl for Low Severity"",
+        ""severity"": ""Low""
+      },
+      {
+        ""advisoryUrl"": ""test AdvisoryUrl for Moderate Severity"",
+        ""severity"": ""Moderate""
+      }
+    ]
   },
   ""packageContent"": ""https://example/fc/windowsazure.storage/7.1.2-alpha/windowsazure.storage.7.1.2-alpha.nupkg"",
   ""registration"": ""https://example/reg-gz-semver2/windowsazure.storage/index.json""
@@ -300,6 +310,19 @@ namespace NuGet.Jobs.Catalog2Registration
         ""targetFramework"": "".NETFramework4.0-Client""
       }
     ],
+    ""deprecation"": {
+      ""@type"": ""deprecation"",
+      ""alternatePackage"": {
+        ""@type"": ""alternatePackage"",
+        ""id"": ""test.alternatepackage"",
+        ""range"": ""[1.0.0, )""
+      },
+      ""message"": ""test message for test.alternatepackage-1.0.0"",
+      ""reasons"": [
+        ""Other"",
+        ""Legacy""
+      ]
+    },
     ""description"": ""Description."",
     ""iconUrl"": ""https://example/fc/windowsazure.storage/7.1.2-alpha/icon"",
     ""id"": ""WindowsAzure.Storage"",

--- a/tests/NuGet.Jobs.Catalog2Registration.Tests/Schema/EntityBuilderFacts.cs
+++ b/tests/NuGet.Jobs.Catalog2Registration.Tests/Schema/EntityBuilderFacts.cs
@@ -253,11 +253,11 @@ namespace NuGet.Jobs.Catalog2Registration
     ""vulnerabilities"": [
       {
         ""advisoryUrl"": ""test AdvisoryUrl for Low Severity"",
-        ""severity"": ""Low""
+        ""severity"": ""0""
       },
       {
         ""advisoryUrl"": ""test AdvisoryUrl for Moderate Severity"",
-        ""severity"": ""Moderate""
+        ""severity"": ""1""
       }
     ]
   },

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -394,6 +394,27 @@ namespace NuGet.Services.AzureSearch
       ],
       ""isLatestStable"": false,
       ""isLatest"": true,
+      ""deprecation"": {
+        ""alternatePackage"": {
+          ""id"": ""test.alternatepackage"",
+          ""range"": ""[1.0.0, )""
+        },
+        ""message"": ""test message for test.alternatepackage-1.0.0"",
+        ""reasons"": [
+          ""Other"",
+          ""Legacy""
+        ]
+      },
+      ""vulnerabilities"": [
+        {
+          ""advisoryURL"": ""test AdvisoryUrl for Low Severity"",
+          ""severity"": 0
+        },
+        {
+          ""advisoryURL"": ""test AdvisoryUrl for Moderate Severity"",
+          ""severity"": 1
+        }
+      ],
       ""semVerLevel"": 2,
       ""authors"": ""Microsoft"",
       ""copyright"": ""\u00A9 Microsoft Corporation. All rights reserved."",
@@ -561,6 +582,145 @@ namespace NuGet.Services.AzureSearch
 
                 Assert.Equal(Data.FlatContainerIconUrl, document.IconUrl);
             }
+
+            [Fact]
+            public void CheckNullDeprecation()
+            {
+                var leaf = Data.Leaf;
+                leaf.Deprecation = null;
+
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                Assert.Null(document.Deprecation);
+            }
+
+            [Fact]
+            public void CheckNullDeprecationReasons()
+            {
+                var leaf = Data.Leaf;
+                leaf.Deprecation = new Protocol.Catalog.PackageDeprecation();
+
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                Assert.Null(document.Deprecation);
+            }
+
+            [Fact]
+            public void CheckEmptyDeprecationReasons()
+            {
+                var leaf = Data.Leaf;
+                leaf.Deprecation = new Protocol.Catalog.PackageDeprecation() { Reasons = new List<string> {} };
+
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                Assert.Null(document.Deprecation);
+            }
+
+            [Fact]
+            public void CheckNullAlternatePackage()
+            {
+                var leaf = Data.Leaf;
+                leaf.Deprecation = new Protocol.Catalog.PackageDeprecation() { Reasons = new List<string> {"Other"} };
+
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                Assert.NotNull(document.Deprecation);
+                Assert.NotEmpty(document.Deprecation.Reasons);
+                Assert.Null(document.Deprecation.AlternatePackage);
+            }
+
+            [Fact]
+            public void CheckNullVulnerabilities()
+            {
+                var leaf = Data.Leaf;
+                leaf.Vulnerabilities = null;
+
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                Assert.NotNull(document.Vulnerabilities);
+                Assert.Empty(document.Vulnerabilities);
+            }
+
+            [Fact]
+            public void CheckEmptyVulnerabilities()
+            {
+                var leaf = Data.Leaf;
+                leaf.Vulnerabilities = new List<Protocol.Catalog.PackageVulnerability>();
+
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                Assert.NotNull(document.Vulnerabilities);
+                Assert.Empty(document.Vulnerabilities);
+            }
+
+            [Fact]
+            public void CheckNullInVulnerabilitiesList()
+            {
+                var leaf = Data.Leaf;
+                leaf.Vulnerabilities = new List<Protocol.Catalog.PackageVulnerability>();
+                leaf.Vulnerabilities.Add(null);
+
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                Assert.NotNull(document.Vulnerabilities);
+                Assert.Empty(document.Vulnerabilities);
+            }
         }
 
         public class FullFromDb : BaseFacts
@@ -701,12 +861,6 @@ namespace NuGet.Services.AzureSearch
       ""totalDownloadCount"": 1001,
       ""downloadScore"": 0.14381174563233068,
       ""isExcludedByDefault"": false,
-      ""deprecation"": {
-        ""alternatePackage"": null,
-        ""message"": null,
-        ""reasons"": []
-      },
-      ""vulnerabilities"": [],
       ""owners"": [
         ""Microsoft"",
         ""azure-sdk""
@@ -727,6 +881,27 @@ namespace NuGet.Services.AzureSearch
       ],
       ""isLatestStable"": false,
       ""isLatest"": true,
+      ""deprecation"": {
+        ""alternatePackage"": {
+          ""id"": ""test.alternatepackage"",
+          ""range"": ""[1.0.0, )""
+        },
+        ""message"": ""test message for test.alternatepackage-1.0.0"",
+        ""reasons"": [
+          ""Other"",
+          ""Legacy""
+        ]
+      },
+      ""vulnerabilities"": [
+        {
+          ""advisoryURL"": ""test AdvisoryUrl for Low Severity"",
+          ""severity"": 0
+        },
+        {
+          ""advisoryURL"": ""test AdvisoryUrl for Moderate Severity"",
+          ""severity"": 1
+        }
+      ],
       ""semVerLevel"": 2,
       ""authors"": ""Microsoft"",
       ""copyright"": ""\u00A9 Microsoft Corporation. All rights reserved."",
@@ -883,9 +1058,7 @@ namespace NuGet.Services.AzureSearch
                     totalDownloadCount: Data.TotalDownloadCount,
                     isExcludedByDefault: false);
 
-                Assert.Null(document.Deprecation.Message);
-                Assert.Null(document.Deprecation.AlternatePackage);
-                Assert.Empty(document.Deprecation.Reasons);
+                Assert.Null(document.Deprecation);
             }
 
             [Fact]
@@ -906,9 +1079,7 @@ namespace NuGet.Services.AzureSearch
                     totalDownloadCount: Data.TotalDownloadCount,
                     isExcludedByDefault: false);
 
-                Assert.Null(document.Deprecation.Message);
-                Assert.Null(document.Deprecation.AlternatePackage);
-                Assert.Empty(document.Deprecation.Reasons);
+                Assert.Null(document.Deprecation);
             }
 
             [Fact]
@@ -931,13 +1102,34 @@ namespace NuGet.Services.AzureSearch
                     totalDownloadCount: Data.TotalDownloadCount,
                     isExcludedByDefault: false);
 
-                Assert.Null(document.Deprecation.Message);
-                Assert.Null(document.Deprecation.AlternatePackage);
-                Assert.Empty(document.Deprecation.Reasons);
+                Assert.Null(document.Deprecation);
+            }
+
+            [Fact]
+            public void CheckMultipleDeprecations()
+            {
+                var package = Data.PackageEntity;
+                package.Deprecations = new List<PackageDeprecation>(); 
+                var deprecation = new PackageDeprecation() {Status = 0};
+                package.Deprecations.Add(deprecation);
+                package.Deprecations.Add(deprecation);
+
+                var document = _target.FullFromDb(
+                    Data.PackageId,
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    fullVersion: Data.FullVersion,
+                    package: package,
+                    owners: Data.Owners,
+                    totalDownloadCount: Data.TotalDownloadCount,
+                    isExcludedByDefault: false);
+
+                Assert.Null(document.Deprecation);
             }
 
             [Theory]
-            [InlineData(0, new string[] {})]
             [InlineData(1, new string[] {"Other"})]
             [InlineData(2, new string[] {"Legacy"})]
             [InlineData(3, new string[] {"Other", "Legacy"})]
@@ -987,27 +1179,28 @@ namespace NuGet.Services.AzureSearch
                     totalDownloadCount: Data.TotalDownloadCount,
                     isExcludedByDefault: false);
 
+                Assert.NotNull(document.Deprecation);
                 Assert.Null(document.Deprecation.AlternatePackage);
             }
 
             [Theory]
-            [InlineData(null, null, null, "[, )")]
-            [InlineData("", "", "", "[, )")]
-            [InlineData("testMessage", "testId", "1.0.0-test", "[1.0.0-test, )")]
-            public void CheckExpectedDeprecation(string message, string id, string version, string expectedRange)
+            [InlineData(null, "[, )")]
+            [InlineData("", "[, )")]
+            [InlineData("1.0.0-test", "[1.0.0-test, )")]
+            public void CheckExpectedRange(string version, string expectedRange)
             {
                 var package = Data.PackageEntity;
                 package.Deprecations = new List<PackageDeprecation>(); 
                 
                 var alternatepackage = Data.PackageEntity;
                 alternatepackage.Version = version;
-                alternatepackage.Id = id;
+                alternatepackage.Id = "testId";
 
                 var deprecation = new PackageDeprecation() 
                 {
                     Status = PackageDeprecationStatus.Other, 
                     AlternatePackage = alternatepackage, 
-                    CustomMessage = message 
+                    CustomMessage = "testMessage" 
                 };
                 package.Deprecations.Add(deprecation);
 
@@ -1025,8 +1218,6 @@ namespace NuGet.Services.AzureSearch
 
                 Assert.NotNull(document.Deprecation.AlternatePackage);
                 Assert.Equal(expectedRange, document.Deprecation.AlternatePackage.Range);
-                Assert.Equal(id, document.Deprecation.AlternatePackage.Id);
-                Assert.Equal(message, document.Deprecation.Message);
             }
 
             [Fact]
@@ -1067,7 +1258,7 @@ namespace NuGet.Services.AzureSearch
 
                 Assert.Empty(document.Vulnerabilities);
 
-                //list contains null elements
+                //list contains null element
                 package.VulnerablePackageRanges = new List<VulnerablePackageVersionRange>();
                 package.VulnerablePackageRanges.Add(null);
 
@@ -1104,45 +1295,6 @@ namespace NuGet.Services.AzureSearch
 
                 Assert.Empty(document.Vulnerabilities);
             }
-
-            [Theory]
-            [InlineData(0)]
-            [InlineData(1)]
-            [InlineData(2)]
-            [InlineData(3)]
-            public void CheckExpectedVulnerabilties(int count)
-            {
-                var package = Data.PackageEntity;
-                package.VulnerablePackageRanges = new List<VulnerablePackageVersionRange>();
-                string expectedAdvisoryUrl = "testAdvisoryUrl";
-
-                for (var v = 0; v <= count; v++)
-                {
-                    var vulnerability = new PackageVulnerability() { AdvisoryUrl = expectedAdvisoryUrl, Severity = (PackageVulnerabilitySeverity)v };
-                    var range = new VulnerablePackageVersionRange() { Vulnerability = vulnerability, PackageId = "testId", PackageVersionRange = "testRange" };
-                    package.VulnerablePackageRanges.Add(range);
-                }
-
-                var document = _target.FullFromDb(
-                    Data.PackageId,
-                    Data.SearchFilters,
-                    Data.Versions,
-                    isLatestStable: false,
-                    isLatest: true,
-                    fullVersion: Data.FullVersion,
-                    package: package,
-                    owners: Data.Owners,
-                    totalDownloadCount: Data.TotalDownloadCount,
-                    isExcludedByDefault: false);
-
-                Assert.Equal(package.VulnerablePackageRanges.Count, document.Vulnerabilities.Count);
-                for (var v = 0; v <= count; v++)
-                {
-                    Assert.Equal(expectedAdvisoryUrl, document.Vulnerabilities.ElementAt(v).AdvisoryURL);
-                    Assert.Equal(v, document.Vulnerabilities.ElementAt(v).Severity);
-                }
-            }
-
         }
 
         public abstract class BaseFacts

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -1137,11 +1137,11 @@ namespace NuGet.Services.AzureSearch
             [InlineData(5, new string[] {"Other", "CriticalBugs"})]
             [InlineData(6, new string[] {"Legacy", "CriticalBugs"})]
             [InlineData(7, new string[] {"Other", "Legacy", "CriticalBugs"})]
-            public void CheckExpectedDeprecationStatus(PackageDeprecationStatus status, string[] expected)
+            public void CheckExpectedDeprecationStatus(int status, string[] expected)
             {
                 var package = Data.PackageEntity;
                 package.Deprecations = new List<PackageDeprecation>(); 
-                var deprecation = new PackageDeprecation() {Status = status};
+                var deprecation = new PackageDeprecation() {Status = (PackageDeprecationStatus)status};
                 package.Deprecations.Add(deprecation);
 
                 var document = _target.FullFromDb(

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -1184,8 +1184,8 @@ namespace NuGet.Services.AzureSearch
             }
 
             [Theory]
-            [InlineData(null, "[, )")]
-            [InlineData("", "[, )")]
+            [InlineData(null, "*")]
+            [InlineData("", "*")]
             [InlineData("1.0.0-test", "[1.0.0-test, )")]
             public void CheckExpectedRange(string version, string expectedRange)
             {

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -951,7 +951,27 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/7.1.2-alpha.json""
         }
       ],
-      ""vulnerabilities"": []
+      ""deprecation"": {
+        ""alternatePackage"": {
+          ""id"": ""test.alternatepackage"",
+          ""range"": ""[1.0.0, )""
+        },
+        ""message"": ""test message for test.alternatepackage-1.0.0"",
+        ""reasons"": [
+          ""Other"",
+          ""Legacy""
+        ]
+      },
+      ""vulnerabilities"": [
+        {
+          ""advisoryUrl"": ""test AdvisoryUrl for Low Severity"",
+          ""severity"": 0
+        },
+        {
+          ""advisoryUrl"": ""test AdvisoryUrl for Moderate Severity"",
+          ""severity"": 1
+        }
+      ]
     }
   ]
 }", actualJson);
@@ -1073,15 +1093,15 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 var doc = _searchResult.Values[0].Document;
                 doc.Vulnerabilities = new List<Vulnerability>();
-                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryURL1", Severity = 1 });
-                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryURL2", Severity = 2 });
-                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryURL3", Severity = 3 });
+                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryUrl1", Severity = 1 });
+                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryUrl2", Severity = 2 });
+                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryUrl3", Severity = 3 });
 
                 //expected result
                 var vulnerabilities = new List<V3SearchVulnerability>();
-                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryURL = "advisoryURL1", Severity = 1 });
-                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryURL = "advisoryURL2", Severity = 2 });
-                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryURL = "advisoryURL3", Severity = 3 });
+                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryUrl = "advisoryUrl1", Severity = 1 });
+                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryUrl = "advisoryUrl2", Severity = 2 });
+                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryUrl = "advisoryUrl3", Severity = 3 });
 
                 var response = Target.V3FromSearchDocument(
                     _v3Request,
@@ -1091,7 +1111,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 for (int i = 0; i < vulnerabilities.Count; i++)
                 {
-                    Assert.Equal(vulnerabilities[i].AdvisoryURL, response.Data[0].Vulnerabilities[i].AdvisoryURL);
+                    Assert.Equal(vulnerabilities[i].AdvisoryUrl, response.Data[0].Vulnerabilities[i].AdvisoryUrl);
                     Assert.Equal(vulnerabilities[i].Severity, response.Data[0].Vulnerabilities[i].Severity);
                 }
 
@@ -1232,7 +1252,27 @@ namespace NuGet.Services.AzureSearch.SearchService
           ""@id"": ""https://example/reg-gz-semver2/windowsazure.storage/7.1.2-alpha.json""
         }
       ],
-      ""vulnerabilities"": []
+      ""deprecation"": {
+        ""alternatePackage"": {
+          ""id"": ""test.alternatepackage"",
+          ""range"": ""[1.0.0, )""
+        },
+        ""message"": ""test message for test.alternatepackage-1.0.0"",
+        ""reasons"": [
+          ""Other"",
+          ""Legacy""
+        ]
+      },
+      ""vulnerabilities"": [
+        {
+          ""advisoryUrl"": ""test AdvisoryUrl for Low Severity"",
+          ""severity"": 0
+        },
+        {
+          ""advisoryUrl"": ""test AdvisoryUrl for Moderate Severity"",
+          ""severity"": 1
+        }
+      ]
     }
   ]
 }", actualJson);
@@ -1401,15 +1441,15 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 var doc = _searchResult.Values[0].Document;
                 doc.Vulnerabilities = new List<Vulnerability>();
-                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryURL1", Severity = 1 });
-                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryURL2", Severity = 2 });
-                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryURL3", Severity = 3 });
+                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryUrl1", Severity = 1 });
+                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryUrl2", Severity = 2 });
+                doc.Vulnerabilities.Add(new Vulnerability() { AdvisoryURL = "advisoryUrl3", Severity = 3 });
 
                 //expected result
                 var vulnerabilities = new List<V3SearchVulnerability>();
-                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryURL = "advisoryURL1", Severity = 1 });
-                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryURL = "advisoryURL2", Severity = 2 });
-                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryURL = "advisoryURL3", Severity = 3 });
+                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryUrl = "advisoryUrl1", Severity = 1 });
+                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryUrl = "advisoryUrl2", Severity = 2 });
+                vulnerabilities.Add(new V3SearchVulnerability() { AdvisoryUrl = "advisoryUrl3", Severity = 3 });
 
                 var response = Target.V3FromSearchDocument(
                     _v3Request,
@@ -1419,7 +1459,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 for (int i = 0; i < vulnerabilities.Count; i++)
                 {
-                    Assert.Equal(vulnerabilities[i].AdvisoryURL, response.Data[0].Vulnerabilities[i].AdvisoryURL);
+                    Assert.Equal(vulnerabilities[i].AdvisoryUrl, response.Data[0].Vulnerabilities[i].AdvisoryUrl);
                     Assert.Equal(vulnerabilities[i].Severity, response.Data[0].Vulnerabilities[i].Severity);
                 }
                 

--- a/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
+++ b/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
@@ -8,6 +8,8 @@ using NuGet.Services.Entities;
 using NuGet.Versioning;
 using NuGetGallery;
 using PackageDependency = NuGet.Protocol.Catalog.PackageDependency;
+using PackageDeprecation = NuGet.Services.Entities.PackageDeprecation;
+using PackageVulnerability = NuGet.Services.Entities.PackageVulnerability;
 
 namespace NuGet.Services
 {
@@ -54,8 +56,39 @@ namespace NuGet.Services
             Tags = "Microsoft Azure Storage Table Blob File Queue Scalable windowsazureofficial",
             Title = "Windows Azure Storage",
             Version = "7.1.2.0-alpha+git",
+            Deprecations = new List<PackageDeprecation>
+            {
+                new PackageDeprecation 
+                {
+                    Status = (PackageDeprecationStatus)3, 
+                    AlternatePackage = new Package
+                    {
+                        Id = "test.alternatepackage",
+                        Version = "1.0.0",
+                    }, 
+                    CustomMessage = "test message for test.alternatepackage-1.0.0",
+                }
+            },
+            VulnerablePackageRanges = new List<VulnerablePackageVersionRange>
+            {
+                new VulnerablePackageVersionRange
+                {
+                    Vulnerability = new PackageVulnerability
+                    {
+                        AdvisoryUrl = "test AdvisoryUrl for Low Severity",
+                        Severity = PackageVulnerabilitySeverity.Low
+                    }, 
+                },
+                new VulnerablePackageVersionRange
+                {
+                    Vulnerability = new PackageVulnerability
+                    {
+                        AdvisoryUrl = "test AdvisoryUrl for Moderate Severity",
+                        Severity = PackageVulnerabilitySeverity.Moderate
+                    },
+                }
+            }
         };
-
         public static PackageDetailsCatalogLeaf Leaf => new PackageDetailsCatalogLeaf
         {
             Authors = "Microsoft",
@@ -104,6 +137,29 @@ namespace NuGet.Services
             Tags = new List<string> { "Microsoft", "Azure", "Storage", "Table", "Blob", "File", "Queue", "Scalable", "windowsazureofficial" },
             Title = "Windows Azure Storage",
             VerbatimVersion = "7.1.2.0-alpha+git",
+            Deprecation = new Protocol.Catalog.PackageDeprecation
+            {
+                Reasons = new List<string> {"Other", "Legacy"},
+                AlternatePackage = new Protocol.Catalog.AlternatePackage
+                {
+                    Id = "test.alternatepackage",
+                    Range = "[1.0.0, )"
+                }, 
+                Message = "test message for test.alternatepackage-1.0.0"
+            },
+            Vulnerabilities = new List<Protocol.Catalog.PackageVulnerability>
+            {
+                new Protocol.Catalog.PackageVulnerability
+                {
+                    AdvisoryUrl = "test AdvisoryUrl for Low Severity",
+                    Severity = "Low"
+                },
+                new Protocol.Catalog.PackageVulnerability
+                {
+                    AdvisoryUrl = "test AdvisoryUrl for Moderate Severity",
+                    Severity = "Moderate"
+                }
+            }
         };
     }
 }

--- a/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
+++ b/tests/NuGet.Services.V3.Tests/Support/V3Data.cs
@@ -152,12 +152,12 @@ namespace NuGet.Services
                 new Protocol.Catalog.PackageVulnerability
                 {
                     AdvisoryUrl = "test AdvisoryUrl for Low Severity",
-                    Severity = "Low"
+                    Severity = "0"
                 },
                 new Protocol.Catalog.PackageVulnerability
                 {
                     AdvisoryUrl = "test AdvisoryUrl for Moderate Severity",
-                    Severity = "Moderate"
+                    Severity = "1"
                 }
             }
         };


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/4615 (Epic: https://github.com/NuGet/NuGetGallery/issues/7297)

**db2azuresearch**: populate deprecation and vulnerability fields in the search document from the database
**catalog2azuresearch**: populate deprecation and vulnerability fields in the search document from the catalog