### PR TITLE
[Search-by-TFM] Search services changes for computed frameworks + All/Any filtering

### DIFF
--- a/src/NuGet.Services.AzureSearch/SearchService/IndexFields.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/IndexFields.cs
@@ -29,6 +29,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public static class Search
         {
+            public static readonly string ComputedFrameworks = Name(nameof(SearchDocument.UpdateLatest.ComputedFrameworks));
+            public static readonly string ComputedTfms = Name(nameof(SearchDocument.UpdateLatest.ComputedTfms));
             public static readonly string DownloadScore = Name(nameof(SearchDocument.Full.DownloadScore));
             public static readonly string FilterablePackageTypes = Name(nameof(SearchDocument.UpdateLatest.FilterablePackageTypes));
             public static readonly string Frameworks = Name(nameof(SearchDocument.UpdateLatest.Frameworks));

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/ParameterUtilities.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/ParameterUtilities.cs
@@ -28,6 +28,12 @@ namespace NuGet.Services.AzureSearch.SearchService
             { "totalDownloads-desc", V2SortBy.TotalDownloadsDesc },
         };
 
+        private static readonly IReadOnlyDictionary<string, V2FrameworkFilterMode> FrameworkFilterMode = new Dictionary<string, V2FrameworkFilterMode>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "all", V2FrameworkFilterMode.All },
+            { "any", V2FrameworkFilterMode.Any },
+        };
+
         private static readonly HashSet<string> FrameworkGenerationIdentifiers = new HashSet<string>{
                                                                                         AssetFrameworkHelper.FrameworkGenerationIdentifiers.Net,
                                                                                         AssetFrameworkHelper.FrameworkGenerationIdentifiers.NetFramework,
@@ -43,6 +49,17 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             return parsedSortBy;
+        }
+
+        public static V2FrameworkFilterMode ParseV2FrameworkFilterMode(string frameworkFilterMode)
+        {
+            // if the input parameter is null or an unexpected value, default to 'All'
+            if (frameworkFilterMode == null || !FrameworkFilterMode.TryGetValue(frameworkFilterMode, out var parsedSelector))
+            {
+                parsedSelector = V2FrameworkFilterMode.All;
+            }
+
+            return parsedSelector;
         }
 
         public static bool ParseIncludeSemVer2(string semVerLevel)

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2FrameworkFilterMode.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2FrameworkFilterMode.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Services.AzureSearch.SearchService
+{
+    public enum V2FrameworkFilterMode
+    {
+        All,
+        Any,
+    }
+}

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchPackage.cs
@@ -42,6 +42,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
         public string[] Frameworks { get; set; }
         public string[] Tfms { get; set; }
+        public string[] ComputedFrameworks { get; set; }
+        public string[] ComputedTfms { get; set; }
         public string MinClientVersion { get; set; }
         public string Hash { get; set; }
         public string HashAlgorithm { get; set; }

--- a/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchRequest.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/Models/V2SearchRequest.cs
@@ -14,5 +14,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         public string PackageType { get; set; }
         public IReadOnlyList<string> Frameworks { get; set; }
         public IReadOnlyList<string> Tfms { get; set; }
+        public bool IncludeComputedFrameworks { get; set; }
+        public V2FrameworkFilterMode FrameworkFilterMode { get; set; }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
@@ -257,7 +257,11 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 if (frameworkFilters.Any())
                 {
-                    filterString.Append("(" + String.Join($" {andOr} ", frameworkFilters) + ")");
+                    filterString
+                        .Append("(")
+                        .Append(string.Join($" {andOr} ", frameworkFilters))
+                        .Append(")");
+
                     isFilterEmpty = false;
                 }
             }
@@ -278,7 +282,11 @@ namespace NuGet.Services.AzureSearch.SearchService
                         filterString.Append($" {andOr} ");
                     }
 
