### PR TITLE
Perf logs for log collector

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/AzureStatsLogSource.cs
@@ -149,6 +149,7 @@ namespace Stats.AzureCdnLogs.Common.Collect
                 _logger.LogInformation("OpenReadAsync: The blob was not found. Blob {BlobUri}", blobUri.AbsoluteUri);
                 return null;
             }
+            _logger.LogInformation("Opening blob {Filename}, {BlobSize} bytes", blob.Name, blob.Properties.Length);
             var inputRawStream = await blob.OpenReadAsync();
             switch (contentType)
             {

--- a/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
@@ -171,15 +171,15 @@ namespace Stats.AzureCdnLogs.Common.Collect
                     };
 
                     processingTime.Stop();
-                    var totalSeconds = processingTime.Elapsed.TotalSeconds;
+                    var totalSeconds = Math.Max(processingTime.Elapsed.TotalSeconds, 0.01);
                     var bytesRead = sourceStream.Position - sourceStartPosition;
                     var bytesWritten = targetStream.Position - targetStartPosition;
                     _logger.LogInformation("ProcessLogStream: Finished writing to the destination stream ({Filename}). " +
                         "{ReadLineCount} lines read ({ReadLinesPerSecond} lines/sec), {WriteLineCount} lines written ({WriteLinesPerSecond} lines/sec) in {TotalTime}. " +
                         "{BytesRead} bytes read ({BytesReadPreSecond} bytes/sec), {BytesWritten} bytes written ({BytesWrittenPerSecond} bytes/sec). ",
                         filename,
-                        rawLineNumber, (int)(rawLineNumber / totalSeconds), targetLineNumber, (int)(targetLineNumber / totalSeconds), processingTime.Elapsed,
-                        bytesRead, (int)(bytesRead / totalSeconds), bytesWritten, (int)(bytesWritten / totalSeconds));
+                        rawLineNumber, (long)(rawLineNumber / totalSeconds), targetLineNumber, (long)(targetLineNumber / totalSeconds), processingTime.Elapsed,
+                        bytesRead, (long)(bytesRead / totalSeconds), bytesWritten, (long)(bytesWritten / totalSeconds));
                 }
             }
             catch (Exception ex)

--- a/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
@@ -175,11 +175,11 @@ namespace Stats.AzureCdnLogs.Common.Collect
                     var bytesRead = sourceStream.Position - sourceStartPosition;
                     var bytesWritten = targetStream.Position - targetStartPosition;
                     _logger.LogInformation("ProcessLogStream: Finished writing to the destination stream ({Filename}). " +
-                        "{ReadLineCount} ({ReadLinesPerSecond} lines/sec) lines read, {WriteLineCount} ({WriteLinesPerSecond} lines/sec) lines written in {TotalTime}. " +
-                        "{BytesRead} ({BytesReadPreSecond} bytes/sec) bytes read, {BytesWritten} ({BytesWrittenPerSecond} bytes/sec) bytes written. ",
+                        "{ReadLineCount} lines read ({ReadLinesPerSecond} lines/sec), {WriteLineCount} lines written ({WriteLinesPerSecond} lines/sec) in {TotalTime}. " +
+                        "{BytesRead} bytes read ({BytesReadPreSecond} bytes/sec), {BytesWritten} bytes written ({BytesWrittenPerSecond} bytes/sec). ",
                         filename,
-                        rawLineNumber, rawLineNumber / totalSeconds, targetLineNumber, targetLineNumber / totalSeconds, processingTime.Elapsed,
-                        bytesRead, bytesRead / totalSeconds, bytesWritten, bytesWritten / totalSeconds);
+                        rawLineNumber, (int)(rawLineNumber / totalSeconds), targetLineNumber, (int)(targetLineNumber / totalSeconds), processingTime.Elapsed,
+                        bytesRead, (int)(bytesRead / totalSeconds), bytesWritten, (int)(bytesWritten / totalSeconds));
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/5175

The job that downloads China logs seem to be working pretty slow. This change adds happy path throughput logging so that we have specific numbers.