### PR TITLE
[Search-by-TFM] Index-builder jobs for computed frameworks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
     <ServerCommonPackageVersion>2.114.0</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.6.1</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-dev-8445918</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-dev-8832253</NuGetGalleryPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.9.1" />

--- a/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
+++ b/src/NuGet.Services.AzureSearch/Models/SearchDocument.cs
@@ -65,6 +65,22 @@ namespace NuGet.Services.AzureSearch
             [SimpleField(IsFilterable = true)]
             public string[] Tfms { get; set; }
 
+            /// <summary>
+            /// The list of a package's 'computed' supported target framework generations. This is a superset of the
+            /// 'Frameworks' field.
+            /// eg. net, netframework
+            /// </summary>
+            [SimpleField(IsFilterable = true)]
+            public string[] ComputedFrameworks { get; set; }
+
+            /// <summary>
+            /// The list of a package's 'computed' supported target framework monikers, stored as normalized TFM strings
+            /// (same as the 'short folder name'). This is a superset of the 'Tfms' field.
+            /// eg. net5.0, net472, netcoreapp3.1, tizen40
+            /// </summary>
+            [SimpleField(IsFilterable = true)]
+            public string[] ComputedTfms { get; set; }
+
             public bool? IsLatestStable { get; set; }
             public bool? IsLatest { get; set; }
 

--- a/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchDocumentBuilder.cs
@@ -174,15 +174,15 @@ namespace NuGet.Services.AzureSearch
 
             // Determine if we have packageTypes to forward.
             // Otherwise, we need to let the system know that there were no explicit package types
-            var packageTypes = leaf.PackageTypes != null && leaf.PackageTypes.Count > 0 ?
-                leaf.PackageTypes.Select(pt => pt.Name).ToArray() :
-                null;
+            string[] packageTypes = leaf.PackageTypes != null && leaf.PackageTypes.Count > 0
+                                                ? leaf.PackageTypes.Select(pt => pt.Name).ToArray()
+                                                : null;
 
-            var frameworks = GetFrameworksFromCatalogLeaf(leaf);
-            var tfms = GetTfmsFromCatalogLeaf(leaf);
+            string[] frameworks = GetFrameworksFromCatalogLeaf(leaf);
+            string[] tfms = GetTfmsFromCatalogLeaf(leaf);
 
