### PR TITLE
[Search DV] Add deprecation and vulnerabilities to V2 search. 

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchDeprecation.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchDeprecation.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class V2SearchDeprecation
+    {
+        public V2SearchAlternatePackage AlternatePackage { get; set; }
+
+        public string Message { get; set; }
+
+        public string[] Reasons { get; set; }
+    }
+
+    public class V2SearchAlternatePackage
+    {
+        public string Id { get; set; }
+
+        public string Range { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
@@ -49,7 +49,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string LicenseUrl { get; set; }
         public bool RequiresLicenseAcceptance { get; set; }
         public object Debug { get; set; }
-        public Deprecation Deprecation { get; internal set; }
-        public Vulnerability[] Vulnerabilities { get; internal set; }
+        public Deprecation Deprecation { get; set; }
+        public Vulnerability[] Vulnerabilities { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
@@ -49,5 +49,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string LicenseUrl { get; set; }
         public bool RequiresLicenseAcceptance { get; set; }
         public object Debug { get; set; }
+        public Deprecation Deprecation { get; internal set; }
+        public Vulnerability[] Vulnerabilities { get; internal set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
@@ -49,7 +49,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string LicenseUrl { get; set; }
         public bool RequiresLicenseAcceptance { get; set; }
         public object Debug { get; set; }
-        public Deprecation Deprecation { get; set; }
-        public Vulnerability[] Vulnerabilities { get; set; }
+        public V2SearchDeprecation Deprecation { get; set; }
+        public V2SearchVulnerability[] Vulnerabilities { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchVulnerability.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchVulnerability.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public class V2SearchVulnerability
+    {
+        public string AdvisoryUrl { get; set; }
+
+        public int Severity { get; set; }
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -446,7 +446,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             if (HasValidDeprecation(document.Deprecation))
             {   
                 var deprecation = new V3SearchDeprecation();
-                deprecation.AlternatePackage = new V3SearchAlternatePackage{}; 
+                deprecation.AlternatePackage = new V3SearchAlternatePackage(); 
 
                 if (document.Deprecation.AlternatePackage != null)
                 {
@@ -509,7 +509,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             if (HasValidDeprecation(document.Deprecation))
             {
                 var deprecation = new V2SearchDeprecation();
-                deprecation.AlternatePackage = new V2SearchAlternatePackage { };
+                deprecation.AlternatePackage = new V2SearchAlternatePackage();
 
                 if (document.Deprecation.AlternatePackage != null)
                 {

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -444,7 +444,6 @@ namespace NuGet.Services.AzureSearch.SearchService
         private V3SearchDeprecation GetV3SearchDeprecation(SearchDocument.Full document)
         {
             if (HasValidDeprecation(document.Deprecation))
-            //according to nuget api, reasons array is required and cannot be empty
             {   
                 var deprecation = new V3SearchDeprecation();
                 deprecation.AlternatePackage = new V3SearchAlternatePackage{}; 
@@ -494,13 +493,14 @@ namespace NuGet.Services.AzureSearch.SearchService
             package.IsLatestStable = result.IsLatestStable.Value;
             package.IsLatest = result.IsLatest.Value;
             package.Deprecation = HasValidDeprecation(result.Deprecation) ? result.Deprecation : null;
-            package.Vulnerabilities = result.Vulnerabilities?.ToArray();
+            package.Vulnerabilities = result.Vulnerabilities != null ? result.Vulnerabilities.ToArray() : Array.Empty<Vulnerability>();
 
             return package;
         }
 
         private bool HasValidDeprecation(Deprecation deprecation)
         {
+            //according to nuget api, reasons array is required and cannot be empty
             return deprecation != null && deprecation.Reasons != null && deprecation.Reasons.Length > 0;
         }
 

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -493,6 +493,8 @@ namespace NuGet.Services.AzureSearch.SearchService
             package.Listed = true;
             package.IsLatestStable = result.IsLatestStable.Value;
             package.IsLatest = result.IsLatest.Value;
+            package.Deprecation = result.Deprecation;
+            package.Vulnerabilities = result.Vulnerabilities?.ToArray();
 
             return package;
         }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -443,7 +443,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         private V3SearchDeprecation GetV3SearchDeprecation(SearchDocument.Full document)
         {
-            if (document.Deprecation != null && document.Deprecation.Reasons != null && document.Deprecation.Reasons.Length > 0)
+            if (HasValidDeprecation(document.Deprecation))
             //according to nuget api, reasons array is required and cannot be empty
             {   
                 var deprecation = new V3SearchDeprecation();
@@ -493,10 +493,15 @@ namespace NuGet.Services.AzureSearch.SearchService
             package.Listed = true;
             package.IsLatestStable = result.IsLatestStable.Value;
             package.IsLatest = result.IsLatest.Value;
-            package.Deprecation = result.Deprecation;
+            package.Deprecation = HasValidDeprecation(result.Deprecation) ? result.Deprecation : null;
             package.Vulnerabilities = result.Vulnerabilities?.ToArray();
 
             return package;
+        }
+
+        private bool HasValidDeprecation(Deprecation deprecation)
+        {
+            return deprecation != null && deprecation.Reasons != null && deprecation.Reasons.Length > 0;
         }
 
         private V2SearchPackage ToV2SearchPackage(HijackDocument.Full result, bool semVer2)

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -632,6 +632,55 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Fact]
+            public void CheckNullDeprecation()
+            {
+                var doc = _searchResult.Values[0].Document;
+                doc.Deprecation = null;
+
+                var response = Target.V2FromSearch(
+                    _v2Request,
+                    _text,
+                    _searchParameters,
+                    _searchResult,
+                    _duration);
+
+                Assert.Null(response.Data[0].Deprecation);
+            }
+
+            [Fact]
+            public void CheckNullDeprecationReasons()
+            {
+                var doc = _searchResult.Values[0].Document;
+                doc.Deprecation = new Deprecation();
+
+                var response = Target.V2FromSearch(
+                    _v2Request,
+                    _text,
+                    _searchParameters,
+                    _searchResult,
+                    _duration);
+
+                Assert.Null(response.Data[0].Deprecation);
+            }
+
+            [Fact]
+            public void CheckEmptyDeprecationReasons()
+            {
+                var doc = _searchResult.Values[0].Document;
+                doc.Deprecation = new Deprecation();
+                doc.Deprecation.Reasons = Array.Empty<string>();
+
+                var response = Target.V2FromSearch(
+                    _v2Request,
+                    _text,
+                    _searchParameters,
+                    _searchResult,
+                    _duration);
+
+                Assert.Null(response.Data[0].Deprecation);
+            }
+
+            [Fact]
             public void UsesFlatContainerUrlWhenConfigured()
             {
                 _config.AllIconsInFlatContainer = true;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -618,11 +618,11 @@ namespace NuGet.Services.AzureSearch.SearchService
       },
       ""Vulnerabilities"": [
         {
-          ""AdvisoryURL"": ""test AdvisoryUrl for Low Severity"",
+          ""AdvisoryUrl"": ""test AdvisoryUrl for Low Severity"",
           ""Severity"": 0
         },
         {
-          ""AdvisoryURL"": ""test AdvisoryUrl for Moderate Severity"",
+          ""AdvisoryUrl"": ""test AdvisoryUrl for Moderate Severity"",
           ""Severity"": 1
         }
       ]
@@ -707,7 +707,6 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _searchResult,
                     _duration);
 
-                Assert.Same(deprecation, response.Data[0].Deprecation);
                 Assert.Equal(message, response.Data[0].Deprecation.Message);
                 Assert.Equal(reason, response.Data[0].Deprecation.Reasons[0]);
                 Assert.Equal(id, response.Data[0].Deprecation.AlternatePackage.Id);
@@ -766,7 +765,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 Assert.Equal(vulnerabilities.Count, response.Data[0].Vulnerabilities.Length);
                 for (int i = 0; i < vulnerabilities.Count; i++)
                 {
-                    Assert.Equal(vulnerabilities[i].AdvisoryURL, response.Data[0].Vulnerabilities[i].AdvisoryURL);
+                    Assert.Equal(vulnerabilities[i].AdvisoryURL, response.Data[0].Vulnerabilities[i].AdvisoryUrl);
                     Assert.Equal(vulnerabilities[i].Severity, response.Data[0].Vulnerabilities[i].Severity);
                 }
 

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -604,7 +604,28 @@ namespace NuGet.Services.AzureSearch.SearchService
       ""HashAlgorithm"": ""SHA512"",
       ""PackageFileSize"": 3039254,
       ""LicenseUrl"": ""http://go.microsoft.com/fwlink/?LinkId=331471"",
-      ""RequiresLicenseAcceptance"": true
+      ""RequiresLicenseAcceptance"": true,
+      ""Deprecation"": {
+        ""AlternatePackage"": {
+          ""Id"": ""test.alternatepackage"",
+          ""Range"": ""[1.0.0, )""
+        },
+        ""Message"": ""test message for test.alternatepackage-1.0.0"",
+        ""Reasons"": [
+          ""Other"",
+          ""Legacy""
+        ]
+      },
+      ""Vulnerabilities"": [
+        {
+          ""AdvisoryURL"": ""test AdvisoryUrl for Low Severity"",
+          ""Severity"": 0
+        },
+        {
+          ""AdvisoryURL"": ""test AdvisoryUrl for Moderate Severity"",
+          ""Severity"": 1
+        }
+      ]
     }
   ]
 }", actualJson);
@@ -627,6 +648,22 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             [Fact]
             public void LeavesNullIconUrlWithFlatContainerIconsButNullOriginalIconUrl()
+            {
+                _config.AllIconsInFlatContainer = true;
+                _searchResult.Values[0].Document.IconUrl = null;
+
+                var response = Target.V2FromSearch(
+                    _v2Request,
+                    _text,
+                    _searchParameters,
+                    _searchResult,
+                    _duration);
+
+                Assert.Null(response.Data[0].IconUrl);
+            }
+
+            [Fact]
+            public void NullIconUrlWithFlatContainerIconsButNullOriginalIconUrl()
             {
                 _config.AllIconsInFlatContainer = true;
                 _searchResult.Values[0].Document.IconUrl = null;


### PR DESCRIPTION
### Changes
* V2Search page updated with deprecation and vulnerabilities properties.
* Updated `ToV2SearchPackage` method to include deprecation and vulnerabilities.

Addresses: https://github.com/NuGet/Engineering/issues/4733