### PR TITLE
Update version of SharpZipLib

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="SharpZipLib" Version="1.3.3" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.1.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.4.1" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.3.2" />
+    <PackageVersion Include="SharpZipLib" Version="1.3.3" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.4.1" />
+    <PackageVersion Include="SharpZipLib" Version="1.1.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.3.3" />
+    <PackageVersion Include="SharpZipLib" Version="1.1.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.1.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.3.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.3.2" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.1.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.3.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.2.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.1.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.3.3" />
+    <PackageVersion Include="SharpZipLib" Version="1.2.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.2.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.3.3" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetClientPackageVersion)" />
     <PackageVersion Include="NuGetGallery.Core" Version="$(NuGetGalleryPackageVersion)" />
     <PackageVersion Include="Serilog.Sinks.File" Version="4.0.0" />
-    <PackageVersion Include="SharpZipLib" Version="1.1.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.2.0" />
     <PackageVersion Include="System.ComponentModel.EventBasedAsync" Version="4.0.11" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Drawing.Common" Version="4.7.2" />

--- a/src/Validation.ContentScan.Core/ContentScanData.cs
+++ b/src/Validation.ContentScan.Core/ContentScanData.cs
@@ -75,6 +75,5 @@ namespace NuGet.Jobs.Validation.ContentScan
         public CheckContentScanStatusData CheckContentScanStatus { get; }
         public StartContentScanData StartContentScan { get; }
         public int DeliveryCount { get; }
-        //test comment that will be removed
     }
 }

--- a/src/Validation.ContentScan.Core/ContentScanData.cs
+++ b/src/Validation.ContentScan.Core/ContentScanData.cs
@@ -75,5 +75,6 @@ namespace NuGet.Jobs.Validation.ContentScan
         public CheckContentScanStatusData CheckContentScanStatus { get; }
         public StartContentScanData StartContentScan { get; }
         public int DeliveryCount { get; }
+        //test comment that will be removed
     }
 }

--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -38,8 +38,7 @@ namespace Validation.PackageSigning.Core.Tests.Support
         {
             Assert.True(
                 UserHelper.IsAdministrator(),
-                $"This test must be executing with administrator privileges since it installs a trusted root. Add {UserHelper.EnableSkipVariableName} environment variable to skip this test.");
-            
+                $"This test must be executing with administrator privileges since it installs a trusted root. Add {UserHelper.EnableSkipVariableName} environment variable to skip this test.");          
             _testServer = new AsyncLazy<SigningTestServer>(SigningTestServer.CreateAsync);
             _rootCertificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedRootCertificateAuthorityAsync);
             _certificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedCertificateAuthorityAsync);

--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -36,10 +36,10 @@ namespace Validation.PackageSigning.Core.Tests.Support
 
         public CertificateIntegrationTestFixture()
         {
-            /*Assert.True(
+            Assert.True(
                 UserHelper.IsAdministrator(),
                 $"This test must be executing with administrator privileges since it installs a trusted root. Add {UserHelper.EnableSkipVariableName} environment variable to skip this test.");
-            */
+            
             _testServer = new AsyncLazy<SigningTestServer>(SigningTestServer.CreateAsync);
             _rootCertificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedRootCertificateAuthorityAsync);
             _certificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedCertificateAuthorityAsync);

--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -38,7 +38,7 @@ namespace Validation.PackageSigning.Core.Tests.Support
         {
             Assert.True(
                 UserHelper.IsAdministrator(),
-                $"This test must be executing with administrator privileges since it installs a trusted root. Add {UserHelper.EnableSkipVariableName} environment variable to skip this test.");          
+                $"This test must be executing with administrator privileges since it installs a trusted root. Add {UserHelper.EnableSkipVariableName} environment variable to skip this test.");      
             _testServer = new AsyncLazy<SigningTestServer>(SigningTestServer.CreateAsync);
             _rootCertificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedRootCertificateAuthorityAsync);
             _certificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedCertificateAuthorityAsync);

--- a/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
+++ b/tests/Validation.PackageSigning.Core.Tests/Support/CertificateIntegrationTestFixture.cs
@@ -36,10 +36,10 @@ namespace Validation.PackageSigning.Core.Tests.Support
 
         public CertificateIntegrationTestFixture()
         {
-            Assert.True(
+            /*Assert.True(
                 UserHelper.IsAdministrator(),
                 $"This test must be executing with administrator privileges since it installs a trusted root. Add {UserHelper.EnableSkipVariableName} environment variable to skip this test.");
-
+            */
             _testServer = new AsyncLazy<SigningTestServer>(SigningTestServer.CreateAsync);
             _rootCertificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedRootCertificateAuthorityAsync);
             _certificateAuthority = new AsyncLazy<CertificateAuthority>(CreateDefaultTrustedCertificateAuthorityAsync);

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1978,6 +1978,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             try
             {
+                File.WriteAllBytes("before.zip", packageStream.ToArray());
                 using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream))
                 {
                     zipFile.IsStreamOwner = false;
@@ -1996,6 +1997,8 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 packageStream.Position = 0;
 
                 _packageStream = packageStream;
+                File.WriteAllBytes("after.zip", packageStream.ToArray());
+
             }
             catch
             {

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1818,7 +1818,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             Assert.Equal("The commitment-type-indication attribute contains an invalid combination of values.", typedIssue.ClientMessage);
         }
 
-        [AdminOnlyTheory(Skip = "https://github.com/orgs/NuGet/projects/21/views/1?filterQuery=backlog&pane=issue&itemId=69718292")]
+        [AdminOnlyTheory(Skip = "https://github.com/NuGet/Engineering/issues/5517")]
         [InlineData("MA0GCyqGSIb3DQEJEAYD")] // base64 of ASN.1 encoded "1.2.840.113549.1.9.16.6.3" OID.
         [InlineData(null)] // No commitment type.
         public async Task AllowsNonAuthorAndRepositoryCounterSignatures(string commitmentTypeOidBase64)

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1978,7 +1978,6 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             try
             {
-                //File.WriteAllBytes("before.zip", packageStream.ToArray());
                 using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream))
                 {
                     zipFile.IsStreamOwner = false;
@@ -1997,8 +1996,6 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 packageStream.Position = 0;
 
                 _packageStream = packageStream;
-                //File.WriteAllBytes("after.zip", packageStream.ToArray());
-
             }
             catch
             {

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1997,7 +1997,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 packageStream.Position = 0;
 
                 _packageStream = packageStream;
-                File.WriteAllBytes("after.zip", packageStream.ToArray());
+                //File.WriteAllBytes("after.zip", packageStream.ToArray());
 
             }
             catch

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1983,11 +1983,9 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     //zipFile.IsStreamOwner = false;
 
                     zipFile.BeginUpdate();
-
-                    if (zipFile.FindEntry(SigningSpecifications.V1.SignaturePath, true) >= 0){
-                        zipFile.Delete(SigningSpecifications.V1.SignaturePath);
-                    }
-
+                    zipFile.Delete(SigningSpecifications.V1.SignaturePath);
+                    zipFile.CommitUpdate();
+                    zipFile.BeginUpdate();
                     zipFile.Add(
                         new StreamDataSource(new MemoryStream(fileContent)),
                         SigningSpecifications.V1.SignaturePath,

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1978,9 +1978,9 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             try
             {
-                using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream))
+                using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream, false))
                 {
-                    zipFile.IsStreamOwner = false;
+                    //zipFile.IsStreamOwner = false;
 
                     zipFile.BeginUpdate();
 

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1818,7 +1818,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             Assert.Equal("The commitment-type-indication attribute contains an invalid combination of values.", typedIssue.ClientMessage);
         }
 
-        [Theory]
+        [AdminOnlyTheory]
         [InlineData("MA0GCyqGSIb3DQEJEAYD")] // base64 of ASN.1 encoded "1.2.840.113549.1.9.16.6.3" OID.
         [InlineData(null)] // No commitment type.
         public async Task AllowsNonAuthorAndRepositoryCounterSignatures(string commitmentTypeOidBase64)

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1869,7 +1869,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             VerifyNU3008(result);
         }
 
-        [AdminOnlyFact]
+        [Fact]
         public async Task RejectsInvalidSignatureContent()
         {
             // Arrange

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1869,7 +1869,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             VerifyNU3008(result);
         }
 