-            var computedFrameworks = GetComputedFrameworksFromCatalogLeaf(leaf);
-            var computedTfms = GetComputedTfmsFromCatalogLeaf(leaf);
+            string[] computedFrameworks = GetComputedFrameworksFromCatalogLeaf(leaf);
+            string[] computedTfms = GetComputedTfmsFromCatalogLeaf(leaf);
 
             PopulateUpdateLatest(
                 document,
@@ -224,21 +224,21 @@ namespace NuGet.Services.AzureSearch
 
             // Determine if we have packageTypes to forward.
             // Otherwise, we need to let the system know that there were no explicit package types
-            var packageTypes = package.PackageTypes != null && package.PackageTypes.Count > 0 ?
-                package.PackageTypes.Select(pt => pt.Name).ToArray() :
-                null;
+            string[] packageTypes = package.PackageTypes != null && package.PackageTypes.Count > 0
+                                                ? package.PackageTypes.Select(pt => pt.Name).ToArray()
+                                                : null;
 
-            var frameworks = package.SupportedFrameworks == null
+            string[] frameworks = package.SupportedFrameworks == null
                                                 ? Array.Empty<string>()
                                                 : GetFrameworksFromPackage(package.SupportedFrameworks);
-            var tfms = package.SupportedFrameworks == null
+            string[] tfms = package.SupportedFrameworks == null
                                                 ? Array.Empty<string>()
                                                 : GetTfmsFromPackage(package.SupportedFrameworks);
 
-            var computedFrameworks = package.SupportedFrameworks == null
+            string[] computedFrameworks = package.SupportedFrameworks == null
                                                 ? Array.Empty<string>()
                                                 : GetComputedFrameworksFromPackage(package.SupportedFrameworks);
-            var computedTfms = package.SupportedFrameworks == null
+            string[] computedTfms = package.SupportedFrameworks == null
                                                 ? Array.Empty<string>()
                                                 : GetComputedTfmsFromPackage(package.SupportedFrameworks);
 
@@ -404,10 +404,10 @@ namespace NuGet.Services.AzureSearch
 
         private static string[] GetFrameworksFromPackage(ICollection<PackageFramework> supportedFrameworks)
         {
-            var tfms = supportedFrameworks
-                            .Select(f => f.FrameworkName)
-                            .Where(f => f.IsSpecificFramework && !f.IsPCL)
-                            .ToArray();
+            NuGetFramework[] tfms = supportedFrameworks
+                                            .Select(f => f.FrameworkName)
+                                            .Where(f => f.IsSpecificFramework && !f.IsPCL)
+                                            .ToArray();
 
             return ParseFrameworkGenerations(tfms);
         }
@@ -424,22 +424,22 @@ namespace NuGet.Services.AzureSearch
 
         private static string[] GetComputedFrameworksFromPackage(IEnumerable<PackageFramework> supportedFrameworks)
         {
-            var assetTfms = supportedFrameworks
-                                .Select(f => f.FrameworkName);
+            IEnumerable<NuGetFramework> assetTfms = supportedFrameworks
+                                                            .Select(f => f.FrameworkName);
 
-            var computedTfms = assetTfms
-                                    .Union(FrameworkCompatibilityService.GetCompatibleFrameworks(assetTfms)) // add computed TFMs
-                                    .Where(f => f.IsSpecificFramework && !f.IsPCL)
-                                    .ToArray();
+            NuGetFramework[] computedTfms = assetTfms
+                                                .Union(FrameworkCompatibilityService.GetCompatibleFrameworks(assetTfms)) // add computed TFMs
+                                                .Where(f => f.IsSpecificFramework && !f.IsPCL)
+                                                .ToArray();
 
             return ParseFrameworkGenerations(computedTfms);
         }
 
         private static string[] GetComputedTfmsFromPackage(IEnumerable<PackageFramework> supportedFrameworks)
         {
-            var assetTfms = supportedFrameworks
-                                .Select(f => f.FrameworkName)
-                                .Select(f => NormalizePlatformVersion(f));
+            IEnumerable<NuGetFramework> assetTfms = supportedFrameworks
+                                                        .Select(f => f.FrameworkName)
+                                                        .Select(f => NormalizePlatformVersion(f));
 
             return assetTfms
                         .Union(FrameworkCompatibilityService.GetCompatibleFrameworks(assetTfms)) // add computed TFMs
@@ -450,8 +450,8 @@ namespace NuGet.Services.AzureSearch
 
         private static string[] GetFrameworksFromCatalogLeaf(PackageDetailsCatalogLeaf leaf)
         {
-            var tfms = GetSupportedFrameworks(leaf)
-                            .ToArray();
+            NuGetFramework[] tfms = GetSupportedFrameworks(leaf)
+                                                        .ToArray();
 
             return ParseFrameworkGenerations(tfms);
         }
@@ -467,20 +467,20 @@ namespace NuGet.Services.AzureSearch
 
         private static string[] GetComputedFrameworksFromCatalogLeaf(PackageDetailsCatalogLeaf leaf)
         {
-            var assetTfms = GetSupportedFrameworks(leaf);
+            IEnumerable<NuGetFramework> assetTfms = GetSupportedFrameworks(leaf);
 
-            var computedTfms = assetTfms
-                                    .Union(FrameworkCompatibilityService.GetCompatibleFrameworks(assetTfms)) // add computed TFMs
-                                    .Where(f => f.IsSpecificFramework && !f.IsPCL)
-                                    .ToArray();
+            NuGetFramework[] computedTfms = assetTfms
+                                                .Union(FrameworkCompatibilityService.GetCompatibleFrameworks(assetTfms)) // add computed TFMs
+                                                .Where(f => f.IsSpecificFramework && !f.IsPCL)
+                                                .ToArray();
 
             return ParseFrameworkGenerations(computedTfms);
         }
 
         private static string[] GetComputedTfmsFromCatalogLeaf(PackageDetailsCatalogLeaf leaf)
         {
-            var assetTfms = GetSupportedFrameworks(leaf)
-                                    .Select(f => NormalizePlatformVersion(f));
+            IEnumerable<NuGetFramework> assetTfms = GetSupportedFrameworks(leaf)
+                                                            .Select(f => NormalizePlatformVersion(f));
 
             return assetTfms
                         .Union(FrameworkCompatibilityService.GetCompatibleFrameworks(assetTfms)) // add computed TFMs
@@ -517,14 +517,15 @@ namespace NuGet.Services.AzureSearch
         private static IEnumerable<NuGetFramework> GetSupportedFrameworks(PackageDetailsCatalogLeaf leaf)
         {
             string[] files = leaf.PackageEntries == null || leaf.PackageEntries.Count == 0
-                                    ? Array.Empty<string>()
-                                    : leaf.PackageEntries.Select(pe => pe.FullName).ToArray();
-            var packageTypes = leaf.PackageTypes == null || leaf.PackageTypes.Count == 0
-                                    ? new List<Packaging.Core.PackageType>()
-                                    : GetPackageTypes(leaf);
+                                                                    ? Array.Empty<string>()
+                                                                    : leaf.PackageEntries.Select(pe => pe.FullName).ToArray();
+
+            List<Packaging.Core.PackageType> packageTypes = leaf.PackageTypes == null || leaf.PackageTypes.Count == 0
+                                                                    ? new List<Packaging.Core.PackageType>()
+                                                                    : GetPackageTypes(leaf);
 
             return AssetFrameworkHelper.GetAssetFrameworks(leaf.PackageId, packageTypes, files)
-                                                .Where(f => f.IsSpecificFramework && !f.IsPCL);
+                                                                    .Where(f => f.IsSpecificFramework && !f.IsPCL);
         }
 
         // Any TFM with a target platform version, like 'net6.0-android31.0', will be normalized to 'net6.0-android' in the search index to provide greater coverage with filters.

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchDocumentBuilderFacts.cs
@@ -398,6 +398,12 @@ namespace NuGet.Services.AzureSearch
       ""tfms"": [
         ""net40-client""
       ],
+      ""computedFrameworks"": [
+        ""netframework""
+      ],
+      ""computedTfms"": [
+        ""net40-client""
+      ],
       ""isLatestStable"": false,
       ""isLatest"": true,
       ""deprecation"": {
@@ -625,6 +631,45 @@ namespace NuGet.Services.AzureSearch
                 foreach (var item in expectedFrameworks)
                 {
                     Assert.Contains(item, document.Frameworks);
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(ComputedFrameworkCases))]
+            public void AddsComputedFrameworksAndTfmsFromCatalogLeaf(List<string> supportedTfms, List<string> computedTfms, List<string> computedFrameworks)
+            {
+                // arrange
+                var leaf = Data.Leaf;
+                leaf.PackageEntries = supportedTfms
+                                                .Select(f => new NuGet.Protocol.Catalog.PackageEntry
+                                                {
+                                                    FullName = $"lib/{f}/{leaf.PackageId}.dll",
+                                                    Name = $"{leaf.PackageId}.dll"
+                                                })
+                                                .ToList();
+
+                // act
+                var document = _target.UpdateLatestFromCatalog(
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    normalizedVersion: Data.NormalizedVersion,
+                    fullVersion: Data.FullVersion,
+                    leaf: leaf,
+                    owners: Data.Owners);
+
+                // assert
+                Assert.True(document.ComputedTfms.Length >= computedTfms.Count);
+                foreach (var item in computedTfms)
+                {
+                    Assert.Contains(item, document.ComputedTfms);
+                }
+
+                Assert.Equal(document.ComputedFrameworks.Length, computedFrameworks.Count);
+                foreach (var item in computedFrameworks)
+                {
+                    Assert.Contains(item, document.ComputedFrameworks);
                 }
             }
 
@@ -969,6 +1014,12 @@ namespace NuGet.Services.AzureSearch
       ""tfms"": [
         ""net40-client""
       ],
+      ""computedFrameworks"": [
+        ""netframework""
+      ],
+      ""computedTfms"": [
+        ""net40-client""
+      ],
       ""isLatestStable"": false,
       ""isLatest"": true,
       ""deprecation"": {
@@ -1175,6 +1226,53 @@ namespace NuGet.Services.AzureSearch
                 foreach (var item in expectedFrameworks)
                 {
                     Assert.Contains(item, document.Frameworks);
+                }
+            }
+
+            [Theory]
+            [MemberData(nameof(ComputedFrameworkCases))]
+            public void AddsComputedFrameworksAndTfmsFromPackage(List<string> supportedTfms, List<string> computedTfms, List<string> computedFrameworks)
+            {
+                // arrange
+                var package = new Package
+                {
+                    PackageRegistration = new PackageRegistration
+                    {
+                        Id = "TestPackage",
+                    },
+                    Id = "TestPackage",
+                    NormalizedVersion = Data.NormalizedVersion,
+                    LicenseExpression = "Unlicense",
+                    HasEmbeddedIcon = true,
+                    SupportedFrameworks = supportedTfms
+                                                .Select(f => new PackageFramework() { TargetFramework = f })
+                                                .ToArray(),
+                };
+
+                // act
+                var document = _target.FullFromDb(
+                    Data.PackageId,
+                    Data.SearchFilters,
+                    Data.Versions,
+                    isLatestStable: false,
+                    isLatest: true,
+                    fullVersion: Data.FullVersion,
+                    package: package,
+                    owners: Data.Owners,
+                    totalDownloadCount: Data.TotalDownloadCount,
+                    isExcludedByDefault: false);
+
+                // assert
+                Assert.True(document.ComputedTfms.Length >= computedTfms.Count);
+                foreach (var item in computedTfms)
+                {
+                    Assert.Contains(item, document.ComputedTfms);
+                }
+
+                Assert.Equal(document.ComputedFrameworks.Length, computedFrameworks.Count);
+                foreach (var item in computedFrameworks)
+                {
+                    Assert.Contains(item, document.ComputedFrameworks);
                 }
             }
 
@@ -1614,8 +1712,6 @@ namespace NuGet.Services.AzureSearch
                     new object[] {new List<string> {"net40", "net45"}, new List<string> {"net40", "net45"}, new List<string> {"netframework"}},
                     new object[] {new List<string> {"net5.0-tvos", "net5.0-ios"}, new List<string> {"net5.0-ios", "net5.0-tvos"}, 
                                     new List<string> {"net"}},
-                    new object[] {new List<string> {"net5.0-tvos", "net5.0-ios13.0"}, new List<string> {"net5.0-ios13.0", "net5.0-tvos"},
-                                    new List<string> {"net"}},
                     new object[] {new List<string> {"net5.1-tvos", "net5.1", "net5.0-tvos"},
                                     new List<string> {"net5.0-tvos", "net5.1", "net5.1-tvos"}, new List<string> {"net"}},
                     new object[] {new List<string> {"net5.0", "netcoreapp3.1", "native"}, new List<string> {"native", "net5.0", "netcoreapp3.1"},
@@ -1633,66 +1729,82 @@ namespace NuGet.Services.AzureSearch
                                     new List<string> {"netframework", "netstandard"}},
                     new object[] {new List<string> {"net20", "net35", "net40", "net45", "netstandard1.0", "netstandard1.3", "netstandard2.0"},
                                     new List<string> {"net20", "net35", "net40", "net45", "netstandard1.0", "netstandard1.3", "netstandard2.0"},
-                                    new List<string> {"netframework", "netstandard"}}
+                                    new List<string> {"netframework", "netstandard"}},
+                    new object[] {new List<string> {"net6.0-android31.0"}, new List<string> {"net6.0-android"}, new List<string> {"net"}}, // normalize platform version
+                    new object[] {new List<string> {"net5.0-tvos", "net5.0-ios13.0"}, new List<string> {"net5.0-ios", "net5.0-tvos"}, new List<string> {"net"}} // normalize platform version
                 };
 
             public static IEnumerable<object[]> AdditionalPackageTFMCases =>
-            new List<object[]>
-            {
-                    new object[] {new List<string> {"any"}, new List<string> {}, new List<string> {}},
-                    new object[] {new List<string> {"foo"}, new List<string> {}, new List<string> {}} // unsupported tfm is not included
-            };
+                new List<object[]>
+                {
+                        new object[] {new List<string> {"any"}, new List<string> {}, new List<string> {}},
+                        new object[] {new List<string> {"foo"}, new List<string> {}, new List<string> {}} // unsupported tfm is not included
+                };
 
             public static IEnumerable<object[]> AdditionalCatalogTFMCases =>
-            new List<object[]>
-            {
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
-                                    new List<string> {"lib/netcoreapp31/_._", "lib/netstandard20/_._"},
-                                    new List<string> {"netcoreapp3.1", "netstandard2.0"}, new List<string> {"netcoreapp", "netstandard"}},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"lib/net40/_._", "lib/net4.7.1/_._"},
-                                    new List<string> {"net40", "net471"}, new List<string> {"netframework"}},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"lib/_._"},
-                                    new List<string> {"net"}, new List<string> {"netframework"}}, // no version
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
-                                    new List<string> {"runtimes/win/net40/_._", "runtimes/win/net471/_._"},
-                                    new List<string>(), new List<string>()}, // no "lib" dir
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
-                                    new List<string> {"runtimes/win/lib/net40/", "runtimes/win/lib/net471/_._"},
-                                    new List<string> {"net471"}, new List<string> {"netframework"}}, // no file in "net40" dir
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
-                                    new List<string> {"lib/net5.0/_1._", "lib/net5.0/_2._", "lib/native/_._"},
-                                    new List<string> {"native", "net5.0" }, new List<string> {"net"}},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"ref/_._"},
-                                    new List<string>(), new List<string>()},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
-                                    new List<string> {"ref/net40/_._", "ref/net451/_._"},
-                                    new List<string> {"net40", "net451"}, new List<string> {"netframework"}},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
-                                    new List<string> {"contentFiles/vb/net45/_._", "contentFiles/cs/netcoreapp3.1/_._"},
-                                    new List<string>{"net45", "netcoreapp3.1"}, new List<string> {"netframework", "netcoreapp"}},
+                new List<object[]>
+                {
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                        new List<string> {"lib/netcoreapp31/_._", "lib/netstandard20/_._"},
+                                        new List<string> {"netcoreapp3.1", "netstandard2.0"}, new List<string> {"netcoreapp", "netstandard"}},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"lib/net40/_._", "lib/net4.7.1/_._"},
+                                        new List<string> {"net40", "net471"}, new List<string> {"netframework"}},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"lib/_._"},
+                                        new List<string> {"net"}, new List<string> {"netframework"}}, // no version
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                        new List<string> {"runtimes/win/net40/_._", "runtimes/win/net471/_._"},
+                                        new List<string>(), new List<string>()}, // no "lib" dir
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                        new List<string> {"runtimes/win/lib/net40/", "runtimes/win/lib/net471/_._"},
+                                        new List<string> {"net471"}, new List<string> {"netframework"}}, // no file in "net40" dir
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                        new List<string> {"lib/net5.0/_1._", "lib/net5.0/_2._", "lib/native/_._"},
+                                        new List<string> {"native", "net5.0" }, new List<string> {"net"}},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"ref/_._"},
+                                        new List<string>(), new List<string>()},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                        new List<string> {"ref/net40/_._", "ref/net451/_._"},
+                                        new List<string> {"net40", "net451"}, new List<string> {"netframework"}},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(),
+                                        new List<string> {"contentFiles/vb/net45/_._", "contentFiles/cs/netcoreapp3.1/_._"},
+                                        new List<string>{"net45", "netcoreapp3.1"}, new List<string> {"netframework", "netcoreapp"}},
 
