### PR TITLE
Revert "update NuGet package version"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
     <ServerCommonPackageVersion>2.115.0</ServerCommonPackageVersion>
-    <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
+    <NuGetClientPackageVersion>6.6.1</NuGetClientPackageVersion>
     <NuGetGalleryPackageVersion>4.4.5-dev-8970351</NuGetGalleryPackageVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -39,7 +39,7 @@
     <PackageVersion Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageVersion Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
     <PackageVersion Include="Moq" Version="4.18.1" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="NuGet.Build.Tasks.Pack" Version="4.8.0" />
     <PackageVersion Include="NuGet.CommandLine" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGet.Commands" Version="$(NuGetClientPackageVersion)" />
@@ -73,8 +73,8 @@
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Reflection.Metadata" Version="1.7.0-preview1-26717-04" />
-    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.2" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="4.7.2" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="Test.Utility" Version="6.4.2-rc.25" />
     <PackageVersion Include="UAParser" Version="3.1.44" />


### PR DESCRIPTION
Reverts NuGet/NuGet.Jobs#1178

Due to permission issue, I can't resolve the conflict, I will revert this change to main, and merge this change to dev first. And then do dev-main release. 

https://github.com/NuGet/NuGet.Jobs/pull/1181

Address: https://github.com/NuGet/Engineering/issues/5251