### PR TITLE
Fix: db2azuresearch add vulnerabilities to search document

### DIFF
--- a/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
+++ b/src/NuGet.Services.AzureSearch/Db2AzureSearch/NewPackageRegistrationProducer.cs
@@ -217,6 +217,7 @@ namespace NuGet.Services.AzureSearch.Db2AzureSearch
                     .Include(x => x.Deprecations)
                     .Include(x => x.Deprecations.Select(d => d.AlternatePackage))
                     .Include(x => x.VulnerablePackageRanges)
+                    .Include(x => x.VulnerablePackageRanges.Select(v => v.Vulnerability))
                     .Where(p => p.PackageStatusKey == PackageStatus.Available)
                     .Where(p => p.PackageRegistrationKey >= minKey);
 


### PR DESCRIPTION
Addresses: https://github.com/NuGet/Engineering/issues/4615 (Epic: https://github.com/NuGet/NuGetGallery/issues/7297)

Fixes issue where complete vulnerability data was not being retrieved from the database. 