### PR TITLE
Add forcible timeout for the catalog client and retry on 400s

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="5.2.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.Azure.Storage.DataMovement" Version="0.7.1" />
+    <PackageVersion Include="Microsoft.Azure.Storage.DataMovement" Version="0.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" />
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="3.6.0" />
     <PackageVersion Include="Microsoft.Data.Services.Client" Version="5.8.4" />

--- a/src/Catalog/CollectorHttpClient.cs
+++ b/src/Catalog/CollectorHttpClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
@@ -100,11 +101,16 @@ namespace NuGet.Services.Metadata.Catalog
         {
             try
             {
+                var sw = Stopwatch.StartNew();
                 using (var httpResponse = await _retryStrategy.SendAsync(this, address, token))
                 {
-                    return await NuGet.Jobs.TaskExtensions.ExecuteWithTimeoutAsync(
+                    Trace.TraceInformation(nameof(GetStringAsync) + "({0}) got " + nameof(HttpResponseMessage) + " after {1}ms", address, sw.ElapsedMilliseconds);
+                    sw.Restart();
+                    var response = await NuGet.Jobs.TaskExtensions.ExecuteWithTimeoutAsync(
                         _ => httpResponse.Content.ReadAsStringAsync(),
                         timeout: this.Timeout);
+                    Trace.TraceInformation(nameof(GetStringAsync) + "({0}) got string ({1} chars) after {2}ms", address, response.Length, sw.ElapsedMilliseconds);
+                    return response;
                 }
             }
             catch (Exception e)

--- a/src/Catalog/CollectorHttpClient.cs
+++ b/src/Catalog/CollectorHttpClient.cs
@@ -102,7 +102,9 @@ namespace NuGet.Services.Metadata.Catalog
             {
                 using (var httpResponse = await _retryStrategy.SendAsync(this, address, token))
                 {
-                    return await httpResponse.Content.ReadAsStringAsync();
+                    return await NuGet.Jobs.TaskExtensions.ExecuteWithTimeoutAsync(
+                        _ => httpResponse.Content.ReadAsStringAsync(),
+                        timeout: this.Timeout);
                 }
             }
             catch (Exception e)

--- a/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
+++ b/src/Catalog/NuGet.Services.Metadata.Catalog.csproj
@@ -52,6 +52,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\NuGet.Jobs.Common\Extensions\TaskExtensions.cs" Link="TaskExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="context\Catalog.json" />
     <EmbeddedResource Include="context\Container.json" />
     <EmbeddedResource Include="context\PackageDetails.json" />

--- a/src/Catalog/Persistence/AzureStorage.cs
+++ b/src/Catalog/Persistence/AzureStorage.cs
@@ -213,7 +213,7 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
 
             if (destinationProperties?.Count > 0)
             {
-                context.SetAttributesCallback = new SetAttributesCallback((destination) =>
+                context.SetAttributesCallbackAsync = new SetAttributesCallbackAsync((destination) =>
                 {
                     var blob = (CloudBlockBlob)destination;
 
@@ -236,10 +236,12 @@ namespace NuGet.Services.Metadata.Catalog.Persistence
                                 throw new NotImplementedException($"Storage property '{property.Value}' is not supported.");
                         }
                     }
+
+                    return Task.CompletedTask;
                 });
             }
 
-            context.ShouldOverwriteCallback = new ShouldOverwriteCallback((source, destination) => true);
+            context.ShouldOverwriteCallbackAsync = new ShouldOverwriteCallbackAsync((source, destination) => Task.FromResult(true));
 
             await TransferManager.CopyAsync(sourceBlob, destinationBlob, _useServerSideCopy, options: null, context: context);
         }

--- a/src/Catalog/RetryWithExponentialBackoff.cs
+++ b/src/Catalog/RetryWithExponentialBackoff.cs
@@ -83,12 +83,14 @@ namespace NuGet.Services.Metadata.Catalog
             using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
             {
                 var delayTask = Task.Delay(timeout, cts.Token);
-                var mainTask = client.GetAsync(address, _httpCompletionOption, cancellationToken);
+                var mainTask = client.GetAsync(address, _httpCompletionOption, cts.Token);
                 var resultTask = await Task.WhenAny(mainTask, delayTask);
                 if (resultTask == delayTask)
                 {
                     if (resultTask.IsCanceled)
                     {
+                        // This will throw an OperationCanceledException exception. In this case, the delay task was
+                        // canceled by the cancellation token passed into this method.
                         await resultTask;
                     }
                     else

--- a/src/Catalog/VerboseHandler.cs
+++ b/src/Catalog/VerboseHandler.cs
@@ -20,7 +20,7 @@ namespace NuGet.Services.Metadata.Catalog
             sw.Start();
             HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
             sw.Stop();
-            Trace.TraceInformation("HTTP {0}_{1}_{2}", request.Method, request.RequestUri, sw.ElapsedMilliseconds);
+            Trace.TraceInformation("HTTP {0} {1} (headers after {2}ms)", request.Method, request.RequestUri, sw.ElapsedMilliseconds);
             return response;
         }
     }

