### PR TITLE
Dummy pipeline to have actual release pipeline trigger source in AzDO

### DIFF
--- a/.pipelines/Release-trigger.yml
+++ b/.pipelines/Release-trigger.yml
@@ -1,0 +1,17 @@
+name: NuGet.Jobs release trigger $(Build.BuildId) - $(Date:yyyyMMdd)
+
+trigger:
+  branches:
+    include:
+    - main
+    - dev
+
+variables:
+- name: NugetMultifeedWarnLevel
+  value: none
+  
+pool:
+  vmImage: 'windows-latest'
+
+steps:
+- powershell: Write-Host "Dummy task"


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5226
Related to https://github.com/NuGet/NuGetGallery/pull/9885

With migration to YAML pipelines we're having issues with triggering build pipelines that are not stored in GitHub based on changes happening in GitHub. This pipeline is created to work around that. Since it is stored in GH, it will get properly triggered when changes are made to main/dev branches and other pipelines can then reference this pipeline to get triggered on its success.