### PR TITLE
Monitoring Jobs Azure Storage v12 SDK migration

### DIFF
--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -376,7 +376,7 @@ namespace Ng
 
             string blobServiceUrl = $"https://{storageAccountName}.blob.{endpointSuffix}";
 
-            if (useManagedIdentity)
+            if (useManagedIdentity && string.IsNullOrEmpty(storageSasValue))
             {
                 var clientId = arguments.GetOrDefault<string>(argumentNameMap[Arguments.ClientId]);
                 var managedIdentityCredential = new ManagedIdentityCredential(clientId);
@@ -402,7 +402,7 @@ namespace Ng
 
             string queueServiceUrl = $"https://{storageAccountName}.queue.core.windows.net";
 
-            if (useManagedIdentity)
+            if (useManagedIdentity && string.IsNullOrEmpty(storageSasValue))
             {
                 var clientId = arguments.GetOrDefault<string>(argumentNameMap[Arguments.ClientId]);
                 var managedIdentityCredential = new ManagedIdentityCredential(clientId);

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -392,7 +392,7 @@ namespace Ng
             var storageKeyValue = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageKeyValue]);
             var keyCredential = new StorageSharedKeyCredential(storageAccountName, storageKeyValue);
 
-            return new BlobServiceClient(blobServiceUri);
+            return new BlobServiceClient(new Uri(blobServiceUri), keyCredential);
         }
 
         private static QueueServiceClient GetQueueServiceClient(string storageAccountName, IDictionary<string, string> arguments, IDictionary<string, string> argumentNameMap)

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -216,7 +216,7 @@ namespace Ng
                 var storageAccountName = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageAccountName]);
                 var storageContainer = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageContainer]);
                 var storagePath = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StoragePath]);
-                var storageSuffix = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StorageSuffix]);
+                var storageSuffix = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StorageSuffix], "core.windows.net");
                 var storageOperationMaxExecutionTime = MaxExecutionTime(arguments.GetOrDefault<int>(argumentNameMap[Arguments.StorageOperationMaxExecutionTimeInSeconds]));
                 var storageServerTimeout = MaxExecutionTime(arguments.GetOrDefault<int>(argumentNameMap[Arguments.StorageServerTimeoutInSeconds]));
                 var storageUseServerSideCopy = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.StorageUseServerSideCopy]);
@@ -359,7 +359,7 @@ namespace Ng
                 var storageAccountName = arguments.GetOrThrow<string>(Arguments.StorageAccountName);
                 var storageQueueName = arguments.GetOrDefault<string>(Arguments.StorageQueueName);
 
-                QueueServiceClient account = GetQueueServiceClient(storageAccountName, endpointSuffix: null, arguments, ArgumentNames);
+                QueueServiceClient account = GetQueueServiceClient(storageAccountName, arguments, ArgumentNames);
                 return new StorageQueue<T>(new AzureStorageQueue(account, storageQueueName),
                     new JsonMessageSerializer<T>(JsonSerializerUtility.SerializerSettings), version);
             }
@@ -374,7 +374,7 @@ namespace Ng
             var useManagedIdentity = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.UseManagedIdentity]);
             var storageSasValue = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StorageSasValue]);
 
-            string blobServiceUri = $"BlobEndpoint=https://{storageAccountName}.blob.{endpointSuffix ?? "core.windows.net"}";
+            string blobServiceUri = $"https://{storageAccountName}.blob.{endpointSuffix}";
 
             if (useManagedIdentity)
             {
@@ -395,12 +395,12 @@ namespace Ng
             return new BlobServiceClient(blobServiceUri);
         }
 
-        private static QueueServiceClient GetQueueServiceClient(string storageAccountName, string endpointSuffix, IDictionary<string, string> arguments, IDictionary<string, string> argumentNameMap)
+        private static QueueServiceClient GetQueueServiceClient(string storageAccountName, IDictionary<string, string> arguments, IDictionary<string, string> argumentNameMap)
         {
             var useManagedIdentity = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.UseManagedIdentity]);
             var storageSasValue = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StorageSasValue]);
 
