### PR TITLE
CI pipeline for NuGet.Jobs

### DIFF
--- a/.pipelines/NuGet.Jobs-CI.yml
+++ b/.pipelines/NuGet.Jobs-CI.yml
@@ -36,7 +36,7 @@ variables:
 - name: ArtifactsFolder
   value: $(NuGetJobsPath)\artifacts
 - name: NuGetJobsBranch
-  value: ${{ Build.SourceBranchName }}
+  value: $(Build.SourceBranchName)
 
 resources:
   repositories:

--- a/.pipelines/NuGet.Jobs-CI.yml
+++ b/.pipelines/NuGet.Jobs-CI.yml
@@ -1,0 +1,98 @@
+name: NuGet.Jobs CI $(BuildId)
+
+trigger:
+  branches:
+    include:
+    - '*'
+  batch: True
+
+variables:
+- name: Assemblies
+  value: ''
+- name: BuildConfiguration
+  value: Release
+- name: Codeql.Enabled
+  value: true
+- name: NUGET_SNK_PATH_DISABLED
+  value: $(NuGetJobsPath)\build\private\Signing\keys\35MSSharedLib1024.snk
+- name: nugetMultiFeedWarnLevel
+  value: none
+- name: NugetSecurityAnalysisWarningLevel
+  value: none
+- name: PackageVersion
+  value: $(SimplePackageVersion)$(PrereleaseVersion)
+- name: PrereleaseVersion
+  value: -$(NuGetJobsBranch)-$(Build.BuildId)
+- name: SimplePackageVersion
+  value: 4.0.0
+- name: UsePrivateRepo
+  value: false
+- name: PrivateRepoBranch
+  value: main
+- name: NuGetJobsDirectory
+  value: nj
+- name: NuGetJobsPath
+  value: $(Agent.BuildDirectory)\$(NuGetJobsDirectory)
+- name: ArtifactsFolder
+  value: $(NuGetJobsPath)\artifacts
+- name: NuGetJobsBranch
+  value: ${{ Build.SourceBranchName }}
+
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: NuGet-1ES-Hosted-Pool
+      image: NuGet-1ESPT-Win2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: stage
+      jobs:
+      - job: Phase_1
+        displayName: Phase 1
+        cancelTimeoutInMinutes: 1
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: UnsignedArtifacts'
+            targetPath: $(ArtifactsFolder)
+            artifactName: UnsignedArtifacts
+        steps:
+        - checkout: self
+          fetchDepth: 1
+          clean: true
+          fetchTags: false
+          path: $(NuGetJobsDirectory)
+        - task: PowerShell@1
+          name: PowerShell_1
+          displayName: Build
+          inputs:
+            scriptName: $(NuGetJobsPath)\build.ps1
+            arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId) -SimpleVersion $(SimplePackageVersion) -SemanticVersion $(PackageVersion) -Branch $(NuGetJobsBranch) -CommitSHA $(Build.SourceVersion)
+            workingFolder: $(NuGetJobsPath)
+        - task: PowerShell@1
+          name: PowerShell_2
+          displayName: Run unit tests
+          inputs:
+            scriptName: $(NuGetJobsPath)\test.ps1
+            arguments: -Configuration $(BuildConfiguration) -BuildNumber $(Build.BuildId)
+            workingFolder: $(NuGetJobsPath)
+        - task: PublishTestResults@1
+          name: PublishTestResults_3
+          displayName: Publish Test Results Results.*.xml
+          condition: succeededOrFailed()
+          inputs:
+            testRunner: XUnit
+            testResultsFiles: $(NuGetJobsPath)\Results.*.xml


### PR DESCRIPTION
Progress on https://github.com/NuGet/Engineering/issues/5226

Storing CI pipeline in GH, so we don't have to invent anything with pipeline triggers.