### PR TITLE
Force stopping Stats.CollectAzureChinaCDNLogs after reaching execution timeout

### DIFF
--- a/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs
@@ -80,8 +80,9 @@ namespace Stats.AzureCdnLogs.Common.Collect
                     if (lockResult.LockIsTaken /*lockResult*/)
                     {
                         using (var inputStream = await _source.OpenReadAsync(file, sourceContentType, blobOperationToken))
+                        using (blobOperationToken.Register(() => inputStream.Close()))
                         {
-                            var blobToDeadLetter = ! await VerifyStreamInternalAsync(file, sourceContentType, blobOperationToken);
+                            var blobToDeadLetter = !await VerifyStreamInternalAsync(file, sourceContentType, blobOperationToken);
                             var filename = file.Segments.LastOrDefault();
                             // If verification passed continue with the rest of the action 
                             // If not just move the blob to deadletter

--- a/src/Stats.AzureCdnLogs.Common/Collect/TaskExtensions.cs
+++ b/src/Stats.AzureCdnLogs.Common/Collect/TaskExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stats.AzureCdnLogs.Common.Collect
+{
+    public static class TaskExtensions
+    {
+        /// <summary>
+        /// Creates a continuation Task with cancellation token attached to it. If the task passed as <paramref name="task"/> still
+        /// runs when cancellation token fires it will throw <see cref="TaskCanceledException"/>. It will not do anything about
+        /// the original task, but it will give the execution back to thee caller, so it can handle the cancellation.
+        /// </summary>
+        /// <param name="task">Original task to "inject" cancellation into.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A task that will throw if cancellation token fires before the original task completes.</returns>
+        /// <exception cref="TaskCanceledException">Thrown when cancellation happens before <paramref name="task"/> completes.</exception>
+        /// <remarks>
+        /// https://stackoverflow.com/a/28626769/31782
+        /// 
+        /// This is useful for tasks that themselves do not handle cancellation well (or at all).
+        /// </remarks>
+        public static Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)
+        {
+            return task.IsCompleted
+                ? task
+                : task.ContinueWith(
+                    completedTask => completedTask.GetAwaiter().GetResult(),
+                    cancellationToken,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+        }
+    }
+}

--- a/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
+++ b/src/Stats.AzureCdnLogs.Common/Stats.AzureCdnLogs.Common.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build" ToolsVersion="15.0">
   <Import Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <Import Project="..\..\sign.thirdparty.props" />
@@ -56,6 +56,7 @@
     <Compile Include="Collect\ILogSource.cs" />
     <Compile Include="Collect\ILogDestination.cs" />
     <Compile Include="Collect\OutputLogLine.cs" />
+    <Compile Include="Collect\TaskExtensions.cs" />
     <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="ExtensionsUtils.cs" />


### PR DESCRIPTION
Attempt at mitigating https://github.com/NuGet/Engineering/issues/5188

Currently, CDN log collector code does not propagate CancellationToken to every I/O operation, probably because in net472 `StreamReader`'s read methods don't accept one. Occasionally, China log copy job gets stuck copying files and firing CancellationToken does not really stop the job.

https://github.com/NuGet/NuGet.Jobs/blob/41435477072534d80ef96450b49200de65bdfde9/src/Stats.AzureCdnLogs.Common/Collect/Collector.cs#L158

The change adds a top-level task that can be cancelled regardless of the state of underlying tasks. If that cancellation happens, the process terminates abandoning the operation in progress, mimicking a current mitigation of manually restarting the stuck service.