-                    filterString.Append("(" + String.Join($" {andOr} ", tfmFilters) + ")");
+                    filterString
+                        .Append("(")
+                        .Append(string.Join($" {andOr} ", tfmFilters))
+                        .Append(")");
+
                     isFilterEmpty = false;
                 }
             }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Models;
 using NuGet.Packaging;
@@ -240,7 +241,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             bool includeComputedFrameworks,
             V2FrameworkFilterMode frameworkFilterMode)
         {
-            string filterString = " and (";
+            var filterString = new StringBuilder(" and (");
 
             string andOr = (frameworkFilterMode == V2FrameworkFilterMode.All) ? "and" : "or";
             bool isFilterEmpty = true;
@@ -256,7 +257,7 @@ namespace NuGet.Services.AzureSearch.SearchService
 
                 if (frameworkFilters.Any())
                 {
-                    filterString += "(" + String.Join($" {andOr} ", frameworkFilters) + ")";
+                    filterString.Append("(" + String.Join($" {andOr} ", frameworkFilters) + ")");
                     isFilterEmpty = false;
                 }
             }
@@ -274,17 +275,19 @@ namespace NuGet.Services.AzureSearch.SearchService
                 {
                     if (!isFilterEmpty)
                     {
-                        filterString += $" {andOr} ";
+                        filterString.Append($" {andOr} ");
                     }
 
-                    filterString += "(" + String.Join($" {andOr} ", tfmFilters) + ")";
+                    filterString.Append("(" + String.Join($" {andOr} ", tfmFilters) + ")");
                     isFilterEmpty = false;
                 }
             }
 
+            filterString.Append(")");
+
             return isFilterEmpty
                         ? String.Empty
-                        : filterString + ")";
+                        : filterString.ToString();
         }
     }
 }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
@@ -243,7 +243,7 @@ namespace NuGet.Services.AzureSearch.SearchService
         {
             var filterString = new StringBuilder(" and (");
 
-            string andOr = (frameworkFilterMode == V2FrameworkFilterMode.All) ? "and" : "or";
+            string andOr = (frameworkFilterMode == V2FrameworkFilterMode.All) ? " and " : " or ";
             bool isFilterEmpty = true;
 
             if (frameworks != null)
@@ -259,7 +259,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 {
                     filterString
                         .Append("(")
-                        .Append(string.Join($" {andOr} ", frameworkFilters))
+                        .Append(string.Join(andOr, frameworkFilters))
                         .Append(")");
 
                     isFilterEmpty = false;
@@ -279,12 +279,12 @@ namespace NuGet.Services.AzureSearch.SearchService
                 {
                     if (!isFilterEmpty)
                     {
-                        filterString.Append($" {andOr} ");
+                        filterString.Append(andOr);
                     }
 
                     filterString
                         .Append("(")
-                        .Append(string.Join($" {andOr} ", tfmFilters))
+                        .Append(string.Join(andOr, tfmFilters))
                         .Append(")");
 
                     isFilterEmpty = false;
@@ -294,7 +294,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             filterString.Append(")");
 
             return isFilterEmpty
-                        ? String.Empty
+                        ? string.Empty
                         : filterString.ToString();
         }
     }

--- a/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
+++ b/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs
@@ -490,6 +490,8 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             package.Frameworks = result.Frameworks;
             package.Tfms = result.Tfms;
+            package.ComputedFrameworks = result.ComputedFrameworks;
+            package.ComputedTfms = result.ComputedTfms;
             package.PackageRegistration.Owners = result.Owners ?? Array.Empty<string>();
             package.Listed = true;
             package.IsLatestStable = result.IsLatestStable.Value;

--- a/src/NuGet.Services.SearchService.Core/Controllers/SearchController.cs
+++ b/src/NuGet.Services.SearchService.Core/Controllers/SearchController.cs
@@ -70,6 +70,8 @@ namespace NuGet.Services.SearchService.Controllers
             string packageType = null,
             string frameworks = null,
             string tfms = null,
+            bool? includeComputedFrameworks = true,
+            string frameworkFilterMode = null,
             bool? testData = false,
             bool? debug = false)
         {
@@ -89,6 +91,8 @@ namespace NuGet.Services.SearchService.Controllers
                 PackageType = packageType,
                 Frameworks = ParameterUtilities.ParseFrameworks(frameworks),
                 Tfms = ParameterUtilities.ParseTfms(tfms),
+                IncludeComputedFrameworks = includeComputedFrameworks ?? true,
+                FrameworkFilterMode = ParameterUtilities.ParseV2FrameworkFilterMode(frameworkFilterMode),
                 IncludeTestData = testData ?? false,
                 ShowDebug = debug ?? false,
             };

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
@@ -265,7 +265,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 };
 
                 // act