--- a/src/NuGet.Jobs.Common/Extensions/TaskExtensions.cs
+++ b/src/NuGet.Jobs.Common/Extensions/TaskExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Jobs
+{
+    internal static class TaskExtensions
+    {
+        public static async Task<T> ExecuteWithTimeoutAsync<T>(Func<CancellationToken, Task<T>> getTask, TimeSpan timeout)
+        {
+            // Source:
+            // https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#using-a-timeout
+            using (var cts = new CancellationTokenSource())
+            {
+                var delayTask = Task.Delay(timeout, cts.Token);
+                var mainTask = getTask(cts.Token);
+                var resultTask = await Task.WhenAny(mainTask, delayTask);
+                if (resultTask == delayTask)
+                {
+                    // Operation cancelled
+                    throw new OperationCanceledException("The operation was forcibly canceled.");
+                }
+                else
+                {
+                    // Cancel the timer task so that it does not fire
+                    cts.Cancel();
+                }
+
+                return await mainTask;
+            }
+        }
+    }
+}

--- a/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
+++ b/src/NuGet.Jobs.GitHubIndexer/NuGet.Jobs.GitHubIndexer.csproj
@@ -45,6 +45,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\NuGet.Jobs.Common\Extensions\TaskExtensions.cs">
+      <Link>GitRepoSearchers\GitHub\TaskExtensions.cs</Link>
+    </Compile>
     <Compile Include="CheckedOutFile.cs" />
     <Compile Include="ConfigFileParser.cs" />
     <Compile Include="FetchedRepo.cs" />

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Helpers\RegistrationIndependentPackage.cs" />
     <Compile Include="Helpers\RegistrationPackageDetails.cs" />
     <Compile Include="Helpers\UtilsTests.cs" />
+    <Compile Include="HungStream.cs" />
     <Compile Include="Icons\CatalogLeafDataProcessorFacts.cs" />
     <Compile Include="Icons\IconCopyResultCacheFacts.cs" />
     <Compile Include="Icons\IconProcessorFacts.cs" />

--- a/tests/CatalogTests/CatalogTests.csproj
+++ b/tests/CatalogTests/CatalogTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="15.0">
   <Import Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
@@ -325,6 +325,10 @@
     <ProjectReference Include="..\NgTests\NgTests.csproj">
       <Project>{05c1c78a-9966-4922-9065-a099023e7366}</Project>
       <Name>NgTests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NuGet.Services.V3.Tests\NuGet.Services.V3.Tests.csproj">
+      <Project>{CCB4D5EF-AC84-449D-AC6E-0A0AD295483A}</Project>
+      <Name>NuGet.Services.V3.Tests</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/CatalogTests/HungStream.cs
+++ b/tests/CatalogTests/HungStream.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CatalogTests
+{
+    public class HungStream : Stream
+    {
+        private readonly Stream _stream;
+        private readonly TimeSpan _hangTime;
+
+        public HungStream(Stream stream, TimeSpan hangTime)
+        {
+            _stream = stream;
+            _hangTime = hangTime;
+        }
+
+        public override bool CanRead => _stream.CanRead;
+        public override bool CanSeek => _stream.CanSeek;
+        public override bool CanWrite => _stream.CanWrite;
+        public override long Length => _stream.Length;
+
+        public override long Position
+        {
+            get => _stream.Position;
+            set => _stream.Position = value;
+        }
+
+        public override void Flush() => _stream.Flush();
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _stream.Read(buffer, offset, count);
+            if (read == 0)
+            {
+                Thread.Sleep(_hangTime);
+            }
+            return read;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var read = await _stream.ReadAsync(buffer, offset, count, CancellationToken.None);
+            if (read == 0)
+            {
+                await Task.Delay(_hangTime);
+            }
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
+        public override void SetLength(long value) => _stream.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _stream.Write(buffer, offset, count);
+        }
+    }
+}


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/4767

This morning Catalog2Dnx in China started hanging on the catalog index download. From application traces, the application was clearly in a hung state (hanging for more than 2 hours with no activity). The timeout for this request is supposed to be 10 minutes so it should have retried well before the time that I investigation the problem. I captured a dump of the process but could find no indication of the blocked thread. It's unclear what state the application was in and I will continue with internal partners to look at the dump.

This is a mitigation to avoid customer impact while we investigate more deeply.

I also enabled retries on HTTP 400. We have seen transient HTTP 400 errors coming from our CDN which causes the application to crash. 

Note that this PR is based against a new `hotfix` branch that I made this predates the non-backwards compatible deprecations and vulnerabilities work.