### PR TITLE
Update Test.Utility to latest working build and resolve CG errors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
-    <PackageVersion Include="Moq" Version="4.13.1" />
+    <PackageVersion Include="Moq" Version="4.18.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NuGet.Build.Tasks.Pack" Version="4.8.0" />
     <PackageVersion Include="NuGet.Packaging" Version="$(NuGetClientPackageVersion)" />
@@ -71,7 +71,7 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageVersion Include="System.Text.Json" Version="4.7.2" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="Test.Utility" Version="6.1.0-preview.1.67" />
+    <PackageVersion Include="Test.Utility" Version="6.6.1-rc.26" />
     <PackageVersion Include="UAParser" Version="3.1.44" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="xunit" Version="2.4.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,7 +71,7 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageVersion Include="System.Text.Json" Version="4.7.2" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageVersion Include="Test.Utility" Version="6.6.1-rc.26" />
+    <PackageVersion Include="Test.Utility" Version="6.4.2-rc.25" />
     <PackageVersion Include="UAParser" Version="3.1.44" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="xunit" Version="2.4.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,8 +41,12 @@
     <PackageVersion Include="Moq" Version="4.18.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NuGet.Build.Tasks.Pack" Version="4.8.0" />
+    <PackageVersion Include="NuGet.CommandLine" Version="$(NuGetClientPackageVersion)" />
+    <PackageVersion Include="NuGet.Commands" Version="$(NuGetClientPackageVersion)" />
+    <PackageVersion Include="NuGet.PackageManagement" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGet.Packaging" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGet.Protocol" Version="$(NuGetClientPackageVersion)" />
+    <PackageVersion Include="NuGet.Resolver" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Configuration" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Cursor" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Entities" Version="$(NuGetGalleryPackageVersion)" />
@@ -53,13 +57,13 @@
     <PackageVersion Include="NuGet.Services.Messaging.Email" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.ServiceBus" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Sql" Version="$(ServerCommonPackageVersion)" />
-    <PackageVersion Include="NuGet.Services.Status" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Status.Table" Version="$(ServerCommonPackageVersion)" />
+    <PackageVersion Include="NuGet.Services.Status" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Storage" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Testing.Entities" Version="$(ServerCommonPackageVersion)" />
     <PackageVersion Include="NuGet.Services.Validation" Version="$(ServerCommonPackageVersion)" />
-    <PackageVersion Include="NuGet.StrongName.Octokit" Version="0.32.0" />
     <PackageVersion Include="NuGet.StrongName.json-ld.net" Version="1.0.6" />
+    <PackageVersion Include="NuGet.StrongName.Octokit" Version="0.32.0" />
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />

--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -89,6 +89,7 @@ namespace Validation.PackageSigning.Core.Tests.Support
             _trustedRoot = new TrustedTestCert<X509Certificate2>(
                 rootCertificate,
                 certificate => certificate,
+                new[] { X509StorePurpose.CodeSigning, X509StorePurpose.Timestamping },
                 StoreName.Root,
                 StoreLocation.LocalMachine);
 
@@ -328,6 +329,7 @@ namespace Validation.PackageSigning.Core.Tests.Support
             var trust = new TrustedTestCert<X509Certificate2>(
                 rootCertificate,
                 certificate => certificate,
+                new[] { X509StorePurpose.CodeSigning, X509StorePurpose.Timestamping },
                 StoreName.Root,
                 StoreLocation.LocalMachine);
 
@@ -412,6 +414,7 @@ namespace Validation.PackageSigning.Core.Tests.Support
                 return new TrustedTestCert<X509Certificate2>(
                     _rootCertificate,
                     x => x,
+                    new[] { X509StorePurpose.CodeSigning, X509StorePurpose.Timestamping },
                     StoreName.Root,
                     StoreLocation.LocalMachine);
             }
@@ -478,6 +481,7 @@ namespace Validation.PackageSigning.Core.Tests.Support
                 return new TrustedTestCert<X509Certificate2>(
                     _certificate,
                     x => x,
+                    new[] { X509StorePurpose.CodeSigning, X509StorePurpose.Timestamping },
                     StoreName.Root,
                     StoreLocation.LocalMachine);
             }

--- a/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
+++ b/tests/Validation.PackageSigning.Core.Tests/Validation.PackageSigning.Core.Tests.csproj
@@ -68,6 +68,10 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="Test.Utility" />
+    <PackageReference Include="NuGet.CommandLine" />
+    <PackageReference Include="NuGet.Commands" />
+    <PackageReference Include="NuGet.PackageManagement" />
+    <PackageReference Include="NuGet.Resolver" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1969,6 +1969,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             return new TrustedTestCert<X509Certificate2>(
                 certificate,
                 x => x,
+                new[] { X509StorePurpose.CodeSigning, X509StorePurpose.Timestamping },
                 StoreName.Root,
                 StoreLocation.LocalMachine);
         }


### PR DESCRIPTION
We don't need to deploy this since it's only related to test projects.

Note that I had to manually push Test.Utility 6.4.2-rc.25 to the nuget-build feed since Client team no longer automatically pushes this as of https://github.com/NuGet/NuGet.Client/pull/5454. Also as of https://github.com/NuGet/NuGet.Client/pull/4994 newer versions of Test.Utility are missing dependencies. I talked to @donnie-msft about that but it's not blocking us.