### PR TITLE
Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.110.0-agr-kv-lib-upgrade2-8229803</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.110.0-agr-kv-lib-upgrade3-8361872</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.4.2</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-agr-kv-update2-8360523</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-agr-kv-update2-8363886</NuGetGalleryPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.110.0-agr-kv-lib-upgrade3-8361872</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.110.0-agr-kv-lib-upgrade3-8363300</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.4.2</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-agr-kv-update2-8363886</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-agr-kv-update2-8366005</NuGetGalleryPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ServerCommonPackageVersion>2.110.0-agr-kv-lib-upgrade2-8229803</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.4.2</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-agr-kv-update2-8356159</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-agr-kv-update2-8360523</NuGetGalleryPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
 
   <!-- NuGet dependencies shared across projects -->
   <PropertyGroup>
-    <ServerCommonPackageVersion>2.109.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.110.0-agr-kv-lib-upgrade2-8229803</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.4.2</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-dev-8078220</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-agr-kv-update2-8356159</NuGetGalleryPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.9.1" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.5.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.8.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.4.0-beta.6" />
     <PackageVersion Include="Dapper.StrongName" Version="1.50.2" />
     <PackageVersion Include="dotNetRDF" Version="1.0.8.3533" />
@@ -33,6 +33,7 @@
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="2.2.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.1.0" />
     <PackageVersion Include="Moq" Version="4.13.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
+++ b/src/Catalog/Downloads/IDownloadsV1JsonClient.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Azure.KeyVault.Models;
 
 namespace NuGet.Services.Metadata.Catalog
 {

--- a/src/Ng/Arguments.cs
+++ b/src/Ng/Arguments.cs
@@ -145,6 +145,7 @@ namespace Ng
         public const string VaultName = "vaultName";
         public const string UseManagedIdentity = "useManagedIdentity";
 
+        public const string TenantId = "tenantId";
         public const string ClientId = "clientId";
 
         public const string StoreName = "storeName";

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -93,7 +93,8 @@ namespace Ng
                 KeyVaultConfiguration keyVaultConfig;
                 if (useManagedIdentity)
                 {
-                    keyVaultConfig = new KeyVaultConfiguration(vaultName);
+                    var clientId = arguments.GetOrDefault<string>(Arguments.ClientId);
+                    keyVaultConfig = new KeyVaultConfiguration(vaultName, clientId);
                 }
                 else
                 {

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -97,6 +97,7 @@ namespace Ng
                 }
                 else
                 {
+                    var tenantId = arguments.GetOrThrow<string>(Arguments.TenantId);
                     var clientId = arguments.GetOrThrow<string>(Arguments.ClientId);
                     var certificateThumbprint = arguments.GetOrThrow<string>(Arguments.CertificateThumbprint);
                     var storeName = arguments.GetOrDefault(Arguments.StoreName, StoreName.My);
@@ -104,7 +105,11 @@ namespace Ng
                     var shouldValidateCert = arguments.GetOrDefault(Arguments.ValidateCertificate, true);
 
                     var keyVaultCertificate = CertificateUtility.FindCertificateByThumbprint(storeName, storeLocation, certificateThumbprint, shouldValidateCert);
-                    keyVaultConfig = new KeyVaultConfiguration(vaultName, clientId, keyVaultCertificate);
+                    keyVaultConfig = new KeyVaultConfiguration(
+                        vaultName,
+                        tenantId,
+                        clientId, 
+                        keyVaultCertificate);
                 }
 
                 secretReader = new CachingSecretReader(new KeyVaultReader(keyVaultConfig),

--- a/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
+++ b/src/NuGet.Jobs.Common/Configuration/JobArgumentNames.cs
@@ -104,6 +104,7 @@ namespace NuGet.Jobs
         // Key Vault
         public const string VaultName = "VaultName";
         public const string UseManagedIdentity = "UseManagedIdentity";
+        public const string TenantId = "TenantId";
         public const string ClientId = "ClientId";
         public const string CertificateThumbprint = "CertificateThumbprint";
         public const string ValidateCertificate = "ValidateCertificate";

--- a/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
@@ -23,7 +23,8 @@ namespace NuGet.Jobs
             KeyVaultConfiguration keyVaultConfiguration;
             if (useManagedIdentity)
             {
-                keyVaultConfiguration = new KeyVaultConfiguration(JobConfigurationManager.GetArgument(settings, JobArgumentNames.VaultName));
+                var clientId = JobConfigurationManager.TryGetArgument(settings, JobArgumentNames.ClientId);
+                keyVaultConfiguration = new KeyVaultConfiguration(JobConfigurationManager.GetArgument(settings, JobArgumentNames.VaultName), clientId);
             }
             else
             {

--- a/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
+++ b/src/NuGet.Jobs.Common/SecretReader/SecretReaderFactory.cs
@@ -39,6 +39,7 @@ namespace NuGet.Jobs
                 keyVaultConfiguration =
                     new KeyVaultConfiguration(
                         JobConfigurationManager.GetArgument(settings, JobArgumentNames.VaultName),
+                        JobConfigurationManager.GetArgument(settings, JobArgumentNames.TenantId),
                         JobConfigurationManager.GetArgument(settings, JobArgumentNames.ClientId),
                         certificate);
             }

--- a/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
+++ b/src/NuGet.Services.AzureSearch/NuGet.Services.AzureSearch.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\SdkProjects.props" />
 
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Search.Documents" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" />
     <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Engineering/issues/4704

Transition from Microsoft.Azure.KeyVault to Azure.Security.KeyVault package dependency. Former one is deprecated.
I manually tested this change in [Gallery dev environment](https://devdiv.visualstudio.com/DevDiv/_releaseProgress?_a=release-pipeline-progress&releaseId=1478870)