### PR TITLE
Update gallery version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <EnablePackageVersionOverride>false</EnablePackageVersionOverride>
     <ServerCommonPackageVersion>2.120.0</ServerCommonPackageVersion>
     <NuGetClientPackageVersion>6.9.1</NuGetClientPackageVersion>
-    <NuGetGalleryPackageVersion>4.4.5-dev-9861622</NuGetGalleryPackageVersion>
+    <NuGetGalleryPackageVersion>4.4.5-main-9892284</NuGetGalleryPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Autofac" Version="4.9.1" />


### PR DESCRIPTION
Updating the gallery version to recent SDK changes, particularly to support consumption of (transitive) gallery types from https://github.com/NuGet/NuGet.Jobs/tree/main/src/Validation.Common.Job consumed in other repos.