### PR TITLE
Return null alternate package if there is none

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -446,12 +446,14 @@ namespace NuGet.Services.AzureSearch.SearchService
             if (HasValidDeprecation(document.Deprecation))
             {   
                 var deprecation = new V3SearchDeprecation();
-                deprecation.AlternatePackage = new V3SearchAlternatePackage(); 
-
+                
                 if (document.Deprecation.AlternatePackage != null)
                 {
-                    deprecation.AlternatePackage.Id = document.Deprecation.AlternatePackage.Id;
-                    deprecation.AlternatePackage.Range = document.Deprecation.AlternatePackage.Range;
+                    deprecation.AlternatePackage = new V3SearchAlternatePackage 
+                    {
+                        Id = document.Deprecation.AlternatePackage.Id,
+                        Range = document.Deprecation.AlternatePackage.Range
+                    };
                 } 
 
                 deprecation.Message = document.Deprecation.Message;

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -1223,6 +1223,25 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Fact]
+            public void CheckNullAlternatePackage()
+            {
+                var doc = _searchResult.Values[0].Document;
+
+                doc.Deprecation = new Deprecation
+                {
+                  Reasons = new string[] { "not maintained" }
+                };
+
+                var response = Target.V3FromSearchDocument(
+                    _v3Request,
+                    doc.Key,
+                    doc,
+                    _duration);
+
+                Assert.Null(response.Data[0].Deprecation.AlternatePackage);             
+            }
+
+            [Fact]
             public void ProducesExpectedDeprecation()
             {
                 var doc = _searchResult.Values[0].Document;
@@ -1551,6 +1570,25 @@ namespace NuGet.Services.AzureSearch.SearchService
                     _duration);
 
                 Assert.Null(response.Data[0].Deprecation);
+            }
+
+            [Fact]
+            public void CheckNullAlternatePackage()
+            {
+                var doc = _searchResult.Values[0].Document;
+
+                doc.Deprecation = new Deprecation
+                {
+                  Reasons = new string[] { "not maintained" }
+                };
+
+                var response = Target.V3FromSearchDocument(
+                    _v3Request,
+                    doc.Key,
+                    doc,
+                    _duration);
+
+                Assert.Null(response.Data[0].Deprecation.AlternatePackage);             
             }
 
             [Fact]


### PR DESCRIPTION
The PM UI client expects the value of the `alternatePackage` object to be `NULL` if there is no alternate package. This pull request addresses that issue.