-                var output = _target.V2Search(request, isDefaultSearch: It.IsAny<bool>());
+                var output = _target.V2Search(request, isDefaultSearch: false);
 
                 // assert
                 Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);
@@ -284,7 +284,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 };
 
                 // act
-                var output = _target.V2Search(request, isDefaultSearch: It.IsAny<bool>());
+                var output = _target.V2Search(request, isDefaultSearch: false);
 
                 // assert
                 Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);
@@ -304,7 +304,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 };
 
                 // act
-                var output = _target.V2Search(request, isDefaultSearch: It.IsAny<bool>());
+                var output = _target.V2Search(request, isDefaultSearch: false);
 
                 // assert
                 Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
@@ -265,7 +265,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 };
 
                 // act
-                var output = _target.V2Search(request, It.IsAny<bool>());
+                var output = _target.V2Search(request, isDefaultSearch: It.IsAny<bool>());
 
                 // assert
                 Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);
@@ -284,7 +284,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 };
 
                 // act
-                var output = _target.V2Search(request, It.IsAny<bool>());
+                var output = _target.V2Search(request, isDefaultSearch: It.IsAny<bool>());
 
                 // assert
                 Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);
@@ -304,7 +304,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 };
 
                 // act
-                var output = _target.V2Search(request, It.IsAny<bool>());
+                var output = _target.V2Search(request, isDefaultSearch: It.IsAny<bool>());
 
                 // assert
                 Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
@@ -253,27 +253,9 @@ namespace NuGet.Services.AzureSearch.SearchService
             }
 
             [Theory]
-            [MemberData(nameof(FrameworkAndTfmFilters))]
-            public void FrameworkAndTfmFiltering(List<string> frameworks, List<string> tfms, string expectedFilterString, bool includeComputedFrameworks = false)
-            {
-                // arrange
-                var request = new V2SearchRequest
-                {
-                    Frameworks = frameworks,
-                    Tfms = tfms,
-                    IncludeComputedFrameworks = includeComputedFrameworks,
-                };
-
-                // act
-                var output = _target.V2Search(request, isDefaultSearch: false);
-
-                // assert
-                Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);
-            }
-
-            [Theory]
+            [MemberData(nameof(FrameworkAndTfmCases))]
             [MemberData(nameof(ComputedFrameworkCases))]
-            public void ComputedFrameworkAndTfmFilters(List<string> frameworks, List<string> tfms, bool includeComputedFrameworks, string expectedFilterString)
+            public void FrameworkAndTfmFiltering(List<string> frameworks, List<string> tfms, string expectedFilterString, bool includeComputedFrameworks = false)
             {
                 // arrange
                 var request = new V2SearchRequest
@@ -628,7 +610,7 @@ namespace NuGet.Services.AzureSearch.SearchService
                 new object[] { "PackageType_With_Underscores" },
             };
 
