### PR TITLE
Drop the message when the entity is hard deleted

### DIFF
--- a/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
@@ -130,9 +130,9 @@ namespace NuGet.Services.Validation.Orchestrator
                     // "ProcessValidationSet" type message polling the validation set status (meaning dropping this
                     // message will not result in a stuck validation).
                     //
-                    // This case typically entity was hard deleted (the record with the matching key was totally removed
-                    // from the DB). A "CheckValidator" type message can only be enqueued if the entity with this key
-                    // existed at one point but now no longer exists.
+                    // This case typically happens when the entity was hard deleted (the record with the matching key
+                    // was totally removed from the DB). A "CheckValidator" type message can only be enqueued if the
+                    // entity with this key existed at one point but now no longer exists.
                     _logger.LogWarning(
                         "Could not find {ValidatingType} {PackageId} {PackageVersion} {Key} for validation set {ValidationSetId}. " +
                         "The entity was most likely hard deleted. Dropping message.",

--- a/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs
@@ -74,7 +74,6 @@ namespace NuGet.Services.Validation.Orchestrator
         }
 
         protected abstract ValidatingType ValidatingType { get; }
-        protected abstract bool ShouldNoOpDueToDeletion { get; }
 
         public async Task<bool> HandleAsync(PackageValidationMessageData message)
         {
@@ -127,18 +126,26 @@ namespace NuGet.Services.Validation.Orchestrator
                 entity = _entityService.FindPackageByKey(validationSet.PackageKey.Value);
                 if (entity == null)
                 {
-                    _logger.LogError(
-                        "Could not find {ValidatingType} {PackageId} {PackageVersion} {Key} for validation set {ValidationSetId}.",
+                    // We can drop this message when the entity is missing. This is because there is already a
+                    // "ProcessValidationSet" type message polling the validation set status (meaning dropping this
+                    // message will not result in a stuck validation).
+                    //
+                    // This case typically entity was hard deleted (the record with the matching key was totally removed
+                    // from the DB). A "CheckValidator" type message can only be enqueued if the entity with this key
+                    // existed at one point but now no longer exists.
+                    _logger.LogWarning(
+                        "Could not find {ValidatingType} {PackageId} {PackageVersion} {Key} for validation set {ValidationSetId}. " +
+                        "The entity was most likely hard deleted. Dropping message.",
                         ValidatingType,
                         validationSet.PackageId,
                         validationSet.PackageNormalizedVersion,
                         validationSet.PackageKey,
                         validationSet.ValidationTrackingId);
-                    return false;
+                    return true;
                 }
                 
                 // Immediately halt validation of a soft deleted package.
-                if (ShouldNoOpDueToDeletion && entity.Status == PackageStatus.Deleted)
+                if (entity.Status == PackageStatus.Deleted)
                 {
                     _logger.LogWarning(
                         "{ValidatingType} {PackageId} {PackageVersion} {Key} is soft deleted. Dropping message for " +
@@ -242,7 +249,7 @@ namespace NuGet.Services.Validation.Orchestrator
                 }
 
                 // Immediately halt validation of a soft deleted package.
-                if (ShouldNoOpDueToDeletion && entity.Status == PackageStatus.Deleted)
+                if (entity.Status == PackageStatus.Deleted)
                 {
                     _logger.LogWarning(
                         "{ValidatingType} {PackageId} {PackageNormalizedVersion} {Key} is soft deleted. Dropping " +

--- a/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/PackageValidationMessageHandler.cs
@@ -37,6 +37,5 @@ namespace NuGet.Services.Validation.Orchestrator
         }
 
         protected override ValidatingType ValidatingType => ValidatingType.Package;
-        protected override bool ShouldNoOpDueToDeletion => true;
     }
 }

--- a/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
+++ b/src/NuGet.Services.Validation.Orchestrator/SymbolValidationMessageHandler.cs
@@ -40,6 +40,5 @@ namespace NuGet.Services.Validation.Orchestrator
         }
 
         protected override ValidatingType ValidatingType => ValidatingType.SymbolPackage;
-        protected override bool ShouldNoOpDueToDeletion => false;
     }
 }

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/BaseValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/BaseValidationMessageHandlerFacts.cs
@@ -288,7 +288,6 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
             }
 
             protected override ValidatingType ValidatingType => ValidatingType.Package;
-            protected override bool ShouldNoOpDueToDeletion => true;
         }
 
         public class TestEntity : IEntity

--- a/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
+++ b/tests/NuGet.Services.Validation.Orchestrator.Tests/ValidationMessageHandlerFacts.cs
@@ -72,7 +72,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
         }
 
         [Fact]
-        public async Task WaitsForPackageAvailabilityInGalleryDBWithCheckValidator()
+        public async Task DoesNotWaitForPackageAvailabilityInGalleryDBWithCheckValidator()
         {
             var messageData = PackageValidationMessageData.NewCheckValidator(Guid.NewGuid());
             var validationConfiguration = new ValidationConfiguration();
@@ -98,7 +98,7 @@ namespace NuGet.Services.Validation.Orchestrator.Tests
                 ps => ps.FindPackageByKey(validationSet.PackageKey.Value),
                 Times.Once);
 
-            Assert.False(result, "The handler should not have succeeded.");
+            Assert.True(result, "The handler should have succeeded.");
         }
 
         [Fact]


### PR DESCRIPTION
This is the current behavior for package validation but not symbol validation on the queue-back message. Since a hard delete can easily happen for symbol packages when the symbol package is replaced, this can lead to DLQ messages when the user replaces the symbols soon after publishing the previous version. There were 4 DLQ messages due to it this week.

Note that there is an important "missing record" case which is still handled here:
https://github.com/NuGet/NuGet.Jobs/blob/76eb3c93605c55ec37e32f0571cba8ee26b60300/src/NuGet.Services.Validation.Orchestrator/BaseValidationMessageHandler.cs#L206-L215

Resolve https://github.com/NuGet/Engineering/issues/2602