-            string queueServiceUri = $"QueueEndpoint=https://{storageAccountName}.queue.{endpointSuffix ?? "core.windows.net"}";
+            string queueServiceUri = $"https://{storageAccountName}.queue.core.windows.net";
 
             if (useManagedIdentity)
             {

--- a/src/Ng/CommandHelpers.cs
+++ b/src/Ng/CommandHelpers.cs
@@ -374,25 +374,25 @@ namespace Ng
             var useManagedIdentity = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.UseManagedIdentity]);
             var storageSasValue = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StorageSasValue]);
 
-            string blobServiceUri = $"https://{storageAccountName}.blob.{endpointSuffix}";
+            string blobServiceUrl = $"https://{storageAccountName}.blob.{endpointSuffix}";
 
             if (useManagedIdentity)
             {
                 var clientId = arguments.GetOrDefault<string>(argumentNameMap[Arguments.ClientId]);
                 var managedIdentityCredential = new ManagedIdentityCredential(clientId);
 
-                return new BlobServiceClient(new Uri(blobServiceUri), managedIdentityCredential);
+                return new BlobServiceClient(new Uri(blobServiceUrl), managedIdentityCredential);
             }
             else if (!string.IsNullOrEmpty(storageSasValue))
             {
                 var sasTokenCredential = new AzureSasCredential(storageSasValue);
-                return new BlobServiceClient(new Uri(blobServiceUri), sasTokenCredential);
+                return new BlobServiceClient(new Uri(blobServiceUrl), sasTokenCredential);
             }
 
             var storageKeyValue = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageKeyValue]);
             var keyCredential = new StorageSharedKeyCredential(storageAccountName, storageKeyValue);
 
-            return new BlobServiceClient(new Uri(blobServiceUri), keyCredential);
+            return new BlobServiceClient(new Uri(blobServiceUrl), keyCredential);
         }
 
         private static QueueServiceClient GetQueueServiceClient(string storageAccountName, IDictionary<string, string> arguments, IDictionary<string, string> argumentNameMap)
@@ -400,26 +400,26 @@ namespace Ng
             var useManagedIdentity = arguments.GetOrDefault<bool>(argumentNameMap[Arguments.UseManagedIdentity]);
             var storageSasValue = arguments.GetOrDefault<string>(argumentNameMap[Arguments.StorageSasValue]);
 
-            string queueServiceUri = $"https://{storageAccountName}.queue.core.windows.net";
+            string queueServiceUrl = $"https://{storageAccountName}.queue.core.windows.net";
 
             if (useManagedIdentity)
             {
                 var clientId = arguments.GetOrDefault<string>(argumentNameMap[Arguments.ClientId]);
                 var managedIdentityCredential = new ManagedIdentityCredential(clientId);
 
-                return new QueueServiceClient(new Uri(queueServiceUri), managedIdentityCredential);
+                return new QueueServiceClient(new Uri(queueServiceUrl), managedIdentityCredential);
             }
             else if (!string.IsNullOrEmpty(storageSasValue))
             {
                 var sasTokenCredential = new AzureSasCredential(storageSasValue);
 
-                return new QueueServiceClient(new Uri(queueServiceUri), sasTokenCredential);
+                return new QueueServiceClient(new Uri(queueServiceUrl), sasTokenCredential);
             }
 
             var storageKeyValue = arguments.GetOrThrow<string>(argumentNameMap[Arguments.StorageKeyValue]);
             var keyCredential = new StorageSharedKeyCredential(storageAccountName, storageKeyValue);
 
-            return new QueueServiceClient(new Uri(queueServiceUri), keyCredential);
+            return new QueueServiceClient(new Uri(queueServiceUrl), keyCredential);
         }
 
     }

