### PR TITLE
Stats.CreateAzureCdnWarehouseReports job not accessing stats DB for stats-totals report.

### DIFF
--- a/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
+++ b/src/Stats.CreateAzureCdnWarehouseReports/CreateAzureCdnWarehouseReportsJob.cs
@@ -215,7 +215,6 @@ namespace Stats.CreateAzureCdnWarehouseReports
                 var galleryTotalsReport = new GalleryTotalsReport(
                     LoggerFactory.CreateLogger<GalleryTotalsReport>(),
                     targets,
-                    OpenSqlConnectionAsync<StatisticsDbConfiguration>,
                     OpenSqlConnectionAsync<GalleryDbConfiguration>,
                     commandTimeoutSeconds: _sqlCommandTimeoutSeconds);
                 await galleryTotalsReport.Run();


### PR DESCRIPTION
The only report that is generated by the job is stats-totals. It takes package counts from Gallery DB and downloads from Stats DB. That report is then ingested by Synapse stats pipeline that replaces download counts with a proper number. So, we don't need the downloads number coming from stats DB and don't need to query it for it.
