### PR TITLE
Changing the way NSSM starts

### DIFF
--- a/src/ArchivePackages/Scripts/Functions.ps1
+++ b/src/ArchivePackages/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/ArchivePackages/Scripts/Functions.ps1
+++ b/src/ArchivePackages/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Gallery.CredentialExpiration/Scripts/Functions.ps1
+++ b/src/Gallery.CredentialExpiration/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Gallery.CredentialExpiration/Scripts/Functions.ps1
+++ b/src/Gallery.CredentialExpiration/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Gallery.Maintenance/Scripts/Functions.ps1
+++ b/src/Gallery.Maintenance/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Gallery.Maintenance/Scripts/Functions.ps1
+++ b/src/Gallery.Maintenance/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Ng/Scripts/Functions.ps1
+++ b/src/Ng/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Ng/Scripts/Functions.ps1
+++ b/src/Ng/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Jobs.Auxiliary2AzureSearch/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.Auxiliary2AzureSearch/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Jobs.Auxiliary2AzureSearch/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.Auxiliary2AzureSearch/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Jobs.Catalog2AzureSearch/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.Catalog2AzureSearch/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Jobs.Catalog2AzureSearch/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.Catalog2AzureSearch/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Jobs.Catalog2Registration/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.Catalog2Registration/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Jobs.Catalog2Registration/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.Catalog2Registration/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Jobs.GitHubIndexer/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.GitHubIndexer/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    $installService = "nssm install $ServiceName $ScriptToRun"
-    cmd /C $installService
+    & nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/NuGet.Jobs.GitHubIndexer/Scripts/Functions.ps1
+++ b/src/NuGet.Jobs.GitHubIndexer/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    & nssm.exe install $ServiceName $ScriptToRun
+    & .\nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/NuGet.Services.Revalidate/Scripts/Functions.ps1
+++ b/src/NuGet.Services.Revalidate/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    $installService = "nssm install $ServiceName $ScriptToRun"
-    cmd /C $installService
+    & nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/NuGet.Services.Revalidate/Scripts/Functions.ps1
+++ b/src/NuGet.Services.Revalidate/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    & nssm.exe install $ServiceName $ScriptToRun
+    & .\nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/NuGet.Services.Validation.Orchestrator/Scripts/Functions.ps1
+++ b/src/NuGet.Services.Validation.Orchestrator/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/NuGet.Services.Validation.Orchestrator/Scripts/Functions.ps1
+++ b/src/NuGet.Services.Validation.Orchestrator/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/PackageLagMonitor/Scripts/Functions.ps1
+++ b/src/PackageLagMonitor/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    $installService = "nssm install $ServiceName $ScriptToRun"
-    cmd /C $installService
+    & nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/PackageLagMonitor/Scripts/Functions.ps1
+++ b/src/PackageLagMonitor/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    & nssm.exe install $ServiceName $ScriptToRun
+    & .\nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/Stats.AggregateCdnDownloadsInGallery/Scripts/Functions.ps1
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.AggregateCdnDownloadsInGallery/Scripts/Functions.ps1
+++ b/src/Stats.AggregateCdnDownloadsInGallery/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.CollectAzureCdnLogs/Scripts/Functions.ps1
+++ b/src/Stats.CollectAzureCdnLogs/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.CollectAzureCdnLogs/Scripts/Functions.ps1
+++ b/src/Stats.CollectAzureCdnLogs/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.CollectAzureChinaCDNLogs/Scripts/Functions.ps1
+++ b/src/Stats.CollectAzureChinaCDNLogs/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.CollectAzureChinaCDNLogs/Scripts/Functions.ps1
+++ b/src/Stats.CollectAzureChinaCDNLogs/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.CreateAzureCdnWarehouseReports/Scripts/Functions.ps1
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.CreateAzureCdnWarehouseReports/Scripts/Functions.ps1
+++ b/src/Stats.CreateAzureCdnWarehouseReports/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.ImportAzureCdnStatistics/Scripts/Functions.ps1
+++ b/src/Stats.ImportAzureCdnStatistics/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.ImportAzureCdnStatistics/Scripts/Functions.ps1
+++ b/src/Stats.ImportAzureCdnStatistics/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.PostProcessReports/Scripts/Functions.ps1
+++ b/src/Stats.PostProcessReports/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.PostProcessReports/Scripts/Functions.ps1
+++ b/src/Stats.PostProcessReports/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.RollUpDownloadFacts/Scripts/Functions.ps1
+++ b/src/Stats.RollUpDownloadFacts/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Stats.RollUpDownloadFacts/Scripts/Functions.ps1
+++ b/src/Stats.RollUpDownloadFacts/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/StatusAggregator/Scripts/Functions.ps1
+++ b/src/StatusAggregator/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/StatusAggregator/Scripts/Functions.ps1
+++ b/src/StatusAggregator/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Validation.PackageSigning.ProcessSignature/Scripts/Functions.ps1
+++ b/src/Validation.PackageSigning.ProcessSignature/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	& nssm.exe install $ServiceName $ScriptToRun
+	& .\nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Validation.PackageSigning.ProcessSignature/Scripts/Functions.ps1
+++ b/src/Validation.PackageSigning.ProcessSignature/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
 	Write-Host Installing service $ServiceName...
 
-	$installService = "nssm install $ServiceName $ScriptToRun"
-	cmd /C $installService
+	& nssm.exe install $ServiceName $ScriptToRun
 	
 	Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
 	sc.exe failure $ServiceName reset= 30 actions= restart/5000 

--- a/src/Validation.PackageSigning.RevalidateCertificate/Scripts/Functions.ps1
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    $installService = "nssm install $ServiceName $ScriptToRun"
-    cmd /C $installService
+    & nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/Validation.PackageSigning.RevalidateCertificate/Scripts/Functions.ps1
+++ b/src/Validation.PackageSigning.RevalidateCertificate/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    & nssm.exe install $ServiceName $ScriptToRun
+    & .\nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/Validation.PackageSigning.ValidateCertificate/Scripts/Functions.ps1
+++ b/src/Validation.PackageSigning.ValidateCertificate/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    $installService = "nssm install $ServiceName $ScriptToRun"
-    cmd /C $installService
+    & nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/Validation.PackageSigning.ValidateCertificate/Scripts/Functions.ps1
+++ b/src/Validation.PackageSigning.ValidateCertificate/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    & nssm.exe install $ServiceName $ScriptToRun
+    & .\nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/Validation.Symbols/Scripts/Functions.ps1
+++ b/src/Validation.Symbols/Scripts/Functions.ps1
@@ -17,8 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    $installService = "nssm install $ServiceName $ScriptToRun"
-    cmd /C $installService
+    & nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000

--- a/src/Validation.Symbols/Scripts/Functions.ps1
+++ b/src/Validation.Symbols/Scripts/Functions.ps1
@@ -17,7 +17,7 @@ Function Install-NuGetService() {
 
     Write-Host Installing service $ServiceName...
 
-    & nssm.exe install $ServiceName $ScriptToRun
+    & .\nssm.exe install $ServiceName $ScriptToRun
 
     Set-Service -Name $ServiceName -DisplayName "$ServiceTitle - $ServiceName" -Description "Runs $ServiceTitle." -StartupType Automatic
     sc.exe failure $ServiceName reset= 30 actions= restart/5000


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5226.

The old way fails when `$ScriptToRun` contains spaces.

New version doesn't try to build the whole command line itself and lets PowerShell do the right thing instead. It properly quotes parameters, and everything works correctly even with spaces in paths.