### PR TITLE
Update SearchResponseBuilderFacts.cs to fix Bug 1974435 (replace 'JsonSerializerOptions.IgnoreNullValues' since obsolete)

### DIFF
--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -2085,7 +2085,7 @@ namespace NuGet.Services.AzureSearch.SearchService
             {
                 return JsonSerializer.Serialize(response, new System.Text.Json.JsonSerializerOptions
                 {
-                    IgnoreNullValues = true,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                     Converters =
                         {
                             new System.Text.Json.Serialization.JsonStringEnumConverter(),

--- a/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
+++ b/tests/NuGet.Services.AzureSearch.Tests/SearchService/SearchResponseBuilderFacts.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
Fix for [Bug 1974435: [ NuGet.Jobs ][ .NET Security Analyzers ] - Defect : SYSLIB0020, Component : tests\NuGet.Services.AzureSearch.Tests\SearchService\SearchResponseBuilderFacts.cs](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1974435)
	
'JsonSerializerOptions.IgnoreNullValues' is obsolete: 'JsonSerializerOptions.IgnoreNullValues is obsolete. To ignore null values when serializing, set DefaultIgnoreCondition to JsonIgnoreCondition.WhenWritingNull.'