-            public static IEnumerable<object[]> FrameworkAndTfmFilters => new[]
+            public static IEnumerable<object[]> FrameworkAndTfmCases => new[]
             {
                 new object[] {  new List<string> {"netstandard"},
                                 new List<string> {"net472"},
@@ -659,20 +641,20 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 new object[] {  new List<string> {"net", "netstandard"},
                                 new List<string> {"netcoreapp3.1"},
-                                true,
-                                "((computedFrameworks/any(f: f eq 'net') and computedFrameworks/any(f: f eq 'netstandard')) and (computedTfms/any(f: f eq 'netcoreapp3.1')))" },
+                                "((computedFrameworks/any(f: f eq 'net') and computedFrameworks/any(f: f eq 'netstandard')) and (computedTfms/any(f: f eq 'netcoreapp3.1')))",
+                                true },
                 new object[] {  new List<string> {"net", "netstandard"},
                                 new List<string> {"netcoreapp3.1"},
-                                false,
-                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))",
+                                false },
                 new object[] {  new List<string> {"netframework"},
                                 new List<string> {"netstandard2.1", "net462"},
-                                true,
-                                "((computedFrameworks/any(f: f eq 'netframework')) and (computedTfms/any(f: f eq 'netstandard2.1') and computedTfms/any(f: f eq 'net462')))" },
+                                "((computedFrameworks/any(f: f eq 'netframework')) and (computedTfms/any(f: f eq 'netstandard2.1') and computedTfms/any(f: f eq 'net462')))",
+                                true },
                 new object[] {  new List<string> {"netframework"},
                                 new List<string> {"netstandard2.1", "net462"},
-                                false,
-                                "((frameworks/any(f: f eq 'netframework')) and (tfms/any(f: f eq 'netstandard2.1') and tfms/any(f: f eq 'net462')))" },
+                                "((frameworks/any(f: f eq 'netframework')) and (tfms/any(f: f eq 'netstandard2.1') and tfms/any(f: f eq 'net462')))",
+                                false },
             };
 
             public static IEnumerable<object[]> FrameworkFilterModeCases => new[]

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchParametersBuilderFacts.cs
@@ -254,13 +254,53 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             [Theory]
             [MemberData(nameof(FrameworkAndTfmFilters))]