-        [Fact]
+        [AdminOnlyFact]
         public async Task RejectsInvalidSignatureContent()
         {
             // Arrange
@@ -1983,12 +1983,9 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     zipFile.IsStreamOwner = false;
 
                     zipFile.BeginUpdate();
-
-                    if (zipFile.FindEntry(SigningSpecifications.V1.SignaturePath, true) >= 0)
-                    {
-                        zipFile.Delete(SigningSpecifications.V1.SignaturePath);
-                    }
-
+                    zipFile.Delete(SigningSpecifications.V1.SignaturePath);
+                    zipFile.CommitUpdate();
+                    zipFile.BeginUpdate();
                     zipFile.Add(
                         new StreamDataSource(new MemoryStream(fileContent)),
                         SigningSpecifications.V1.SignaturePath,

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1983,9 +1983,12 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     zipFile.IsStreamOwner = false;
 
                     zipFile.BeginUpdate();
-                    zipFile.Delete(SigningSpecifications.V1.SignaturePath);
-                    zipFile.CommitUpdate();
-                    zipFile.BeginUpdate();
+
+                    if (zipFile.FindEntry(SigningSpecifications.V1.SignaturePath, true) >= 0)
+                    {
+                        zipFile.Delete(SigningSpecifications.V1.SignaturePath);
+                    }
+
                     zipFile.Add(
                         new StreamDataSource(new MemoryStream(fileContent)),
                         SigningSpecifications.V1.SignaturePath,

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1978,7 +1978,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             try
             {
-                File.WriteAllBytes("before.zip", packageStream.ToArray());
+                //File.WriteAllBytes("before.zip", packageStream.ToArray());
                 using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream))
                 {
                     zipFile.IsStreamOwner = false;

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1978,7 +1978,6 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             try
             {
-                File.WriteAllBytes("before.zip", packageStream.ToArray());
                 using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream))
                 {
                     zipFile.IsStreamOwner = false;
@@ -1997,8 +1996,6 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 packageStream.Position = 0;
 
                 _packageStream = packageStream;
-                File.WriteAllBytes("after.zip", packageStream.ToArray());
-
             }
             catch
             {

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1978,9 +1978,9 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             try
             {
-                using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream, false))
+                using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream))
                 {
-                    //zipFile.IsStreamOwner = false;
+                    zipFile.IsStreamOwner = false;
 
                     zipFile.BeginUpdate();
                     zipFile.Delete(SigningSpecifications.V1.SignaturePath);

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1818,7 +1818,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             Assert.Equal("The commitment-type-indication attribute contains an invalid combination of values.", typedIssue.ClientMessage);
         }
 
-        [AdminOnlyTheory]
+        [AdminOnlyTheory(Skip = "https://github.com/orgs/NuGet/projects/21/views/1?filterQuery=backlog&pane=issue&itemId=69718292")]
         [InlineData("MA0GCyqGSIb3DQEJEAYD")] // base64 of ASN.1 encoded "1.2.840.113549.1.9.16.6.3" OID.
         [InlineData(null)] // No commitment type.
         public async Task AllowsNonAuthorAndRepositoryCounterSignatures(string commitmentTypeOidBase64)
@@ -1978,6 +1978,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
         {
             try
             {
+                File.WriteAllBytes("before.zip", packageStream.ToArray());
                 using (var zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile(packageStream))
                 {
                     zipFile.IsStreamOwner = false;
@@ -1996,6 +1997,8 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                 packageStream.Position = 0;
 
                 _packageStream = packageStream;
+                File.WriteAllBytes("after.zip", packageStream.ToArray());
+
             }
             catch
             {

--- a/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
+++ b/tests/Validation.PackageSigning.ProcessSignature.Tests/SignatureValidatorIntegrationTests.cs
@@ -1818,7 +1818,7 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
             Assert.Equal("The commitment-type-indication attribute contains an invalid combination of values.", typedIssue.ClientMessage);
         }
 
-        [AdminOnlyTheory]
+        [Theory]
         [InlineData("MA0GCyqGSIb3DQEJEAYD")] // base64 of ASN.1 encoded "1.2.840.113549.1.9.16.6.3" OID.
         [InlineData(null)] // No commitment type.
         public async Task AllowsNonAuthorAndRepositoryCounterSignatures(string commitmentTypeOidBase64)
@@ -1983,9 +1983,11 @@ namespace Validation.PackageSigning.ProcessSignature.Tests
                     zipFile.IsStreamOwner = false;
 
                     zipFile.BeginUpdate();
-                    zipFile.Delete(SigningSpecifications.V1.SignaturePath);
-                    zipFile.CommitUpdate();
-                    zipFile.BeginUpdate();
+
+                    if (zipFile.FindEntry(SigningSpecifications.V1.SignaturePath, true) >= 0){
+                        zipFile.Delete(SigningSpecifications.V1.SignaturePath);
+                    }
+
                     zipFile.Add(
                         new StreamDataSource(new MemoryStream(fileContent)),
                         SigningSpecifications.V1.SignaturePath,


### PR DESCRIPTION
Updated version of SharpZipLib form 1.0.0 to 1.3.3 because of component governance.
Related issues: https://github.com/orgs/NuGet/projects/21/views/1?filterQuery=milestone%3A%22Sprint+2024-07%22+assignee%3A%40me&pane=issue&itemId=64464447
https://github.com/orgs/NuGet/projects/21/views/1?filterQuery=backlog&pane=issue&itemId=69718292