### PR TITLE
Updating to NuGetGallery.Core version with bugfixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
     <ServerCommonPackageVersion>2.120.0</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-agr-msi-9855149</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-dev-9861622</NuGetGalleryPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.9.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
     <ServerCommonPackageVersion>2.120.0</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-dev-9801477</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-agr-msi-9855149</NuGetGalleryPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.9.1" />

--- a/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
+++ b/src/NuGet.Jobs.Common/JsonConfigurationJob.cs
@@ -13,8 +13,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.RetryPolicies;
 using NuGet.Jobs.Configuration;
 using NuGet.Services.Configuration;
 using NuGet.Services.FeatureFlags;
@@ -241,17 +239,6 @@ namespace NuGet.Jobs
 
             services.AddSingleton<IFeatureFlagCacheService, FeatureFlagCacheService>();
             services.AddSingleton<IFeatureFlagRefresher, FeatureFlagRefresher>();
-        }
-
-        private static BlobRequestOptions GetFeatureFlagBlobRequestOptions()
-        {
-            return new BlobRequestOptions
-            {
-                ServerTimeout = TimeSpan.FromMinutes(2),
-                MaximumExecutionTime = TimeSpan.FromMinutes(10),
-                LocationMode = LocationMode.PrimaryThenSecondary,
-                RetryPolicy = new ExponentialRetry(),
-            };
         }
 
         private void ConfigureLibraries(IServiceCollection services)

--- a/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Services.AzureSearch/DependencyInjectionExtensions.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.Rest;
 using Microsoft.WindowsAzure.Storage;
 using NuGet.Protocol;
-using NuGet.Protocol.Catalog;
 using NuGet.Services.AzureSearch.Auxiliary2AzureSearch;
 using NuGet.Services.AzureSearch.AuxiliaryFiles;
 using NuGet.Services.AzureSearch.Catalog2AzureSearch;

--- a/src/NuGet.Services.SearchService.Core/Startup.cs
+++ b/src/NuGet.Services.SearchService.Core/Startup.cs
@@ -3,25 +3,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Autofac;
-using Azure.Core.Serialization;
-using Azure.Search.Documents;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.PackageManagement.Search.Web;
-using NuGet.Jobs.Configuration;
 using NuGet.Services.AzureSearch;
 using NuGet.Services.AzureSearch.SearchService;
-using NuGet.Services.AzureSearch.Wrappers;
 using NuGet.Services.Logging;
 using NuGet.Services.SearchService.Controllers;
 

--- a/src/Validation.Common.Job/Validation.Common.Job.csproj
+++ b/src/Validation.Common.Job/Validation.Common.Job.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="WindowsAzure.Storage" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
Pulling in NuGetGallery.Core update with a fix for a bug that caused Azure Search Service startup failures.

Added direct reference to `WindowsAzure.Storage` to Validation.Common.Job since `NuGetGallery.Core` no longer provides one. It will get removed later as Validation jobs are migrated.