--- a/src/Ng/Jobs/Catalog2DnxJob.cs
+++ b/src/Ng/Jobs/Catalog2DnxJob.cs
@@ -45,7 +45,7 @@ namespace Ng.Jobs
                    + $"-{Arguments.StoragePath} <path> "
                    + $"[-{Arguments.VaultName} <keyvault-name> "
                    + $"-{Arguments.UseManagedIdentity} true|false "
-                   + $"-{Arguments.ClientId} <keyvault-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
+                   + $"-{Arguments.ClientId} <managed-identity-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"-{Arguments.CertificateThumbprint} <keyvault-certificate-thumbprint> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"[-{Arguments.ValidateCertificate} true|false]]] "
                    + $"[-{Arguments.Verbose} true|false] "

--- a/src/Ng/Jobs/Db2CatalogJob.cs
+++ b/src/Ng/Jobs/Db2CatalogJob.cs
@@ -63,7 +63,7 @@ namespace Ng.Jobs
                    + $"-{Arguments.StoragePath} <path> "
                    + $"[-{Arguments.VaultName} <keyvault-name> "
                    + $"-{Arguments.UseManagedIdentity} true|false "
-                   + $"-{Arguments.ClientId} <keyvault-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
+                   + $"-{Arguments.ClientId} <managed-identity-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"-{Arguments.CertificateThumbprint} <keyvault-certificate-thumbprint> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"[-{Arguments.ValidateCertificate} true|false]]] "
                    + $"-{Arguments.StorageTypeAuditing} file|azure "

--- a/src/Ng/Jobs/FixCatalogCachingJob.cs
+++ b/src/Ng/Jobs/FixCatalogCachingJob.cs
@@ -52,7 +52,7 @@ namespace Ng.Jobs
                    + $"-{Arguments.StoragePath} <path> "
                    + $"[-{Arguments.VaultName} <keyvault-name> "
                    + $"-{Arguments.UseManagedIdentity} true|false "
-                   + $"-{Arguments.ClientId} <keyvault-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
+                   + $"-{Arguments.ClientId} <managed-identity-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"-{Arguments.CertificateThumbprint} <keyvault-certificate-thumbprint> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"[-{Arguments.ValidateCertificate} true|false ]]";
         }