-                    // Tools cases
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
-                                    new List<string> {"tools/netcoreapp3.1/_._"}, new List<string>(), new List<string>()},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
-                                    new List<string> {"tools/netcoreapp3.1/win10-x86/tool1/_._", "tools/netcoreapp3.1/win10-x86/tool2/_._" },
-                                    new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
-                                    new List<string> {"tools/netcoreapp3.1/any/_._"},
-                                    new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"tools/netcoreapp3.1/any/_._"},
-                                    new List<string>(), new List<string>()}, // not a tools package, no supported TFMs
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), // not a tools package
-                                    new List<string> {"Foo.nuspec", "runtimes/win10-x86/lib/net40/_._", "runtimes/win10-x86/lib/net471/_._",
-                                    "ref/net5.0-watchos/_1._", "ref/net5.0-watchos/_2._", "tools/netcoreapp3.1/win10-x86/tool1/_._",
-                                    "tools/netcoreapp3.1/win10-x86/tool2/_._"},
-                                    new List<string> {"net40", "net471", "net5.0-watchos"}, new List<string> {"netframework", "net"}},
-                    new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
-                                    new List<string> {"Foo.nuspec", "runtimes/win10-x86/lib/net40/_._", "runtimes/win10-x86/lib/net471/_._",
-                                    "ref/net5.0-watchos/_1._", "ref/net5.0-watchos/_2._", "tools/netcoreapp3.1/win10-x86/tool1/_._",
-                                    "tools/netcoreapp3.1/win10-x86/tool2/_._"},
-                                    new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
-            };
+                        // Tools cases
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
+                                        new List<string> {"tools/netcoreapp3.1/_._"}, new List<string>(), new List<string>()},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
+                                        new List<string> {"tools/netcoreapp3.1/win10-x86/tool1/_._", "tools/netcoreapp3.1/win10-x86/tool2/_._" },
+                                        new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
+                                        new List<string> {"tools/netcoreapp3.1/any/_._"},
+                                        new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), new List<string> {"tools/netcoreapp3.1/any/_._"},
+                                        new List<string>(), new List<string>()}, // not a tools package, no supported TFMs
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType>(), // not a tools package
+                                        new List<string> {"Foo.nuspec", "runtimes/win10-x86/lib/net40/_._", "runtimes/win10-x86/lib/net471/_._",
+                                        "ref/net5.0-watchos/_1._", "ref/net5.0-watchos/_2._", "tools/netcoreapp3.1/win10-x86/tool1/_._",
+                                        "tools/netcoreapp3.1/win10-x86/tool2/_._"},
+                                        new List<string> {"net40", "net471", "net5.0-watchos"}, new List<string> {"netframework", "net"}},
+                        new object[] {new List<NuGet.Protocol.Catalog.PackageType> {new NuGet.Protocol.Catalog.PackageType{ Name = "DotnetTool" }},
+                                        new List<string> {"Foo.nuspec", "runtimes/win10-x86/lib/net40/_._", "runtimes/win10-x86/lib/net471/_._",
+                                        "ref/net5.0-watchos/_1._", "ref/net5.0-watchos/_2._", "tools/netcoreapp3.1/win10-x86/tool1/_._",
+                                        "tools/netcoreapp3.1/win10-x86/tool2/_._"},
+                                        new List<string> {"netcoreapp3.1"}, new List<string> {"netcoreapp"}},
+                };
+
+            public static IEnumerable<object[]> ComputedFrameworkCases =>
+                new List<object[]>
+                {
+                    new object[] {new List<string> {}, new List<string>(), new List<string> {}},
+                    new object[] {new List<string> { "net5.0" }, new List<string> { "net5.0", "net6.0", "net7.0", "net5.0-windows" }, new List<string> { "net" }},
+                    new object[] {new List<string> { "net6.0" }, new List<string> { "net6.0", "net7.0", "net6.0-android" }, new List<string> { "net" }},
+                    new object[] {new List<string> { "net6.0-windows" }, new List<string> { "net6.0-windows", "net7.0-windows", "net8.0-windows" }, new List<string> { "net" }},
+                    new object[] {new List<string> { "net462" }, new List<string> { "net462", "net472", "net481" }, new List<string> { "netframework" }},
+                    new object[] {new List<string> { "netstandard2.1" }, new List<string> { "netstandard2.1", "net6.0", "net6.0-windows", "netcoreapp3.1", "tizen60" }, new List<string> { "net", "netstandard", "netcoreapp" }},
+                    new object[] {new List<string> { "netcoreapp3.0" }, new List<string> { "netcoreapp3.0", "netcoreapp3.1", "net5.0", "net7.0-windows" }, new List<string> { "net", "netcoreapp" }},
+                    new object[] {new List<string> { "net6.0-windows7.0" }, new List<string> { "net6.0-windows", "net7.0-windows", "net8.0-windows" }, new List<string> { "net" }}, // normalize platform version
+                    new object[] {new List<string> { "net7.0-android99.9" }, new List<string> { "net7.0-android", "net8.0-android" }, new List<string> { "net" }}, // normalize platform version
+                };
         }
     }
 }


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/5169
Part of https://github.com/NuGet/Engineering/issues/4979

This will be merged into a search-by-TFM feature branch first. and then merged into `dev` later on alongside the SearchService changes.

### Background

This PR modifies the `Db2AzureSearch` and `Catalog2AzureSearch` jobs that create and update the search index.

We are adding 2 new fields to the search index, `ComputedFrameworks` and `ComputedTfms`, which will be the computed supersets of the `Frameworks` and `Tfms` fields respectively.

To populate these fields, we get a package's asset frameworks the same way we do for the `Frameworks` and `Tfms` fields, and then expand that set using the `GetCompatibleFrameworks()` method from NuGetGallery.Core's `FrameworkCompatibilityService`.

**Normalizing TFMs with Platform Versions**

Another change we are making here is to normalize any TFMs we see with platform versions. `net6.0-androidY.Z` will become `net6.0-android` in the index. There are packages in our ecosystem that have `net6.0-android31.0`, as well as packages that have `net6.0-android`, both of which are equivalent to each other. This causes some packages to remain hidden with search filters that should be showing them. Packages with platform versions will often be hidden unless the user knows the exact TFM string to filter by.

We decided to do this in order to increase the coverage of our search filters and not hide packages that are truly compatible with a given framework filter.