### PR TITLE
Reduce default timeout for catalog HTTP requests

### DIFF
--- a/src/Catalog/Icons/IconsCollector.cs
+++ b/src/Catalog/Icons/IconsCollector.cs
@@ -35,7 +35,7 @@ namespace NuGet.Services.Metadata.Catalog.Icons
             IStorageFactory iconCacheStorageFactory,
             Func<HttpMessageHandler> httpHandlerFactory,
             ILogger<IconsCollector> logger)
-            : base(index, telemetryService, httpHandlerFactory, httpClientTimeout: TimeSpan.FromMinutes(5))
+            : base(index, telemetryService, httpHandlerFactory, httpClientTimeout: TimeSpan.FromMinutes(1))
         {
             _targetStorageFactory = targetStorageFactory ?? throw new ArgumentNullException(nameof(targetStorageFactory));
             _catalogClient = catalogClient ?? throw new ArgumentNullException(nameof(catalogClient));

--- a/src/NuGet.Jobs.Catalog2Registration/Catalog2RegistrationConfiguration.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Catalog2RegistrationConfiguration.cs
@@ -84,7 +84,7 @@ namespace NuGet.Jobs.Catalog2Registration
         /// <summary>
         /// The timeout used for the collector <see cref="System.Net.Http.HttpClient"/>.
         /// </summary>
-        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(10);
+        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
         /// <summary>
         /// Whether or not the registration containers should be created at runtime. In general it is best to allow

--- a/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/Catalog2AzureSearchConfiguration.cs
+++ b/src/NuGet.Services.AzureSearch/Catalog2AzureSearch/Catalog2AzureSearchConfiguration.cs
@@ -12,7 +12,7 @@ namespace NuGet.Services.AzureSearch.Catalog2AzureSearch
         public int MaxConcurrentCatalogLeafDownloads { get; set; } = 64;
         public bool CreateContainersAndIndexes { get; set; }
         public string Source { get; set; }
-        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(10);
+        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(1);
         public List<string> DependencyCursorUrls { get; set; }
         public string RegistrationsBaseUrl { get; set; }
     }

--- a/src/NuGet.Services.V3/CommitCollectorConfiguration.cs
+++ b/src/NuGet.Services.V3/CommitCollectorConfiguration.cs
@@ -9,6 +9,6 @@ namespace NuGet.Services.V3
     {
         public int MaxConcurrentCatalogLeafDownloads { get; set; } = 64;
         public string Source { get; set; }
-        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(10);
+        public TimeSpan HttpClientTimeout { get; set; } = TimeSpan.FromMinutes(1);
     }
 }


### PR DESCRIPTION
The old value was 10 minutes. The new value is 1 minute. We saw causes where the job VMs, under high CPU load, would use the entire 10 minutes for the request and retry 2 more times. For this known endpoint, it's better to prefer a lower timeout and force the job to fail if the timeout of 1 minute fails after retries.

Progress on https://github.com/NuGet/Engineering/issues/4767