### PR TITLE
Update pakage version fix vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,14 +2,14 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
-    <ServerCommonPackageVersion>2.113.0</ServerCommonPackageVersion>
+    <ServerCommonPackageVersion>2.114.0</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.6.1</NuGetClientPackageVersion>
     <NuGetGalleryPackageVersion>4.4.5-dev-8445918</NuGetGalleryPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.9.1" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.8.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.10.3" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.4.0-beta.6" />
     <PackageVersion Include="Dapper.StrongName" Version="1.50.2" />
     <PackageVersion Include="dotNetRDF" Version="1.0.8.3533" />


### PR DESCRIPTION
1. Upgrade Azure.Identity from 1.8.0 to 1.10.3 to fix the vulnerability.
2. Update serverCommon since we updated Azure.Identity in that repo as well 


Task: https://github.com/NuGet/Engineering/issues/4933