--- a/src/Ng/Jobs/LightningJob.cs
+++ b/src/Ng/Jobs/LightningJob.cs
@@ -508,7 +508,7 @@ namespace Ng.Jobs
             {
                 config.UseManagedIdentity = _arguments.GetOrDefault<bool>(Arguments.UseManagedIdentity);
                 config.ManagedIdentityClientId = _arguments.GetOrDefault<string>(Arguments.ClientId);
-
+                
                 config.LegacyBaseUrl = _arguments.GetOrDefault<string>(Arguments.StorageBaseAddress);
                 config.LegacyStorageContainer = _arguments.GetOrDefault<string>(Arguments.StorageContainer);
 
@@ -518,10 +518,21 @@ namespace Ng.Jobs
                 config.SemVer2BaseUrl = _arguments.GetOrDefault<string>(Arguments.SemVer2StorageBaseAddress);
                 config.SemVer2StorageContainer = _arguments.GetOrDefault<string>(Arguments.SemVer2StorageContainer);
 
-                if (config.UseManagedIdentity)
+                config.HasSasToken = new List<string>()
+                {
+                    _arguments.GetOrDefault<string>(Arguments.StorageSasValue),
+                    _arguments.GetOrDefault<string>(Arguments.CompressedStorageSasValue),
+                    _arguments.GetOrDefault<string>(Arguments.SemVer2StorageSasValue)
+                }
+                .All(t => !string.IsNullOrEmpty(t));
+
+                if (config.UseManagedIdentity && !config.HasSasToken)
                 {
                     var storageAccountName = _arguments.GetOrDefault<string>(Arguments.StorageAccountName);
-                    config.StorageConnectionString = $"BlobEndpoint=https://{storageAccountName}.blob.{_arguments.GetOrDefault(Arguments.StorageSuffix, "core.windows.net")}";
+                    var storageSuffix = _arguments.GetOrDefault(Arguments.StorageSuffix, "core.windows.net");
+
+                    config.StorageServiceUrl = $"https://{storageAccountName}.blob.{storageSuffix}";
+                    config.StorageConnectionString = $"BlobEndpoint={config.StorageServiceUrl}";
                 }
                 else
                 {

--- a/src/Ng/Jobs/NgJob.cs
+++ b/src/Ng/Jobs/NgJob.cs
@@ -51,7 +51,7 @@ namespace Ng.Jobs
             return "Usage: ng [" + string.Join("|", NgJobFactory.JobMap.Keys) + "] "
                    + $"[-{Arguments.VaultName} <keyvault-name> "
                    + $"-{Arguments.UseManagedIdentity} true|false "
-                   + $"-{Arguments.ClientId} <keyvault-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
+                   + $"-{Arguments.ClientId} <managed-identity-client-id> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"-{Arguments.CertificateThumbprint} <keyvault-certificate-thumbprint> Should not be set if {Arguments.UseManagedIdentity} is true"
                    + $"[-{Arguments.ValidateCertificate} true|false]]";
         }

--- a/src/NuGet.Jobs.Catalog2Registration/Catalog2RegistrationConfiguration.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Catalog2RegistrationConfiguration.cs
@@ -12,6 +12,16 @@ namespace NuGet.Jobs.Catalog2Registration
         private static readonly int DefaultMaxConcurrentHivesPerId = Enum.GetValues(typeof(HiveType)).Length;
 
         /// <summary>
+        /// Whether or not managed identity will be used as credential.
+        /// </summary>
+        public bool UseManagedIdentity { get; set; }
+
+        /// <summary>
+        /// Specific manage identity client id.
+        /// </summary>
+        public string ManagedIdentityClientId { get; set; }
+
+        /// <summary>
         /// The connection string used to connect to an Azure Blob Storage account. The connection string specifies
         /// the account name, the endpoint suffix (e.g. Azure vs. Azure China), and authentication credential (e.g. storage
         /// key).

--- a/src/NuGet.Jobs.Catalog2Registration/Catalog2RegistrationConfiguration.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/Catalog2RegistrationConfiguration.cs
@@ -22,6 +22,16 @@ namespace NuGet.Jobs.Catalog2Registration
         public string ManagedIdentityClientId { get; set; }
 
         /// <summary>
+        /// Whether or not any storage contains a sas token.
+        /// </summary>
+        public bool HasSasToken { get; set; }
+
+        /// <summary>
+        /// Azure storage service uri. e.g. https://<storage>.blob.core.windows.net
+        /// </summary>
+        public string StorageServiceUrl { get; set; }
+
+        /// <summary>
         /// The connection string used to connect to an Azure Blob Storage account. The connection string specifies
         /// the account name, the endpoint suffix (e.g. Azure vs. Azure China), and authentication credential (e.g. storage
         /// key).

--- a/src/NuGet.Jobs.Catalog2Registration/DependencyInjectionExtensions.cs
+++ b/src/NuGet.Jobs.Catalog2Registration/DependencyInjectionExtensions.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.WindowsAzure.Storage;
 using NuGet.Protocol;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Services.V3;
@@ -32,6 +31,12 @@ namespace NuGet.Jobs.Catalog2Registration
                 .Register<ICloudBlobClient>(c =>
                 {
                     var options = c.Resolve<IOptionsSnapshot<Catalog2RegistrationConfiguration>>();
+
+                    if (options.Value.UseManagedIdentity)
+                    {
+                        return CloudBlobClientWrapper.UsingMsi(options.Value.StorageConnectionString, options.Value.ManagedIdentityClientId);
+                    }
+
                     return new CloudBlobClientWrapper(
                         options.Value.StorageConnectionString,
                         requestTimeout: DefaultBlobRequestOptions.ServerTimeout);


### PR DESCRIPTION
# Changes
* Monitoring jobs will reuse the `clientId` and `useManagedIdentity` arguments when passed on configuration.
* For Mooncake if there is still a sas token it will use that instead.