-            public void FrameworkAndTfmFiltering(List<string> frameworks, List<string> tfms, string expectedFilterString)
+            public void FrameworkAndTfmFiltering(List<string> frameworks, List<string> tfms, string expectedFilterString, bool includeComputedFrameworks = false)
             {
                 // arrange
                 var request = new V2SearchRequest
                 {
                     Frameworks = frameworks,
-                    Tfms = tfms
+                    Tfms = tfms,
+                    IncludeComputedFrameworks = includeComputedFrameworks,
+                };
+
+                // act
+                var output = _target.V2Search(request, It.IsAny<bool>());
+
+                // assert
+                Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);
+            }
+
+            [Theory]
+            [MemberData(nameof(ComputedFrameworkCases))]
+            public void ComputedFrameworkAndTfmFilters(List<string> frameworks, List<string> tfms, bool includeComputedFrameworks, string expectedFilterString)
+            {
+                // arrange
+                var request = new V2SearchRequest
+                {
+                    Frameworks = frameworks,
+                    Tfms = tfms,
+                    IncludeComputedFrameworks = includeComputedFrameworks,
+                };
+
+                // act
+                var output = _target.V2Search(request, It.IsAny<bool>());
+
+                // assert
+                Assert.Equal($"searchFilters eq 'Default' and {expectedFilterString}", output.Filter);
+            }
+
+            [Theory]
+            [MemberData(nameof(FrameworkFilterModeCases))]
+            public void FilterStringShouldMatchFrameworkFilterMode(List<string> frameworks, List<string> tfms, string frameworkFilterMode, string expectedFilterString)
+            {
+                // arrange
+                var request = new V2SearchRequest
+                {
+                    Frameworks = frameworks,
+                    Tfms = tfms,
+                    IncludeComputedFrameworks = false,
+                    FrameworkFilterMode = ParameterUtilities.ParseV2FrameworkFilterMode(frameworkFilterMode)
                 };
 
                 // act
@@ -590,20 +630,85 @@ namespace NuGet.Services.AzureSearch.SearchService
 
             public static IEnumerable<object[]> FrameworkAndTfmFilters => new[]
             {
-                new object[] { new List<string> {"netstandard"}, new List<string> {"net472"},
-                    "(frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'net472'))" },
-                new object[] { new List<string> {"netcoreapp"}, new List<string>(),
-                    "(frameworks/any(f: f eq 'netcoreapp'))" },
-                new object[] { new List<string>(), new List<string> {"net5.0"},
-                    "(tfms/any(f: f eq 'net5.0'))" },
-                new object[] { new List<string> {"net", "netstandard"},
-                    new List<string> {"netcoreapp3.1"},
-                    "(frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard'))" +
-                    " and (tfms/any(f: f eq 'netcoreapp3.1'))" },
-                new object[] { new List<string> {"netframework"},
-                    new List<string> {"netstandard2.1", "net40-client"},
-                    "(frameworks/any(f: f eq 'netframework'))" +
-                    " and (tfms/any(f: f eq 'netstandard2.1') and tfms/any(f: f eq 'net40-client'))" },
+                new object[] {  new List<string> {"netstandard"},
+                                new List<string> {"net472"},
+                                "((frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'net472')))" },
+                new object[] {  new List<string> {"netcoreapp"},
+                                new List<string>(),
+                                "((frameworks/any(f: f eq 'netcoreapp')))" },
+                new object[] {  new List<string>(),
+                                new List<string> {"net5.0"},
+                                "((tfms/any(f: f eq 'net5.0')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"netframework"},
+                                new List<string> {"netstandard2.1", "net40-client"},
+                                "((frameworks/any(f: f eq 'netframework')) and (tfms/any(f: f eq 'netstandard2.1') and tfms/any(f: f eq 'net40-client')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                "((computedFrameworks/any(f: f eq 'net') and computedFrameworks/any(f: f eq 'netstandard')) and (computedTfms/any(f: f eq 'netcoreapp3.1')))",
+                                true },
+                new object[] {  new List<string> {"netframework"},
+                                new List<string> {"netstandard2.1", "net40-client"},
+                                "((computedFrameworks/any(f: f eq 'netframework')) and (computedTfms/any(f: f eq 'netstandard2.1') and computedTfms/any(f: f eq 'net40-client')))",
+                                true },
+            };
+
+            public static IEnumerable<object[]> ComputedFrameworkCases => new[]
+            {
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                true,
+                                "((computedFrameworks/any(f: f eq 'net') and computedFrameworks/any(f: f eq 'netstandard')) and (computedTfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                false,
+                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"netframework"},
+                                new List<string> {"netstandard2.1", "net462"},
+                                true,
+                                "((computedFrameworks/any(f: f eq 'netframework')) and (computedTfms/any(f: f eq 'netstandard2.1') and computedTfms/any(f: f eq 'net462')))" },
+                new object[] {  new List<string> {"netframework"},
+                                new List<string> {"netstandard2.1", "net462"},
+                                false,
+                                "((frameworks/any(f: f eq 'netframework')) and (tfms/any(f: f eq 'netstandard2.1') and tfms/any(f: f eq 'net462')))" },
+            };
+
+            public static IEnumerable<object[]> FrameworkFilterModeCases => new[]
+            {
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                null, // null
+                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                "blah", // unexpected value
+                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                "all",
+                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"netframework"},
+                                new List<string> {"netstandard2.1", "net462"},
+                                "all",
+                                "((frameworks/any(f: f eq 'netframework')) and (tfms/any(f: f eq 'netstandard2.1') and tfms/any(f: f eq 'net462')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                "aLl", // case insensitive
+                                "((frameworks/any(f: f eq 'net') and frameworks/any(f: f eq 'netstandard')) and (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                "any",
+                                "((frameworks/any(f: f eq 'net') or frameworks/any(f: f eq 'netstandard')) or (tfms/any(f: f eq 'netcoreapp3.1')))" },
+                new object[] {  new List<string> {"netframework"},
+                                new List<string> {"netstandard2.1", "net462"},
+                                "any",
+                                "((frameworks/any(f: f eq 'netframework')) or (tfms/any(f: f eq 'netstandard2.1') or tfms/any(f: f eq 'net462')))" },
+                new object[] {  new List<string> {"net", "netstandard"},
+                                new List<string> {"netcoreapp3.1"},
+                                "AnY", // case insensitive
+                                "((frameworks/any(f: f eq 'net') or frameworks/any(f: f eq 'netstandard')) or (tfms/any(f: f eq 'netcoreapp3.1')))" },
             };
 
             public BaseFacts()

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -144,6 +144,8 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""CountOnly"": false,
     ""SortBy"": ""Popularity"",
     ""LuceneQuery"": false,
+    ""IncludeComputedFrameworks"": false,
+    ""FrameworkFilterMode"": ""All"",
     ""Skip"": 0,
     ""Take"": 0,
     ""IncludePrerelease"": true,
@@ -491,6 +493,8 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""CountOnly"": false,
     ""SortBy"": ""Popularity"",
     ""LuceneQuery"": false,
+    ""IncludeComputedFrameworks"": false,
+    ""FrameworkFilterMode"": ""All"",
     ""Skip"": 0,
     ""Take"": 0,
     ""IncludePrerelease"": true,
@@ -597,6 +601,12 @@ namespace NuGet.Services.AzureSearch.SearchService
         ""netframework""
       ],
       ""Tfms"": [
+        ""net40-client""
+      ],
+      ""ComputedFrameworks"": [
+        ""netframework""
+      ],
+      ""ComputedTfms"": [
         ""net40-client""
       ],
       ""MinClientVersion"": ""2.12"",
@@ -1875,6 +1885,8 @@ namespace NuGet.Services.AzureSearch.SearchService
     ""CountOnly"": false,
     ""SortBy"": ""Popularity"",
     ""LuceneQuery"": false,
+    ""IncludeComputedFrameworks"": false,
+    ""FrameworkFilterMode"": ""All"",
     ""Skip"": 0,
     ""Take"": 0,
     ""IncludePrerelease"": true,


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/5172
Part of https://github.com/NuGet/Engineering/issues/4979

The changes to the index-builder jobs were already merged into the feature branch with https://github.com/NuGet/NuGet.Jobs/pull/1166. Once this PR is merged as well, I'll merge the feature branch into `dev` and begin the index rebuild process for the search index.

### Background

This PR modifies the `SearchService`, which is responsible for responding to search requests from the Gallery (V2 API) as well as clients using the V3 API.

In this PR, we are making changes to the V2 search API, adding two new search parameters: 
1. `includeComputedFrameworks` is a boolean, which defaults to `true`. This decides whether we filter purely by a package's asset frameworks, or filter by its computed frameworks as well.
2. `frameworkFilterMode` is an enum that can have the values `all` or `any`. This determines whether we return packages matching **all** the framework/TFM filters, or **any** one of the framework filters. The default behavior, and the current behavior, is to show packages matching **all** the filters.

The core changes were the modifications to the filtering logic in `src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs`:
1. We choose which field to filter on based on the value of `includeComputedFrameworks`. If it is `true`, we will filter against the `ComputedFrameworks` and `ComputedTfms` fields (asset frameworks + computed frameworks), and if it is `false`, we will filter against the `Frameworks` and `Tfms` fields (just asset frameworks) instead. 
3. If `frameworkFilterMode` is set to `all`, we will filter for packages matching all the framework filters and all the TFM filters:
    `(frameworks contains 'net') and (tfms contains 'net6.0') and (tfms contains 'net462')`

    If `frameworkFilterMode` is set to `any`, we will filter for packages matching at least one of the framework filters or any one of the TFM filters:
    `(frameworks contains 'net') or (tfms contains 'net6.0') or (tfms contains 'net462')`